### PR TITLE
DD-6: Mandate Reference Fields

### DIFF
--- a/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
@@ -1,0 +1,98 @@
+<?php
+
+class CRM_ManualDirectDebit_BAO_RecurrMandateRef extends CRM_ManualDirectDebit_DAO_RecurrMandateRef {
+
+  /**
+   * @param $params
+   * @param $defaults
+   *
+   * @return \CRM_ManualDirectDebit_BAO_RecurrMandateRef|null
+   */
+  public static function retrieve(&$params, &$defaults) {
+    $object = new CRM_ManualDirectDebit_BAO_RecurrMandateRef();
+    $object->copyValues($params);
+
+    if ($object->find(TRUE)) {
+      CRM_Core_DAO::storeValues($object, $defaults);
+      $object->free();
+      return $object;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @param $params
+   *
+   * @return \CRM_Core_DAO
+   */
+  public static function add(&$params) {
+    $entity = new CRM_ManualDirectDebit_BAO_RecurrMandateRef();
+    $entity->copyValues($params);
+
+    return $entity->save();
+  }
+
+  /**
+   * @param $params
+   *
+   * @return \CRM_Core_DAO
+   */
+  public static function &create(&$params) {
+    $transaction = new CRM_ManualDirectDebit_BAO_RecurrMandateRef();
+
+    if (!empty($params['id'])) {
+      CRM_Utils_Hook::pre('edit', self::getEntityName(), $params['id'], $params);
+    }
+    else {
+      CRM_Utils_Hook::pre('create', self::getEntityName(), NULL, $params);
+    }
+
+    $entityData = self::add($params);
+
+    if (is_a($entityData, 'CRM_Core_Error')) {
+      $transaction->rollback();
+      return $entityData;
+    }
+
+    $transaction->commit();
+
+    if (!empty($params['id'])) {
+      CRM_Utils_Hook::post('edit', self::getEntityName(), $entityData->id, $entityData);
+    }
+    else {
+      CRM_Utils_Hook::post('create', self::getEntityName(), $entityData->id, $entityData);
+    }
+
+    return $entityData;
+  }
+
+  /**
+   * Delete entity
+   *
+   * @param int $id
+   */
+  public static function deleteEntity($id) {
+    $entity = new CRM_ManualDirectDebit_BAO_RecurrMandateRef();
+    $entity->id = $id;
+    $params = [];
+    if ($entity->find(TRUE)) {
+      CRM_Utils_Hook::pre('delete', self::getEntityName(), $entity->id, $params);
+      $entity->delete();
+      CRM_Utils_Hook::post('delete', self::getEntityName(), $entity->id, $entity);
+    }
+  }
+
+  /**
+   * Gets all rows
+   *
+   * @return array
+   */
+  public static function getAll() {
+    $query = CRM_Utils_SQL_Select::from(CRM_ManualDirectDebit_BAO_RecurrMandateRef::getTableName())
+      ->toSQL();
+
+    return CRM_Core_DAO::executeQuery($query)->fetchAll();
+  }
+
+}

--- a/CRM/ManualDirectDebit/DAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/DAO/RecurrMandateRef.php
@@ -1,0 +1,199 @@
+<?php
+
+require_once 'CRM/Core/DAO.php';
+require_once 'CRM/Utils/Type.php';
+
+class CRM_ManualDirectDebit_DAO_RecurrMandateRef extends CRM_Core_DAO {
+
+  /**
+   * Static instance to hold the table name.
+   *
+   * @var string
+   */
+  static $_tableName = 'dd_contribution_recurr_mandate_ref';
+
+  /**
+   * Static entity name.
+   *
+   * @var string
+   */
+  static $entityName = 'RecurrMandateRef';
+
+  /**
+   * Should CiviCRM log any modifications to this table in the civicrm_log
+   * table.
+   *
+   * @var boolean
+   */
+  static $_log = TRUE;
+
+  /**
+   * Unique ID
+   *
+   * @var int unsigned
+   */
+  public $id;
+
+  /**
+   * Recurr id
+   *
+   * @var int
+   */
+  public $recurr_id;
+
+  /**
+   * Mandate id
+   *
+   * @var int
+   */
+  public $mandate_id;
+
+  /**
+   * Returns all the column names of this table
+   *
+   * @return array
+   */
+  static function &fields() {
+    if (!isset(Civi::$statics[__CLASS__]['fields'])) {
+      Civi::$statics[__CLASS__]['fields'] = [
+        'id' => [
+          'name' => 'id',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('id'),
+          'description' => 'id',
+          'required' => TRUE,
+          'import' => TRUE,
+          'where' => self::getTableName() . '.id',
+          'headerPattern' => '',
+          'dataPattern' => '',
+          'export' => TRUE,
+          'table_name' => self::getTableName(),
+          'entity' => self::getEntityName(),
+          'bao' => 'CRM_ManualDirectDebit_BAO_RecurrMandateRef',
+        ],
+        'recurr_id' => [
+          'name' => 'recurr_id',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Recurr id'),
+          'description' => 'Recurr id',
+          'required' => TRUE,
+          'import' => TRUE,
+          'where' => self::getTableName() . '.recurr_id',
+          'headerPattern' => '',
+          'dataPattern' => '',
+          'export' => TRUE,
+          'table_name' => self::getTableName(),
+          'entity' => self::getEntityName(),
+          'bao' => 'CRM_ManualDirectDebit_BAO_RecurrMandateRef',
+        ],
+        'mandate_id' => [
+          'name' => 'mandate_id',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Mandate id'),
+          'description' => 'mandate_id',
+          'required' => FALSE,
+          'import' => FALSE,
+          'where' => self::getTableName() . '.mandate_id',
+          'headerPattern' => '',
+          'dataPattern' => '',
+          'export' => TRUE,
+          'table_name' => self::getTableName(),
+          'entity' => self::getEntityName(),
+          'bao' => 'CRM_ManualDirectDebit_BAO_RecurrMandateRef',
+        ],
+      ];
+      CRM_Core_DAO_AllCoreTables::invoke(__CLASS__, 'fields_callback', Civi::$statics[__CLASS__]['fields']);
+    }
+
+    return Civi::$statics[__CLASS__]['fields'];
+  }
+
+  /**
+   * Returns the names of this table
+   *
+   * @return string
+   */
+  static function getTableName() {
+    return self::$_tableName;
+  }
+
+  /**
+   * Returns entity name
+   *
+   * @return string
+   */
+  static function getEntityName() {
+    return self::$entityName;
+  }
+
+  /**
+   * Given an associative array of name/value pairs, extract all the values
+   * that belong to this object and initialize the object with said values
+   *
+   * @param array $params
+   *   (reference ) associative array of name/value pairs.
+   *
+   * @return bool
+   *   Did we copy all null values into the object
+   */
+  public function copyValues(&$params) {
+    $fields = &$this->fields();
+    $allNull = TRUE;
+    foreach ($fields as $name => $value) {
+      $dbName = $value['name'];
+      if (array_key_exists($dbName, $params)) {
+        $pValue = $params[$dbName];
+        $exists = TRUE;
+      }
+      elseif (array_key_exists($name, $params)) {
+        $pValue = $params[$name];
+        $exists = TRUE;
+      }
+      else {
+        $exists = FALSE;
+      }
+
+      // if there is no value then make the variable NULL
+      if ($exists) {
+        if ($pValue === '') {
+          $this->$dbName = 'null';
+        }
+        else {
+          $this->$dbName = $pValue;
+          $allNull = FALSE;
+        }
+      }
+    }
+
+    return $allNull;
+  }
+
+  /**
+   * Returns the list of fields that can be exported
+   *
+   * @param bool $prefix
+   *
+   * @return array
+   */
+  static function &export($prefix = FALSE) {
+    $exportedListOfFields = CRM_Core_DAO_AllCoreTables::getExports(__CLASS__, self::getTableName(), $prefix, []);
+
+    return $exportedListOfFields;
+  }
+
+  /**
+   * Return a mapping from field-name to the corresponding key (as used in
+   * fields()).
+   *
+   * @return array
+   *   Array(string $name => string $uniqueName).
+   */
+  static function &fieldKeys() {
+    if (!isset(Civi::$statics[__CLASS__]['fieldKeys'])) {
+      Civi::$statics[__CLASS__]['fieldKeys'] = array_flip(CRM_Utils_Array::collect('name', self::fields()));
+    }
+
+    return Civi::$statics[__CLASS__]['fieldKeys'];
+  }
+
+}

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -5,4 +5,13 @@ use CRM_ManualDirectDebit_ExtensionUtil as E;
  * Collection of upgrade steps.
  */
 class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base {
+
+  public function install() {
+    $this->executeSqlFile('sql/install.sql');
+  }
+
+  public function uninstall() {
+    $this->executeSqlFile('sql/uninstall.sql');
+  }
+
 }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -138,22 +138,32 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/', $directDebitMenuItem);
 
-  $directDebitCodeSubMenuItem = [
-    'name' => ts('Direct Debit Codes'),
-    'url' => 'civicrm/admin/options/direct_debit_codes',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
+  $subMenuItems = [
+    [
+      'name' => ts('Direct Debit Codes'),
+      'url' => 'civicrm/admin/options/direct_debit_codes',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
+    [
+      'name' => ts('Direct Debit Configuration'),
+      'url' => 'civicrm/admin/direct_debit_configuration',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
+    [
+      'name' => ts('Direct Debit Originator Number'),
+      'url' => 'civicrm/admin/options/direct_debit_originator_number',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
   ];
-  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitCodeSubMenuItem);
 
-  $directDebitConfigurationSubMenuItem = [
-    'name' => 'Direct Debit Configuration',
-    'url' => 'civicrm/admin/direct_debit_configuration',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitConfigurationSubMenuItem);
+  foreach ($subMenuItems as $menuItem) {
+    _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $menuItem);
+  }
 }
 

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,0 +1,14 @@
+-- /*******************************************************
+-- * Create direct debit tables
+-- *******************************************************/
+
+CREATE TABLE IF NOT EXISTS `dd_contribution_recurr_mandate_ref` (
+  `id` INT unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+  `recurr_id` INT(11) NULL COMMENT 'FK to Recurrent ID ....',
+  `mandate_id` INT(11) NULL COMMENT 'FK to Mandate ID ....',
+   PRIMARY KEY (`id`)
+--   CONSTRAINT FK_....._recurr_id FOREIGN KEY (`recurr_id`) REFERENCES `.....`(`id`) ON DELETE SET NULL,
+--   CONSTRAINT FK_....._mandate_id FOREIGN KEY (`mandate_id`) REFERENCES `....`(`id`) ON DELETE SET NULL,
+);
+-- TODO: Add table names for FK
+

--- a/sql/uninstall.sql
+++ b/sql/uninstall.sql
@@ -1,0 +1,8 @@
+-- /*******************************************************
+-- * Delete direct debit tables
+-- *******************************************************/
+
+--SET FOREIGN_KEY_CHECKS=0;
+
+DROP TABLE IF EXISTS `dd_contribution_recurr_mandate_ref`;
+

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -15,6 +15,22 @@
             <is_multiple>1</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
             <created_date>0000-00-00 00:00:00</created_date>
+            <is_reserved>0</is_reserved>
+        </CustomGroup>
+        <CustomGroup>
+            <name>direct_debit_information</name>
+            <title>Direct Debit Information</title>
+            <extends>Contribution</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <help_pre></help_pre>
+            <help_post></help_post>
+            <weight>11</weight>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_dd_information</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <created_date>0000-00-00 00:00:00</created_date>
             <is_reserved>1</is_reserved>
         </CustomGroup>
     </CustomGroups>
@@ -56,8 +72,8 @@
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>city</name>
-            <label>City</label>
+            <name>bank_city</name>
+            <label>Bank City</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -69,13 +85,13 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>city</column_name>
+            <column_name>bank_city</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>county</name>
-            <label>County</label>
+            <name>bank_county</name>
+            <label>Bank County</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -87,13 +103,13 @@
             <text_length>64</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>county</column_name>
+            <column_name>bank_county</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>postcode</name>
-            <label>Postcode</label>
+            <name>bank_postcode</name>
+            <label>Bank Postcode</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -105,7 +121,7 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>postcode</column_name>
+            <column_name>bank_postcode</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
@@ -179,24 +195,6 @@
             <note_rows>4</note_rows>
             <column_name>dd_code</column_name>
             <option_group_name>direct_debit_codes</option_group_name>
-            <custom_group_name>direct_debit_mandate</custom_group_name>
-            <in_selector>1</in_selector>
-        </CustomField>
-        <CustomField>
-            <name>amount</name>
-            <label>Amount</label>
-            <data_type>Int</data_type>
-            <html_type>Text</html_type>
-            <is_required>1</is_required>
-            <is_searchable>1</is_searchable>
-            <is_search_range>0</is_search_range>
-            <weight>26</weight>
-            <is_active>1</is_active>
-            <is_view>0</is_view>
-            <text_length>64</text_length>
-            <note_columns>60</note_columns>
-            <note_rows>4</note_rows>
-            <column_name>amount</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
@@ -279,7 +277,7 @@
             <label>Collection Day</label>
             <data_type>Int</data_type>
             <html_type>Text</html_type>
-            <is_required>0</is_required>
+            <is_required>1</is_required>
             <is_searchable>1</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>31</weight>
@@ -292,12 +290,57 @@
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
+        <CustomField>
+            <name>mandate id</name>
+            <label>mandate_id</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <weight>36</weight>
+            <is_active>1</is_active>
+            <is_view>0</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <attributes>readonly="readonly"</attributes>
+            <note_rows>4</note_rows>
+            <column_name>mandate_id</column_name>
+            <custom_group_name>direct_debit_information</custom_group_name>
+            <in_selector>1</in_selector>
+            <is_reserved>1</is_reserved>
+        </CustomField>
+        <CustomField>
+          <name>originator_number</name>
+          <label>Originator Number</label>
+          <data_type>String</data_type>
+          <html_type>Select</html_type>
+          <is_required>1</is_required>
+          <is_searchable>1</is_searchable>
+          <is_search_range>0</is_search_range>
+          <weight>32</weight>
+          <is_active>1</is_active>
+          <is_view>0</is_view>
+          <text_length>64</text_length>
+          <note_columns>60</note_columns>
+          <note_rows>4</note_rows>
+          <column_name>originator_number</column_name>
+          <option_group_name>direct_debit_originator_number</option_group_name>
+          <custom_group_name>direct_debit_mandate</custom_group_name>
+          <in_selector>1</in_selector>
+        </CustomField>
     </CustomFields>
     <OptionGroups>
         <OptionGroup>
             <name>direct_debit_codes</name>
             <title>Direct Debit Codes</title>
             <is_reserved>1</is_reserved>
+            <is_active>1</is_active>
+        </OptionGroup>
+        <OptionGroup>
+          <name>direct_debit_originator_number</name>
+          <title>Direct Debit Originator Number</title>
+          <is_reserved>0</is_reserved>
             <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
@@ -401,7 +444,7 @@
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.city</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_city</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -411,13 +454,13 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>City</label>
+            <label>Bank City</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.county</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_county</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -427,13 +470,13 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>County</label>
+            <label>Bank County</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.postcode</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_postcode</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -443,7 +486,7 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>Postcode</label>
+            <label>Bank Postcode</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
@@ -608,8 +651,6 @@
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
-
-
     </ProfileFields>
     <ProfileJoins>
         <ProfileJoin>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -291,8 +291,8 @@
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>mandate id</name>
-            <label>mandate_id</label>
+            <name>mandate_id</name>
+            <label>Mandate ID</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -300,10 +300,9 @@
             <is_search_range>0</is_search_range>
             <weight>36</weight>
             <is_active>1</is_active>
-            <is_view>0</is_view>
+            <is_view>1</is_view>
             <text_length>64</text_length>
             <note_columns>60</note_columns>
-            <attributes>readonly="readonly"</attributes>
             <note_rows>4</note_rows>
             <column_name>mandate_id</column_name>
             <custom_group_name>direct_debit_information</custom_group_name>


### PR DESCRIPTION
## Overview 
1. Add 'dd_contribution_recurr_mandate_ref' custom schema that containing:

- "recurr_id"  field - the id of the recurring contribution that are paid by direct debit

- "mandate_id"  field - the id of the mandate that are used for the recurring contribution
2. Add custom fieldset "Direct Debit Information" that are used for Contributions. The fieldset should have a read-only "mandate_id" field .

![mandate-id](https://user-images.githubusercontent.com/31275766/36987311-b434211a-20a4-11e8-8f48-8e73532f1f70.png)
