### PR TITLE
DD-10: Adding direct debt configurations page.

### DIFF
--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -30,7 +30,7 @@ return [
     'default' => 0,
     'is_help' => FALSE,
     'is_required' => TRUE,
-    'html_attributes' => generateSequenceNumbers(30),
+    'html_attributes' => generateSequenceNumbers(31),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',
@@ -49,7 +49,7 @@ return [
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(31),
+    'html_attributes' => generateSequenceNumbers(30),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',


### PR DESCRIPTION
## Overview
1. "New instruction run dates" multi-select field. The options range from 1 to 31.
2. "Payment collection run dates" multi-select field. Now, the options range from 1 to 30.

## Before
![dd10_before](https://user-images.githubusercontent.com/36959503/37086716-ed29f672-2200-11e8-9a0e-b52a36cf1f5c.png)

## After
![dd10_after](https://user-images.githubusercontent.com/36959503/37086727-f1aa5098-2200-11e8-88d3-e631f656c721.png)
