### PR TITLE
DD-16: Create and export of New instruction Batches

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * This class is used for batch handling
+ *
+ */
+class CRM_ManualDirectDebit_Batch_BatchHandler {
+
+  /**
+   * Batch id
+   *
+   * @var integer
+   *
+   */
+  private $batchID;
+
+  /**
+   * Batch status
+   *
+   * @var string
+   */
+  private $batchStatus;
+
+  /**
+   * Batch status
+   *
+   * @var string
+   */
+  private $batchStatusId;
+
+  public function __construct($batchID) {
+    $this->batchID = $batchID;
+  }
+
+  /**
+   * Gets batch status ID
+   *
+   * @return int
+   */
+  public function getBatchStatusId() {
+    if (!$this->batchStatusId) {
+      $this->batchStatusId = CRM_Core_DAO::getFieldValue('CRM_Batch_DAO_Batch', $this->batchID, 'status_id');
+    }
+
+    return $this->batchStatusId;
+  }
+
+  /**
+   * Gets batch status
+   *
+   * @return string
+   */
+  public function getBatchStatus() {
+    if (!$this->batchStatus) {
+      $statusID = $this->getBatchStatusId();
+      $batchStatuses = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', [
+        'labelColumn' => 'name',
+        'status' => " v.value={$statusID }",
+      ]);
+      $this->batchStatus = $batchStatuses[$statusID];
+    }
+
+    return $this->batchStatus;
+  }
+
+  /**
+   * Checks whether the batch is open
+   *
+   * @return bool
+   */
+  public function validBatchStatus() {
+    return in_array($this->getBatchStatus(), ['Open', 'Reopened']);
+  }
+
+  /**
+   * Creates Export File
+   *
+   * @param array $params
+   */
+  public function createExportFile($params) {
+
+    $config = CRM_Core_Config::singleton();
+
+    $columnHeader = [
+      'contact_id' => ts('Contact ID'),
+      'name' => ts('Account Holder Name'),
+      'sort_code' => ts('Sort code'),
+      'account_number' => ts('Account Number'),
+      'amount' => ts('Amount'),
+      'reference_number' => ts('Reference Number'),
+      'transaction_type' => ts('Transaction Type'),
+    ];
+
+    $returnValues = [
+      'id' => 'civicrm_value_dd_mandate.id as id',
+      'contact_id' => 'civicrm_value_dd_mandate.entity_id as contact_id',
+      'name' => 'civicrm_value_dd_mandate.account_holder_name as name',
+      'sort_code' => 'civicrm_value_dd_mandate.sort_code as sort_code',
+      'account_number' => 'civicrm_value_dd_mandate.ac_number as account_number',
+      'amount' => '0 as amount',
+      'reference_number' => 'civicrm_value_dd_mandate.dd_ref as reference_number',
+      'transaction_type' => 'civicrm_value_dd_mandate.dd_code as transaction_type',
+    ];
+
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($params['batch_id'], $params, $columnHeader, $returnValues);
+
+    $mandateItems = $batchTransaction->getRows();
+    foreach ($mandateItems as &$mandateItem) {
+      unset($mandateItem['check']);
+    }
+
+    $mandateItems['headers'] = $columnHeader;
+
+    $fileName = $this->generateCSVFile($mandateItems);
+
+    $this->createActivityExport($fileName);
+
+    CRM_Utils_System::setHttpHeader('Content-Type', 'text/plain');
+    CRM_Utils_System::setHttpHeader('Content-Disposition', 'attachment; filename=' . CRM_Utils_File::cleanFileName(basename($fileName)));
+    CRM_Utils_System::setHttpHeader('Content-Length', '' . filesize($fileName));
+    ob_clean();
+    flush();
+    readfile($config->customFileUploadDir . CRM_Utils_File::cleanFileName(basename($fileName)));
+    CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Creates csv File
+   *
+   * @param array $export
+   *
+   * @return string
+   *
+   */
+  private function generateCSVFile($export) {
+    $config = CRM_Core_Config::singleton();
+    $fileName = $config->uploadDir . 'Instructions_Batch' . $this->batchID . '_' . date('YmdHis') . '.csv';
+    $out = fopen($fileName, 'w');
+    if (!empty($export['headers'])) {
+      fputcsv($out, $export['headers']);
+    }
+    unset($export['headers']);
+    if (!empty($export)) {
+      foreach ($export as $fields) {
+        fputcsv($out, $fields);
+      }
+      fclose($out);
+    }
+
+    return $fileName;
+  }
+
+  /**
+   * Creates activity with type "Export Accounting Batch".
+   *
+   * @param string $fileName
+   *
+   */
+  private function createActivityExport($fileName) {
+    $session = CRM_Core_Session::singleton();
+    $values = [];
+    $params = ['id' => $this->batchID];
+    CRM_Batch_BAO_Batch::retrieve($params, $values);
+    $createdBy = CRM_Contact_BAO_Contact::displayName($values['created_id']);
+    $modifiedBy = CRM_Contact_BAO_Contact::displayName($values['modified_id']);
+
+    $details = '<p>' . ts('Record:') . ' ' . $values['title'] . '</p><p>' . ts('Description:') . '</p><p>' . ts('Created By:') . " $createdBy" . '</p><p>' . ts('Created Date:') . ' ' . $values['created_date'] . '</p><p>' . ts('Last Modified By:') . ' ' . $modifiedBy . '</p>';
+    $subject = '';
+    if (!empty($values['total'])) {
+      $subject .= ts('Total') . '[' . CRM_Utils_Money::format($values['total']) . '],';
+    }
+    if (!empty($values['item_count'])) {
+      $subject .= ' ' . ts('Count') . '[' . $values['item_count'] . '],';
+    }
+
+    // create activity.
+    $subject .= ' ' . ts('Batch') . '[' . $values['title'] . ']';
+    $activityTypes = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'activity_type_id');
+    $activityParams = [
+      'activity_type_id' => array_search('Export Accounting Batch', $activityTypes),
+      'subject' => $subject,
+      'status_id' => 2,
+      'activity_date_time' => date('YmdHis'),
+      'source_contact_id' => $session->get('userID'),
+      'source_record_id' => $values['id'],
+      'target_contact_id' => $session->get('userID'),
+      'details' => $details,
+      'attachFile_1' => [
+        'uri' => $fileName,
+        'type' => 'text/csv',
+        'location' => $fileName,
+        'upload_date' => date('YmdHis'),
+      ],
+    ];
+
+    CRM_Activity_BAO_Activity::create($activityParams);
+  }
+
+  /**
+   * Returns max batch id
+   *
+   * @return null|string
+   */
+  public static function getMaxBatchId() {
+    $sql = "SELECT max(id) FROM civicrm_batch";
+    return CRM_Core_DAO::singleValueQuery($sql);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -1,0 +1,309 @@
+<?php
+
+/**
+ *
+ * This class is used to retrieve and display a range of direct debit mandates
+ * that match the given criteria.
+ *
+ */
+class CRM_ManualDirectDebit_Batch_Transaction {
+
+  /**
+   * Table name of "Direct Debit Mandate" custom group
+   *
+   * @var string
+   */
+  protected $directDebitMandateTable = 'civicrm_value_dd_mandate';
+
+  /**
+   * Batch ID
+   *
+   * @var int
+   */
+  protected $batchID;
+
+  /**
+   * Search element
+   *
+   * @var boolean
+   */
+  protected $notPresent;
+
+  /**
+   * Limit element
+   *
+   * @var boolean
+   */
+  protected $total;
+
+  /**
+   * Searchable fields
+   *
+   * @var array
+   */
+  protected $searchableFields = [
+    'entity_id',
+    'bank_name',
+    'bank_street_address',
+    'bank_city',
+    'bank_county',
+    'bank_postcode',
+    'account_holder_name',
+    'ac_number',
+    'sort_code',
+    'dd_code',
+    'dd_ref',
+    'start_date',
+    'authorisation_date',
+    'collection_day',
+    'originator_number',
+  ];
+
+  /**
+   * What column does select in SQL query
+   *
+   * @code
+   *
+   *  $returnValues = [
+   *    'name' => 'tableName.column as alias',
+   *  ]
+   *
+   * @endcode
+   *
+   * @var array
+   */
+  protected $returnValues = [];
+
+  /**
+   * What column does select in SQL query
+   *
+   * @code
+   *
+   *  $columnHeader = [
+   *    'alias' => 'label',
+   *  ]
+   *
+   * @endcode
+   *
+   * @var array
+   */
+  protected $columnHeader = [];
+
+  /**
+   * Search, order, limits params
+   *
+   * @var array
+   */
+  protected $params;
+
+  /**
+   * CRM_ManualDirectDebit_Batch_Transaction constructor.
+   *
+   * @param int $batchID
+   * @param array $params
+   * @param array $columnHeader
+   * @param array $returnValues
+   * @param bool $notPresent
+   */
+  public function __construct($batchID, $params, $columnHeader = [], $returnValues = [], $notPresent = FALSE) {
+    $this->batchID = $batchID;
+    $this->notPresent = $notPresent;
+    $this->params = $params;
+    $this->setColumnHeader($columnHeader);
+    $this->setReturnValues($returnValues);
+  }
+
+
+  /**
+   * Sets columns for rows
+   *
+   * @param array $columnHeader
+   *
+   * @return array|bool
+   */
+  private function setColumnHeader($columnHeader = []) {
+
+    if (empty($columnHeader)) {
+      $columnHeader = [
+        'contact_id' => ts('ID'),
+        'name' => ts('Account Holder Name'),
+        'sort_code' => ts('Sort code'),
+        'account_number' => ts('Account Number'),
+        'reference_number' => ts('Reference Number'),
+        'transaction_type' => ts('Transaction Type'),
+      ];
+
+    }
+
+    $this->columnHeader = $columnHeader;
+
+    return $this->columnHeader;
+  }
+
+  /**
+   * Prepares fields for SQL select function
+   *
+   * @param array $returnValues
+   *
+   * @return array|bool
+   */
+  private function setReturnValues($returnValues = []) {
+    if (!is_array($returnValues)) {
+      return FALSE;
+    }
+
+    if (empty($returnValues)) {
+      $returnValues = [
+        'id' => $this->directDebitMandateTable . '.id as id',
+        'contact_id' => $this->directDebitMandateTable . '.entity_id as contact_id',
+        'name' => $this->directDebitMandateTable . '.account_holder_name as name',
+        'sort_code' => $this->directDebitMandateTable . '.sort_code as sort_code',
+        'account_number' => $this->directDebitMandateTable . '.ac_number as account_number',
+        'reference_number' => $this->directDebitMandateTable . '.dd_ref as reference_number',
+        'transaction_type' => $this->directDebitMandateTable . '.dd_code as transaction_type',
+      ];
+    }
+
+    $this->returnValues = $returnValues;
+
+    return $this->returnValues;
+  }
+
+  /**
+   * Gets transaction rows what assign/not assign to batch
+   *
+   * @return array
+   */
+  public function getRows() {
+
+    $mandateItems = $this->getDDMandateInstructions();
+
+    $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID);
+    $ddCodes = CRM_Core_OptionGroup::values('direct_debit_codes');
+
+    $rows = [];
+    while ($mandateItems->fetch()) {
+      $row = [];
+      foreach ($this->columnHeader as $columnKey => $columnValue) {
+        if (isset($mandateItems->$columnKey)) {
+          if ($columnKey == 'transaction_type') {
+            $ddCode = CRM_Utils_Array::value($mandateItems->$columnKey, $ddCodes);
+            $row[$columnKey] = $ddCode;
+            continue;
+          }
+          $row[$columnKey] = $mandateItems->$columnKey;
+        }
+        else {
+          $row[$columnKey] = NULL;
+        }
+      }
+
+      if ($batch->validBatchStatus()) {
+        if ($this->notPresent) {
+          $js = "enableActions('x')";
+          $row['check'] = "<input type='checkbox' id='mark_x_" . $mandateItems->id . "' name='mark_x_" . $mandateItems->id . "' value='1' onclick={$js}></input>";
+        }
+        else {
+          $js = "enableActions('y')";
+          $row['check'] = "<input type='checkbox' id='mark_y_" . $mandateItems->id . "' name='mark_y_" . $mandateItems->id . "' value='1' onclick={$js}></input>";
+        }
+      }
+      else {
+        $row['check'] = NULL;
+      }
+
+      $rows[$mandateItems->id] = $row;
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Returns DAO of Direct Debit mandate instructions
+   *
+   * @return object
+   */
+  private function getDDMandateInstructions() {
+
+    $query = CRM_Utils_SQL_Select::from($this->directDebitMandateTable);
+    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->directDebitMandateTable . '.id AND civicrm_entity_batch.entity_table = \'' . $this->directDebitMandateTable . '\'');
+    //select
+    $query->select(implode(' , ', $this->returnValues));
+
+    foreach ($this->searchableFields as $field) {
+      if (isset($this->params[$field])) {
+        if ($field == 'start_date') {
+          $query->where($field . ' < @' . $field, [$field => $this->params[$field]]);
+          continue;
+        }
+        $query->where($field . ' = @' . $field, [$field => $this->params[$field]]);
+      }
+    }
+
+    if ($this->notPresent) {
+      $query->where('civicrm_entity_batch.batch_id IS NULL');
+    }
+    else {
+      $query->where('civicrm_entity_batch.batch_id = !entityID', ['entityID' => $this->batchID]);
+    }
+
+    if (!empty($this->params['sortBy'])) {
+      $query->orderBy($this->params['sortBy']);
+    }
+    else {
+      $query->orderBy($this->directDebitMandateTable . '.id');
+    }
+
+    if (!$this->total) {
+      if (!empty($this->params['rowCount']) &&
+        $this->params['rowCount'] > 0
+      ) {
+        $query->limit((int) $this->params['rowCount'], (int) $this->params['offset']);
+      }
+    }
+
+    $mandateItems = CRM_Core_DAO::executeQuery($query->toSQL());
+    return $mandateItems;
+  }
+
+  /**
+   * Gets total rows
+   *
+   * @return int
+   */
+  public function getTotalNumber() {
+    $this->total = TRUE;
+    return count($this->getDDMandateInstructions()
+      ->fetchAll());
+  }
+
+  /**
+   * Adds new properties for SQL select function
+   *
+   * @param $returnValues
+   *
+   * @return array
+   */
+  public function addReturnValues($returnValues) {
+
+    $this->returnValues = array_merge($this->returnValues, $returnValues);
+
+    return $this->returnValues;
+  }
+
+
+  /**
+   * Adds new columns for rows
+   *
+   * @param $columnHeader
+   *
+   * @return array
+   */
+  public function addColumnHeader($columnHeader) {
+
+    $this->columnHeader = array_merge($this->columnHeader, $columnHeader);
+
+    return $this->columnHeader;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -1,0 +1,159 @@
+<?php
+
+
+/**
+ * This class generates form components for Batch Transaction
+ */
+class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form {
+
+  /**
+   * The action links that we need to display for the browse screen.
+   *
+   * @var array
+   */
+  protected $links = NULL;
+
+  /**
+   * Batch id.
+   *
+   * @var integer
+   */
+  protected $batchID;
+
+  /**
+   * PreProcess function.
+   */
+  public function preProcess() {
+    $this->batchID = CRM_Utils_Request::retrieve('bid', 'Positive') ? CRM_Utils_Request::retrieve('bid', 'Positive') : CRM_Utils_Array::value('batch_id', $_POST);
+    $this->assign('entityID', $this->batchID);
+    if (isset($this->batchID)) {
+      $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID);
+      $this->assign('statusID', $batch->getBatchStatusId());
+      $this->assign('batchStatus', $batch->getBatchStatus());
+      $this->assign('validStatus', $batch->validBatchStatus());
+
+      $this->_values = civicrm_api3('Batch', 'getSingle', ['id' => $this->batchID]);
+      CRM_Utils_System::setTitle(ts('New Direct Debit Instructions'));
+
+      $columnHeaders = [
+        'created_by' => ts('Created By'),
+        'status' => ts('Status'),
+        'description' => ts('Description'),
+        'payment_instrument' => ts('Payment Method'),
+        'item_count' => ts('Expected Number of Items'),
+        'assigned_item_count' => ts('Actual Number of Items'),
+        'total' => ts('Expected Total Amount'),
+        'assigned_total' => ts('Actual Total Amount'),
+        'opened_date' => ts('Opened'),
+      ];
+      $this->assign('columnHeaders', $columnHeaders);
+      $values = json_decode($this->_values['data'], TRUE);
+      $ddCode = civicrm_api3('OptionValue', 'getvalue', [
+        'return' => "value",
+        'option_group_id' => "direct_debit_codes",
+        'name' => "new_direct_debit_i_setup",
+      ]);
+
+      $values['values']['dd_code'] = $ddCode;
+      $values['values']['start_date'] = date('Y-m-d H:i:s');
+      $this->assign($values['values']);
+    }
+  }
+
+  /**
+   * Builds the form object.
+   *
+   */
+  public function buildQuickForm() {
+
+    parent::buildQuickForm();
+    if (CRM_Batch_BAO_Batch::checkBatchPermission('close', $this->_values['created_id'])) {
+      if (CRM_Batch_BAO_Batch::checkBatchPermission('export', $this->_values['created_id'])) {
+        $this->add('submit', 'export_batch', ts('Done and Export Batch'), ['formtarget' => '_blank']);
+      }
+    }
+
+    $this->_group = CRM_Core_PseudoConstant::nestedGroup();
+
+    CRM_Contribute_BAO_Query::buildSearchForm($this);
+    $this->addElement('checkbox', 'toggleSelects', NULL, NULL);
+
+    $this->add('select',
+      'trans_remove',
+      ts('Task'),
+      ['' => ts('- actions -')] + ['Remove' => ts('Remove from Batch')]);
+
+    $this->add('submit', 'rSubmit', ts('Go'),
+      [
+        'class' => 'crm-form-submit',
+        'id' => 'GoRemove',
+      ]);
+
+    $this->addButtons(
+      [
+        [
+          'type' => 'submit',
+          'name' => ts('Search'),
+          'isDefault' => TRUE,
+        ],
+      ]
+    );
+
+    $this->addElement('checkbox', 'toggleSelect', NULL, NULL);
+    $this->add('select',
+      'trans_assign',
+      ts('Task'),
+      ['' => ts('- actions -')] + ['Assign' => ts('Assign to Batch')]);
+
+    $this->add('submit', 'submit', ts('Go'),
+      [
+        'class' => 'crm-form-submit',
+        'id' => 'Go',
+      ]);
+
+    $this->addElement('hidden', 'batch_id', $this->batchID);
+
+    $this->add('text', 'name', ts('Batch Name'));
+  }
+
+  /**
+   * postProcess function.
+   *
+   */
+  public function postProcess() {
+    $params = $this->controller->exportValues($this->_name);
+
+    if (isset($params['export_batch'])) {
+      $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID);
+      $batch->createExportFile($params);
+    }
+  }
+
+  /**
+   * Get action links.
+   *
+   * @return array
+   *
+   */
+  public function &links() {
+    if (!($this->links)) {
+      $this->links = [
+        'view' => [
+          'name' => ts('View'),
+          'url' => 'civicrm/contact/view/contribution',
+          'qs' => 'reset=1&id=%%contid%%&cid=%%cid%%&action=view&context=contribution&selectedChild=contribute',
+          'title' => ts('View Contribution'),
+        ],
+        'assign' => [
+          'name' => ts('Assign'),
+          'ref' => 'disable-action',
+          'title' => ts('Assign Transaction'),
+          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'assign' . '\' );"',
+        ],
+      ];
+    }
+
+    return $this->links;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Form/InstructionsBatch.php
+++ b/CRM/ManualDirectDebit/Form/InstructionsBatch.php
@@ -1,0 +1,127 @@
+<?php
+
+use CRM_ManualDirectDebit_ExtensionUtil as E;
+
+/**
+ * This class generates form components for Create Instructions Batch
+ */
+class CRM_ManualDirectDebit_Form_InstructionsBatch extends CRM_Admin_Form {
+
+  /**
+   * PreProcess function.
+   *
+   */
+  public function preProcess() {
+    parent::preProcess();
+
+    CRM_Utils_System::setTitle(E::ts('Create New Direct Debit Instructions'));
+
+    // Set the user context.
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext(CRM_Utils_System::url('civicrm/direct_debit/batch/instructions_batch', "reset=1"));
+
+    $this->assign('batch_id', CRM_ManualDirectDebit_Batch_BatchHandler::getMaxBatchId() + 1);
+
+    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', 'instructions_batch', 'name', 'String', FALSE);
+
+    $this->add('hidden', 'type_id', $instructionsBatchTypeId['value']);
+    $this->assign('batch_type', ts('New Direct Debit Instructions'));
+  }
+
+  /**
+   * Builds the form object.
+   *
+   */
+  public function buildQuickForm() {
+    parent::buildQuickForm();
+
+    $attributes = CRM_Core_DAO::getAttribute('CRM_Batch_DAO_Batch');
+    $this->add('text', 'title', ts('Batch Name'), $attributes['name'], TRUE);
+
+    $this->add('select', 'originator_number', ts('Originator number'),
+      ['' => ts('- select -')] + CRM_Core_OptionGroup::values('direct_debit_originator_number'),
+      TRUE
+    );
+
+    $this->addButtons([
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+      [
+        'type' => 'next',
+        'name' => ts('Next'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+  }
+
+  /**
+   * Sets defaults for form.
+   *
+   * @see CRM_Core_Form::setDefaultValues()
+   *
+   */
+  public function setDefaultValues() {
+    $defaults = parent::setDefaultValues();
+
+    $defaults['title'] = CRM_Batch_BAO_Batch::generateBatchName();
+
+    return $defaults;
+  }
+
+  /**
+   * postProcess function.
+   *
+   */
+  public function postProcess() {
+    $session = CRM_Core_Session::singleton();
+    $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
+    $params = $this->controller->exportValues($this->_name);
+    $params['data'] = json_encode(['values' => ['originator_number' => $params['originator_number']]]);
+    $params['modified_date'] = date('YmdHis');
+    $params['modified_id'] = $session->get('userID');
+    $batchMode = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'mode_id', ['labelColumn' => 'name']);
+    $params['mode_id'] = CRM_Utils_Array::key('Manual Batch', $batchMode);
+    $params['status_id'] = CRM_Utils_Array::key('Open', $batchStatus);
+    $params['created_date'] = date('YmdHis');
+    $params['created_id'] = $session->get('userID');
+
+    $batch = CRM_Batch_BAO_Batch::create($params);
+
+    $this->_id = $batch->id;
+
+    $this->createBatchActivity($batch->title);
+
+    if ($batch->title) {
+      CRM_Core_Session::setStatus(ts("'%1' batch has been saved.", [1 => $batch->title]), ts('Saved'), 'success');
+    }
+
+    $session->replaceUserContext(CRM_Utils_System::url('civicrm/direct_debit/batchtransaction',
+      "reset=1&bid={$batch->id}"));
+  }
+
+  /**
+   * Creates activity for new batch
+   *
+   * @param object $batchTitle
+   *
+   */
+  private function createBatchActivity($batchTitle) {
+    $activityTypes = CRM_Core_PseudoConstant::get('CRM_Activity_DAO_Activity', 'activity_type_id');
+    $details = ts('%1 batch has been created by this contact.', [1 => $batchTitle]);
+    $activityParams = [
+      'activity_type_id' => array_search('Create Batch', $activityTypes),
+      'subject' => $batchTitle,
+      'status_id' => 2,
+      'priority_id' => 2,
+      'activity_date_time' => date('YmdHis'),
+      'source_contact_id' => CRM_Core_Session::singleton()->get('userID'),
+      'source_contact_qid' => CRM_Core_Session::singleton()->get('userID'),
+      'details' => $details,
+    ];
+
+    CRM_Activity_BAO_Activity::create($activityParams);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * This class contains all the function that are called using AJAX
+ */
+class CRM_ManualDirectDebit_Page_AJAX {
+
+  /**
+   * Prepares Direct Debit mandates' transactions items
+   *
+   * @return string
+   */
+  public static function getInstructionTransactionsList() {
+    $sortMapper = [
+      0 => '',
+      1 => 'id',
+      2 => 'name',
+      3 => 'sort_code',
+      4 => 'account_number',
+      5 => 'amount',
+      6 => 'reference_number',
+      7 => 'transaction_type',
+    ];
+
+    $sEcho = CRM_Utils_Request::retrieveValue('sEcho', 'Integer');
+    $return = CRM_Utils_Request::retrieveValue('return', 'Boolean', FALSE);
+    $offset = CRM_Utils_Request::retrieveValue('iDisplayStart', 'Integer', 0);
+    $rowCount = CRM_Utils_Request::retrieveValue('iDisplayLength', 'Integer', 25);
+    $context = CRM_Utils_Request::retrieveValue('context', 'String', NULL);
+    $entityID = CRM_Utils_Request::retrieveValue('entityID', 'String', NULL);
+    $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
+
+    $sort = CRM_Utils_Array::value(CRM_Utils_Request::retrieveValue('iSortCol_0', 'Integer', NULL), $sortMapper);
+    $sortOrder = CRM_Utils_Request::retrieveValue('sSortDir_0', 'String', 'asc');
+
+    $params = $_POST;
+
+    if ($sort && $sortOrder) {
+      $params['sortBy'] = $sort . ' ' . $sortOrder;
+    }
+
+    $params['page'] = ($offset / $rowCount) + 1;
+    $params['rp'] = $rowCount;
+
+    $params['context'] = $context;
+    $params['offset'] = ($params['page'] - 1) * $params['rp'];
+    $params['rowCount'] = $params['rp'];
+    $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
+    $params['total'] = 0;
+
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($entityID, $params, [], [], $notPresent);
+    $batchTransaction->addColumnHeader(['amount' => ts('Amount')]);
+    $batchTransaction->addReturnValues(['amount' => '0 as amount']);
+
+    $mandateItems = $batchTransaction->getRows();
+
+    $iFilteredTotal = $iTotal = $batchTransaction->getTotalNumber();
+
+    $selectorElements = [
+      'check',
+      'contact_id',
+      'name',
+      'sort_code',
+      'account_number',
+      'amount',
+      'reference_number',
+      'transaction_type',
+    ];
+
+    if ($return) {
+      return CRM_Utils_JSON::encodeDataTableSelector($mandateItems, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
+    }
+    CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
+    echo CRM_Utils_JSON::encodeDataTableSelector($mandateItems, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
+    CRM_Utils_System::civiExit();
+  }
+
+
+  /**
+   * Callback to perform action on batch records.
+   */
+  public static function bulkAssignRemove() {
+    $mandatesIDs = CRM_Utils_Request::retrieveValue('ID', 'Memo');
+    $entityID = CRM_Utils_Request::retrieveValue('entityID', 'String');
+    $actions = CRM_Utils_Request::retrieveValue('actions', 'String');
+
+    foreach ($mandatesIDs as $key => $value) {
+      if ((substr($value, 0, 7) == "mark_x_" && $actions == 'Assign') || (substr($value, 0, 7) == "mark_y_" && $actions == 'Remove')) {
+        $mandates = explode("_", $value);
+        $mandatesIDs[$key] = $mandates[2];
+      }
+    }
+
+    foreach ($mandatesIDs as $key => $value) {
+
+      if ($actions == 'Remove' || $actions == 'Assign') {
+        $params = [
+          'entity_id' => $value,
+          'entity_table' => 'civicrm_value_dd_mandate',
+          'batch_id' => $entityID,
+        ];
+        if ($actions == 'Assign') {
+          $updated = CRM_Batch_BAO_EntityBatch::create($params);
+        }
+        else {
+          $updated = CRM_Batch_BAO_EntityBatch::del($params);
+        }
+      }
+    }
+    if (!empty($updated)) {
+      $status = ['status' => 'record-updated-success'];
+    }
+    else {
+      $status = ['status' => ts('Can not %1 mandate', [1 => $actions])];
+    }
+    CRM_Utils_JSON::output($status);
+  }
+
+  /**
+   * Callback to perform action on batch records.
+   */
+  public static function assignRemove() {
+    $op = CRM_Utils_Request::retrieveValue('op', 'String');
+    $recordBAO = CRM_Utils_Request::retrieveValue('recordBAO', 'String');
+
+    $records = [];
+    foreach (CRM_Utils_Request::retrieveValue('records', 'String', []) as $record) {
+      $recordID = CRM_Utils_Type::escape($record, 'Positive', FALSE);
+      if ($recordID) {
+        $records[] = $recordID;
+      }
+    }
+
+    $entityID = CRM_Utils_Request::retrieveValue('entityID', 'Positive');
+    $methods = [
+      'assign' => 'create',
+      'remove' => 'del',
+    ];
+
+    $response = ['status' => 'record-updated-fail'];
+    // first munge and clean the recordBAO and get rid of any non alpha numeric characters
+    $recordBAO = CRM_Utils_String::munge($recordBAO);
+    $recordClass = explode('_', $recordBAO);
+    // make sure recordClass is in the CRM namespace and
+    // at least 3 levels deep
+    if ($recordClass[0] == 'CRM' && count($recordClass) >= 3) {
+      foreach ($records as $recordID) {
+        $params = [];
+        switch ($op) {
+          case 'assign':
+          case 'remove':
+            $params = [
+              'entity_id' => $recordID,
+              'entity_table' => 'civicrm_value_dd_mandate',
+              'batch_id' => $entityID,
+            ];
+            break;
+        }
+
+        if (method_exists($recordBAO, $methods[$op]) && !empty($params)) {
+          $updated = call_user_func_array([
+            $recordBAO,
+            $methods[$op],
+          ], [ & $params]);
+          if ($updated) {
+            $redirectStatus = $updated->status_id;
+            $response = [
+              'status' => 'record-updated-success',
+              'status_id' => $redirectStatus,
+            ];
+          }
+        }
+      }
+    }
+    CRM_Utils_JSON::output($response);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Page for displaying list of Batch Transaction
+ */
+class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
+
+  /**
+   * The action links that we need to display for the browse screen.
+   *
+   * @var array
+   */
+  protected $links = NULL;
+
+  /**
+   * @var integer
+   */
+  protected $entityID;
+
+  /**
+   * Runs the page.
+   *
+   */
+  public function run() {
+    // get the requested action
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse'); // default to 'browse'
+
+    // assign vars to templates
+    $this->assign('action', $action);
+
+    $this->entityID = CRM_Utils_Request::retrieve('bid', 'Positive');
+
+    $this->edit($action, $this->entityID);
+    return parent::run();
+  }
+
+  /**
+   * Gets action Links.
+   *
+   * @return array
+   *   (reference) of action links
+   *
+   */
+  public function &links() {
+    return $this->links;
+  }
+
+  /**
+   * Gets BAO Name.
+   *
+   * @return string
+   *   Classname of BAO.
+   */
+  public function getBAOName() {
+    return 'CRM_Batch_BAO_Batch';
+  }
+
+  /**
+   * Gets name of edit form.
+   *
+   * @return string
+   *   Classname of edit form.
+   *
+   */
+  public function editForm() {
+    return 'CRM_ManualDirectDebit_Form_BatchTransaction';
+  }
+
+  /**
+   * Gets edit form name.
+   *
+   * @return string
+   *   name of this page.
+   *
+   */
+  public function editName() {
+    return 'Batch';
+  }
+
+  /**
+   * Gets user context.
+   *
+   * @param null $mode
+   *
+   * @return string
+   *   user context.
+   *
+   */
+  public function userContext($mode = NULL) {
+    return 'civicrm/direct_debit/batchtransaction';
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -160,6 +160,13 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
       'operator' => NULL,
       'separator' => NULL,
     ],
+    [
+      'name' => ts('Create New Direct Debit Instructions'),
+      'url' => 'civicrm/direct_debit/batch/instructions_batch?reset=1&action=add',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => 2,
+    ],
   ];
 
   foreach ($subMenuItems as $menuItem) {
@@ -217,4 +224,26 @@ function _manualdirectdebit_isDirectDebitCustomGroup($groupID) {
   ]);
 
   return $groupID == $directDebitMandateId;
+}
+
+/**
+ * Implements hook_civicrm_links().
+ *
+ */
+function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+
+  if ($objectName == 'Batch') {
+    $batch = CRM_Batch_BAO_Batch::findById($objectId);
+
+    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', 'instructions_batch', 'name', 'String', FALSE);
+    if ($batch->type_id == $instructionsBatchTypeId['value']) {
+      foreach ($links as &$link) {
+        switch ($link['name']) {
+          case 'Transactions':
+            $link['url'] = 'civicrm/direct_debit/batchtransaction';
+            break;
+        }
+      }
+    }
+  }
 }

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -1,0 +1,292 @@
+
+<h3>{ts}Added to batch{/ts}:</h3>
+{if in_array($batchStatus, array('Open', 'Reopened'))} {* Add / remove transactions only allowed for Open/Reopened batches *}
+  <br /><div class="form-layout-compressed">{$form.trans_remove.html}&nbsp;{$form.rSubmit.html}</div><br/>
+{/if}
+<div id="ltype">
+  <div class="form-item">
+      {strip}
+        <table id="crm-transaction-selector-remove-{$entityID}" cellpadding="0" cellspacing="0" border="0">
+          <thead>
+          <tr>
+            <th class="crm-transaction-checkbox">{if in_array($batchStatus, array('Open', 'Reopened'))}{$form.toggleSelects.html}{/if}</th>
+            <th class="crm-contact-id">{ts}Contact ID{/ts}</th>
+            <th class="crm-name">{ts}Account Holder Name{/ts}</th>
+            <th class="crm-sort-code">{ts}Sort code{/ts}</th>
+            <th class="crm-account-number">{ts}Account Number{/ts}</th>
+            <th class="crm-amount">{ts}Amount{/ts}</th>
+            <th class="crm-reference-number">{ts}Reference Number{/ts}</th>
+            <th class="crm-transaction-type">{ts}Transaction Type{/ts}</th>
+          </tr>
+          </thead>
+        </table>
+      {/strip}
+  </div>
+</div>
+<br/>
+
+{if in_array($batchStatus, array('Open', 'Reopened'))}
+  <h3>{ts}Available instructions{/ts}:</h3>
+  <div class="form-layout-compressed">{$form.trans_assign.html}&nbsp;{$form.submit.html}</div>
+  <div id="ltype">
+    <div class="form-item">
+    {strip}
+      <table id="crm-transaction-selector-assign-{$entityID}" cellpadding="0" cellspacing="0" border="0">
+        <thead>
+        <tr>
+          <th class="crm-transaction-checkbox">{if in_array($batchStatus, array('Open', 'Reopened'))}{$form.toggleSelect.html}{/if}</th>
+          <th class="crm-contact-id">{ts}Contact ID{/ts}</th>
+          <th class="crm-name">{ts}Account Holder Name{/ts}</th>
+          <th class="crm-sort-code">{ts}Sort code{/ts}</th>
+          <th class="crm-account-number">{ts}Account Number{/ts}</th>
+          <th class="crm-amount">{ts}Amount{/ts}</th>
+          <th class="crm-reference-number">{ts}Reference Number{/ts}</th>
+          <th class="crm-transaction-type">{ts}Transaction Type{/ts}</th>
+        </tr>
+        </thead>
+      </table>
+    {/strip}
+    </div>
+</div>
+{/if}
+
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+  CRM.$('#_qf_BatchTransaction_submit-top, #_qf_BatchTransaction_submit-bottom').click(function() {
+    CRM.$('.crm-batch_transaction_search-accordion:not(.collapsed)').crmAccordionToggle();
+  });
+  var batchStatus = {/literal}{$statusID}{literal};
+  {/literal}{if $validStatus}{literal}
+    // build transaction listing only for open/reopened batches
+    buildTransactionSelectorAssign();
+    buildTransactionSelectorRemove();
+
+    CRM.$("#trans_assign").prop('disabled',true);
+    CRM.$("#trans_remove").prop('disabled',true);
+    CRM.$('#crm-transaction-selector-assign-{/literal}{$entityID}{literal} #toggleSelect').click( function() {
+      enableActions('x');
+    });
+    CRM.$('#crm-transaction-selector-remove-{/literal}{$entityID}{literal} #toggleSelects').click( function() {
+      enableActions('y');
+    });
+    CRM.$('#Go').click( function() {
+      return selectAction("trans_assign","toggleSelect", "crm-transaction-selector-assign-{/literal}{$entityID}{literal} input[id^='mark_x_']");
+    });
+    CRM.$('#GoRemove').click( function() {
+      return selectAction("trans_remove","toggleSelects", "crm-transaction-selector-remove-{/literal}{$entityID}{literal} input[id^='mark_y_']");
+    });
+    CRM.$('#Go').click( function() {
+      if (CRM.$("#trans_assign" ).val() != "" && CRM.$("input[id^='mark_x_']").is(':checked')) {
+        bulkAssignRemove('Assign');
+      }
+      return false;
+    });
+    CRM.$('#GoRemove').click( function() {
+      if (CRM.$("#trans_remove" ).val() != "" && CRM.$("input[id^='mark_y_']").is(':checked')) {
+        bulkAssignRemove('Remove');
+      }
+      return false;
+    });
+    CRM.$("#crm-transaction-selector-assign-{/literal}{$entityID}{literal} input[id^='mark_x_']").click( function() {
+      enableActions('x');
+    });
+    CRM.$("#crm-transaction-selector-remove-{/literal}{$entityID}{literal} input[id^='mark_y_']").click( function() {
+      enableActions('y');
+    });
+
+    CRM.$("#crm-transaction-selector-assign-{/literal}{$entityID}{literal} #toggleSelect").click( function() {
+      toggleFinancialSelections('#toggleSelect', 'assign');
+    });
+    CRM.$("#crm-transaction-selector-remove-{/literal}{$entityID}{literal} #toggleSelects").click( function() {
+      toggleFinancialSelections('#toggleSelects', 'remove');
+    });
+  {/literal}{else}{literal}
+    buildTransactionSelectorRemove();
+  {/literal}{/if}{literal}
+});
+
+function enableActions( type ) {
+  if (type == 'x') {
+    CRM.$("#trans_assign").prop('disabled',false);
+  }
+  else {
+    CRM.$("#trans_remove").prop('disabled',false);
+  }
+}
+
+function toggleFinancialSelections(toggleID, toggleClass) {
+  var mark = 'x';
+  if (toggleClass == 'remove') {
+    mark = 'y';
+  }
+  if (CRM.$("#crm-transaction-selector-" + toggleClass + "-{/literal}{$entityID}{literal} " +	toggleID).is(':checked')) {
+    CRM.$("#crm-transaction-selector-" + toggleClass + "-{/literal}{$entityID}{literal} input[id^='mark_" + mark + "_']").prop('checked',true);
+  }
+  else {
+    CRM.$("#crm-transaction-selector-" + toggleClass + "-{/literal}{$entityID}{literal} input[id^='mark_" + mark + "_']").prop('checked',false);
+  }
+}
+
+function buildTransactionSelectorAssign() {
+  var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=getInstructionTransactionsList&snippet=4&context=instructionBatch&entityID=$entityID&notPresent=1&statusID=$statusID"}'{literal};
+  var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}None found.{/ts}{literal}</li></ul></div>';
+
+  crmBatchSelector1 = CRM.$('#crm-transaction-selector-assign-{/literal}{$entityID}{literal}').dataTable({
+  "bDestroy"   : true,
+  "bFilter"    : false,
+  "bAutoWidth" : false,
+  "lengthMenu": [ 10, 25, 50, 100, 250, 500, 1000, 2000 ],
+  "aaSorting"  : [],
+  "aoColumns"  : [
+    {sClass:'crm-transaction-checkbox', bSortable:false},
+    {sClass:'crm-contact-id', bSortable:false},
+    {sClass:'crm-name'},
+    {sClass:'crm-sort-code'},
+    {sClass:'crm-account-number'},
+    {sClass:'crm-amount'},
+    {sClass:'crm-reference-number'},
+    {sClass:'crm-transaction-type'}
+  ],
+  "bProcessing": true,
+  "asStripClasses" : [ "odd-row", "even-row" ],
+  "sPaginationType": "full_numbers",
+  "sDom"       : '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
+  "bServerSide": true,
+  "bJQueryUI": true,
+  "sAjaxSource": sourceUrl,
+  "iDisplayLength": 25,
+  "oLanguage": {
+    "sZeroRecords":  ZeroRecordText,
+    "sProcessing":    {/literal}"{ts escape='js'}Processing...{/ts}"{literal},
+    "sLengthMenu":    {/literal}"{ts escape='js'}Show _MENU_ entries{/ts}"{literal},
+    "sInfo":          {/literal}"{ts escape='js'}Showing _START_ to _END_ of _TOTAL_ entries{/ts}"{literal},
+    "sInfoEmpty":     {/literal}"{ts escape='js'}Showing 0 to 0 of 0 entries{/ts}"{literal},
+    "sInfoFiltered":  {/literal}"{ts escape='js'}(filtered from _MAX_ total entries){/ts}"{literal},
+    "sSearch":        {/literal}"{ts escape='js'}Search:{/ts}"{literal},
+    "oPaginate": {
+      "sFirst":    {/literal}"{ts escape='js'}First{/ts}"{literal},
+      "sPrevious": {/literal}"{ts escape='js'}Previous{/ts}"{literal},
+      "sNext":     {/literal}"{ts escape='js'}Next{/ts}"{literal},
+      "sLast":     {/literal}"{ts escape='js'}Last{/ts}"{literal}
+    }
+  },
+  "fnServerData": function ( sSource, aoData, fnCallback ) {
+
+    aoData.push( { name: 'originator_number', value: "{/literal}{$originator_number}{literal}" } );
+    aoData.push( { name: 'start_date', value: "{/literal}{$start_date}{literal}" } );
+    aoData.push( { name: 'dd_code', value: "{/literal}{$dd_code}{literal}" } );
+
+    CRM.$.ajax({
+    "dataType": 'json',
+    "type": "POST",
+    "url": sSource,
+    "data": aoData,
+    "success": function(b) {
+      fnCallback(b);
+      toggleFinancialSelections('#toggleSelect', 'assign');
+    }
+    });
+  }
+});
+	
+}
+
+function buildTransactionSelectorRemove( ) {
+  var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=getInstructionTransactionsList&snippet=4&context=financialBatch&entityID=$entityID&statusID=$statusID"}'{literal};
+
+  crmBatchSelector = CRM.$('#crm-transaction-selector-remove-{/literal}{$entityID}{literal}').dataTable({
+  "bDestroy"   : true,
+  "bFilter"    : false,
+  "bAutoWidth" : false,
+  "aaSorting"  : [],
+  "aoColumns"  : [
+    {sClass:'crm-transaction-checkbox', bSortable:false},
+    {sClass:'crm-contact-id', bSortable:false},
+    {sClass:'crm-name'},
+    {sClass:'crm-sort-code'},
+    {sClass:'crm-account-number'},
+    {sClass:'crm-amount'},
+    {sClass:'crm-reference-number'},
+    {sClass:'crm-transaction-type'}
+  ],
+  "bProcessing": true,
+  "asStripClasses" : [ "odd-row", "even-row" ],
+  "sPaginationType": "full_numbers",
+  "sDom"       : '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
+  "bServerSide": true,
+  "bJQueryUI": true,
+  "sAjaxSource": sourceUrl,
+  "iDisplayLength": 25,
+  "oLanguage": {
+    "sProcessing":    {/literal}"{ts escape='js'}Processing...{/ts}"{literal},
+    "sLengthMenu":    {/literal}"{ts escape='js'}Show _MENU_ entries{/ts}"{literal},
+    "sInfo":          {/literal}"{ts escape='js'}Showing _START_ to _END_ of _TOTAL_ entries{/ts}"{literal},
+    "sInfoEmpty":     {/literal}"{ts escape='js'}Showing 0 to 0 of 0 entries{/ts}"{literal},
+    "sInfoFiltered":  {/literal}"{ts escape='js'}(filtered from _MAX_ total entries){/ts}"{literal},
+    "sSearch":        {/literal}"{ts escape='js'}Search:{/ts}"{literal},
+    "oPaginate": {
+      "sFirst":    {/literal}"{ts escape='js'}First{/ts}"{literal},
+      "sPrevious": {/literal}"{ts escape='js'}Previous{/ts}"{literal},
+      "sNext":     {/literal}"{ts escape='js'}Next{/ts}"{literal},
+      "sLast":     {/literal}"{ts escape='js'}Last{/ts}"{literal}
+    }
+  },
+  "fnServerData": function (sSource, aoData, fnCallback) {
+    CRM.$.ajax({
+      "dataType": 'json',
+      "type": "POST",
+      "url": sSource,
+      "data": aoData,
+      "success": function(b) {
+        fnCallback(b);
+        toggleFinancialSelections('#toggleSelects', 'remove');
+      }
+    });
+  }
+});
+}
+
+function selectAction( id, toggleSelectId, checkId ) {
+  if (CRM.$("#"+ id ).is(':disabled')) {
+    return false;
+  }
+  else if (!CRM.$("#" + toggleSelectId).is(':checked') && !CRM.$("#" + checkId).is(':checked') && CRM.$("#" + id).val() != "") {
+    CRM.alert ({/literal}'{ts escape="js"}Please select one or more contributions for this action.{/ts}'{literal});
+    return false;
+  }
+  else if (CRM.$("#" + id).val() == "") {
+    CRM.alert ({/literal}'{ts escape="js"}Please select an action from the drop-down menu.{/ts}'{literal});
+    return false;
+  }
+}
+
+function bulkAssignRemove( action ) {
+  var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=bulkAssignRemove&entityID=$entityID" }"{literal};
+  var fids = [];
+  if (action == 'Assign') {
+    CRM.$("input[id^='mark_x_']:checked").each( function () {
+      var a = CRM.$(this).attr('id');
+      fids.push(a);
+    });
+  }
+  if (action == 'Remove') {
+    CRM.$("input[id^='mark_y_']:checked").each( function () {
+      var a = CRM.$(this).attr('id');
+      fids.push(a);
+    });
+  }
+  CRM.$.post(postUrl, { ID: fids, actions:action }, function(data) {
+    //this is custom status set when record update success.
+    if (data.status == 'record-updated-success') {
+      buildTransactionSelectorAssign( true );
+      buildTransactionSelectorRemove();
+      batchSummary({/literal}{$entityID}{literal});
+    }
+    else {
+      CRM.alert(data.status);
+    }
+  }, 'json');
+}
+</script>
+{/literal}

--- a/templates/CRM/ManualDirectDebit/Form/InstructionsBatch.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/InstructionsBatch.tpl
@@ -1,0 +1,19 @@
+<div class="crm-section">
+    <div class="clear">
+        <div class="label">{ts}Batch ID{/ts}:</div>
+        <div class="content">{$batch_id}</div>
+    </div>
+    <div class="clear">
+        <div class="label">{$form.title.label}</div>
+        <div class="content">{$form.title.html}</div>
+    </div>
+    <div class="clear">
+        <div class="label">{ts}Type{/ts}</div>
+        <div class="content">{$batch_type}</div>
+    </div>
+    <div class="clear">
+        <div class="label">{$form.originator_number.label}</div>
+        <div class="content">{$form.originator_number.html}</div>
+    </div>
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
@@ -1,0 +1,47 @@
+<div id="enableDisableStatusMsg" class="crm-container" style="display:none;"></div>
+<div class="crm-submit-buttons">{$form.export_batch.html}</div>
+
+{include file="CRM/ManualDirectDebit/Form/BatchTransaction.tpl"}
+
+{literal}
+<script type="text/javascript">
+
+
+function assignRemove(recordID, op) {
+  var recordBAO = 'CRM_Batch_BAO_Batch';
+  if (op == 'assign' || op == 'remove') {
+    recordBAO = 'CRM_Batch_BAO_EntityBatch';   
+  }
+  var entityID = {/literal}"{$entityID}"{literal};
+  CRM.$('#mark_x_' + recordID).closest('tr').block({message: {/literal}'{ts escape="js"}Updating{/ts}'{literal}});
+
+  saveRecord(recordID, op, recordBAO, entityID);
+}
+
+function noServerResponse() {
+  CRM.alert({/literal}'{ts escape="js"}No response from the server. Check your internet connection and try reloading the page.{/ts}', '{ts escape="js"}Network Error{/ts}'{literal}, 'error');
+}
+
+function saveRecord(recordID, op, recordBAO, entityID) {
+
+  var postUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_ManualDirectDebit_Page_AJAX&fnName=assignRemove'}"{literal};
+  //post request and get response
+  CRM.$.post( postUrl, { records: [recordID], recordBAO: recordBAO, op:op, entityID:entityID, key: {/literal}"{crmKey name='civicrm/ajax/ar'}"{literal},  originator_number: {/literal}"{$originator_number}"{literal} }, function( html ){
+    //this is custom status set when record update success.
+    if (html.status == 'record-updated-success') {
+      if (op == 'close') {
+        window.location.href = CRM.url('civicrm/financial/financialbatches', 'reset=1&batchStatus=2');
+      }
+      else {
+        buildTransactionSelectorAssign( true );
+        buildTransactionSelectorRemove();
+      }
+    }
+    else {
+      CRM.alert(html.status);
+    }
+  },
+  'json').error(noServerResponse);
+}
+</script>
+{/literal}

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -8,4 +8,14 @@
         <access_arguments>administer CiviCRM</access_arguments>
         <page_type>0</page_type>
     </item>
+    <item>
+        <path>civicrm/direct_debit/batch/instructions_batch</path>
+        <title>New instructions batch</title>
+        <page_callback>CRM_ManualDirectDebit_Form_InstructionsBatch</page_callback>
+    </item>
+    <item>
+        <path>civicrm/direct_debit/batchtransaction</path>
+        <title>Accounting Batch</title>
+        <page_callback>CRM_ManualDirectDebit_Page_BatchTransaction</page_callback>
+    </item>
 </menu>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -390,6 +390,18 @@
             <description>To cancel a Direct Debit</description>
             <option_group_name>direct_debit_codes</option_group_name>
         </OptionValue>
+        <OptionValue>
+            <label>New Direct Debit Instructions</label>
+            <value>4</value>
+            <name>instructions_batch</name>
+            <is_default>0</is_default>
+            <weight>4</weight>
+            <is_optgroup>0</is_optgroup>
+            <is_reserved>1</is_reserved>
+            <is_active>1</is_active>
+            <description>New Direct Debit Instructions</description>
+            <option_group_name>batch_type</option_group_name>
+        </OptionValue>
     </OptionValues>
     <ProfileGroups>
         <ProfileGroup>


### PR DESCRIPTION
## Overview

1. Add new menu item to Direct Debit > Create new instructions batch.
2. New menu item leads to ‘Create new instructions batch’ page for creating new instructions batch.
3. ‘Create new instructions batch’ page leads to the next page ‘New Direct Debit Instructions’ with two tables  ‘Available Instructions’ and ‘Added to batch’ with the same columns.
4. User is able to add Mandates into the batch from the ‘Available Instructions’ table listing Direct Debit mandates that match the following criteria: 	
- mandate's "Originator Number" matches with the originator number selected on the page  ‘Create new instructions batch’ 
- mandate's "Start Date" is equal to or earlier than today
- mandate's "DD code" is 0N.
- mandate's "DD code" is not 0C.
5. On ‘Done and Export Batch’ click  the batch is put in "Open" status and a CSV file containing all columns is generated.

![dd-16](https://user-images.githubusercontent.com/36959503/38682353-8c680baa-3e73-11e8-9e1a-7d9d3ab757fa.gif)

## Sample CSV file

[Instructions_Batch30_20180412190954.csv.zip](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/files/1904071/Instructions_Batch30_20180412190954.csv.zip)
