### PR TITLE
DD-5 fix: Direct Debit Mandate Custom Fields

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -138,31 +138,32 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/', $directDebitMenuItem);
 
-  $directDebitCodeSubMenuItem = [
-    'name' => ts('Direct Debit Codes'),
-    'url' => 'civicrm/admin/options/direct_debit_codes',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
+  $subMenuItems = [
+    [
+      'name' => ts('Direct Debit Codes'),
+      'url' => 'civicrm/admin/options/direct_debit_codes',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
+    [
+      'name' => ts('Direct Debit Configuration'),
+      'url' => 'civicrm/admin/direct_debit_configuration',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
+    [
+      'name' => ts('Direct Debit Originator Number'),
+      'url' => 'civicrm/admin/options/direct_debit_originator_number',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => NULL,
+    ],
   ];
-  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitCodeSubMenuItem);
 
-  $directDebitConfigurationSubMenuItem = [
-    'name' => ts('Direct Debit Configuration'),
-    'url' => 'civicrm/admin/direct_debit_configuration',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitConfigurationSubMenuItem);
-
-  $directDebitOriginatorNumberSubMenuItem = [
-    'name' => ts('Direct Debit Originator Number'),
-    'url' => 'civicrm/admin/options/direct_debit_originator_number',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitOriginatorNumberSubMenuItem);
+  foreach ($subMenuItems as $menuItem) {
+    _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $menuItem);
+  }
 }
 

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -148,12 +148,21 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitCodeSubMenuItem);
 
   $directDebitConfigurationSubMenuItem = [
-    'name' => 'Direct Debit Configuration',
+    'name' => ts('Direct Debit Configuration'),
     'url' => 'civicrm/admin/direct_debit_configuration',
     'permission' => 'administer CiviCRM',
     'operator' => NULL,
     'separator' => NULL,
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitConfigurationSubMenuItem);
+
+  $directDebitOriginatorNumberSubMenuItem = [
+    'name' => ts('Direct Debit Originator Number'),
+    'url' => 'civicrm/admin/options/direct_debit_originator_number',
+    'permission' => 'administer CiviCRM',
+    'operator' => NULL,
+    'separator' => NULL,
+  ];
+  _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/' . $directDebitMenuItem['name'], $directDebitOriginatorNumberSubMenuItem);
 }
 

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -15,7 +15,7 @@
             <is_multiple>1</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
             <created_date>0000-00-00 00:00:00</created_date>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
         </CustomGroup>
     </CustomGroups>
     <CustomFields>
@@ -56,8 +56,8 @@
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>city</name>
-            <label>City</label>
+            <name>bank_city</name>
+            <label>Bank City</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -69,13 +69,13 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>city</column_name>
+            <column_name>bank_city</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>county</name>
-            <label>County</label>
+            <name>bank_county</name>
+            <label>Bank County</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -87,13 +87,13 @@
             <text_length>64</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>county</column_name>
+            <column_name>bank_county</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>postcode</name>
-            <label>Postcode</label>
+            <name>bank_postcode</name>
+            <label>Bank Postcode</label>
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
@@ -105,7 +105,7 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>postcode</column_name>
+            <column_name>bank_postcode</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
@@ -179,24 +179,6 @@
             <note_rows>4</note_rows>
             <column_name>dd_code</column_name>
             <option_group_name>direct_debit_codes</option_group_name>
-            <custom_group_name>direct_debit_mandate</custom_group_name>
-            <in_selector>1</in_selector>
-        </CustomField>
-        <CustomField>
-            <name>amount</name>
-            <label>Amount</label>
-            <data_type>Int</data_type>
-            <html_type>Text</html_type>
-            <is_required>1</is_required>
-            <is_searchable>1</is_searchable>
-            <is_search_range>0</is_search_range>
-            <weight>26</weight>
-            <is_active>1</is_active>
-            <is_view>0</is_view>
-            <text_length>64</text_length>
-            <note_columns>60</note_columns>
-            <note_rows>4</note_rows>
-            <column_name>amount</column_name>
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
@@ -279,7 +261,7 @@
             <label>Collection Day</label>
             <data_type>Int</data_type>
             <html_type>Text</html_type>
-            <is_required>0</is_required>
+            <is_required>1</is_required>
             <is_searchable>1</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>31</weight>
@@ -292,6 +274,25 @@
             <custom_group_name>direct_debit_mandate</custom_group_name>
             <in_selector>1</in_selector>
         </CustomField>
+        <CustomField>
+          <name>originator_number</name>
+          <label>Originator Number</label>
+          <data_type>String</data_type>
+          <html_type>Select</html_type>
+          <is_required>1</is_required>
+          <is_searchable>1</is_searchable>
+          <is_search_range>0</is_search_range>
+          <weight>32</weight>
+          <is_active>1</is_active>
+          <is_view>0</is_view>
+          <text_length>64</text_length>
+          <note_columns>60</note_columns>
+          <note_rows>4</note_rows>
+          <column_name>originator_number</column_name>
+          <option_group_name>direct_debit_originator_number</option_group_name>
+          <custom_group_name>direct_debit_mandate</custom_group_name>
+          <in_selector>1</in_selector>
+        </CustomField>
     </CustomFields>
     <OptionGroups>
         <OptionGroup>
@@ -299,6 +300,12 @@
             <title>Direct Debit Codes</title>
             <is_reserved>1</is_reserved>
             <is_active>1</is_active>
+        </OptionGroup>
+        <OptionGroup>
+          <name>direct_debit_originator_number</name>
+          <title>Direct Debit Originator Number</title>
+          <is_reserved>0</is_reserved>
+          <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
     <OptionValues>
@@ -401,7 +408,7 @@
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.city</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_city</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -411,13 +418,13 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>City</label>
+            <label>Bank City</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.county</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_county</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -427,13 +434,13 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>County</label>
+            <label>Bank County</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
         <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.postcode</field_name>
+            <field_name>custom.civicrm_value_dd_mandate.bank_postcode</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
             <is_required>0</is_required>
@@ -443,7 +450,7 @@
             <visibility>User and User Admin Only</visibility>
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
-            <label>Postcode</label>
+            <label>Bank Postcode</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
@@ -508,22 +515,6 @@
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
             <label>DD Code</label>
-            <field_type>Contact</field_type>
-            <is_multi_summary>1</is_multi_summary>
-            <profile_group_name>direct_debit_mandate</profile_group_name>
-        </ProfileField>
-        <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.amount</field_name>
-            <is_active>1</is_active>
-            <is_view>0</is_view>
-            <is_required>1</is_required>
-            <weight>11</weight>
-            <help_post></help_post>
-            <help_pre></help_pre>
-            <visibility>User and User Admin Only</visibility>
-            <in_selector>0</in_selector>
-            <is_searchable>0</is_searchable>
-            <label>Amount</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
@@ -596,7 +587,7 @@
             <field_name>custom.civicrm_value_dd_mandate.collection_day</field_name>
             <is_active>1</is_active>
             <is_view>0</is_view>
-            <is_required>0</is_required>
+            <is_required>1</is_required>
             <weight>16</weight>
             <help_post></help_post>
             <help_pre></help_pre>
@@ -608,8 +599,6 @@
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>
         </ProfileField>
-
-
     </ProfileFields>
     <ProfileJoins>
         <ProfileJoin>


### PR DESCRIPTION
## Overview
1. Remove Amount field
2. Add bank_ prefix to address fields. 
3. Set Collection Day as required
4. Add a new empty 'Originator Number' custom group
5. Add a new menu item Administer > Direct Debit > Originator Number. It shows "Direct Debit Originator Number" options. 

## Before
![direct_debit_fields_1](https://user-images.githubusercontent.com/31275766/36899224-d9afbb82-1e26-11e8-8f56-668a2e57360b.png)

## After
![direct_debit_fields_2](https://user-images.githubusercontent.com/31275766/36899226-dddea786-1e26-11e8-8358-a59cd7683f03.png)

![direct_debit_originator_number](https://user-images.githubusercontent.com/31275766/36898869-54bc3f78-1e25-11e8-874e-6d168aa51e3e.png)

