### PR TITLE
DD-13: Direct Debit Mandate Generation when submit a Direct Debit Payment from Webform

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/ContributionDataGenerator.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This class automatically generates all required fields for contribution
+ */
+class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
+
+  /**
+   * Recurring contribution cycle day
+   *
+   * @var int
+   */
+  private $cycleDay;
+
+  /**
+   * Contribution start date
+   *
+   * @var object
+   */
+  private $start_date;
+
+  /**
+   * Array of extension settings
+   *
+   * @var array
+   */
+  private $settings;
+
+  /**
+   * Contact entity ID
+   *
+   * @var int
+   */
+  private $entityID;
+
+  /**
+   * Mandate Start Date
+   *
+   * @var object
+   */
+  private $mandateStartDate;
+
+  public function __construct($entityID, $settings) {
+    $this->entityID = $entityID;
+    $this->settings = $settings;
+  }
+
+  /**
+   * Sets mandate start date
+   *
+   * @param $mandateStartDate
+   */
+  public function setMandateStartDate($mandateStartDate) {
+    $this->mandateStartDate = $mandateStartDate;
+  }
+
+  /**
+   * Launches generation of required contribution fields
+   *
+   */
+  public function generateContributionFieldsValues() {
+    $this->generateCycleDate();
+    $this->generateRecurringContributionStartDate();
+  }
+
+  /**
+   * Generates cycle date
+   *
+   */
+  private function generateCycleDate() {
+    $mandateStartDateDayNumber = DateTime::createFromFormat('Y-m-d H:i:s', $this->mandateStartDate)->format('d');
+    $closestNewInstructionRunDate = $this->findClosestDate($this->settings['new_instruction_run_dates'], $mandateStartDateDayNumber);
+    $closestNewInstructionRunDateWithOffset = $closestNewInstructionRunDate + $this->settings['minimum_days_to_first_payment'];
+
+    $this->cycleDay = $this->findClosestDate($this->settings['payment_collection_run_dates'], $closestNewInstructionRunDateWithOffset);
+  }
+
+  /**
+   * Gets closest date to 'selectedDate' in array 'possibleRunDates'. If it`s
+   * not exists it gets lowest value in 'possibleRunDates'
+   *
+   * @param $possibleRunDates
+   * @param $selectedDate
+   *
+   * @return int|mixed
+   */
+  private function findClosestDate($possibleRunDates, $selectedDate) {
+    $closestDay = 0;
+    foreach ($possibleRunDates as $possibleDate) {
+      if ($possibleDate > $selectedDate) {
+        $closestDay = $possibleDate;
+        break;
+      }
+    }
+
+    if ($closestDay === 0) {
+      $closestDay = min($possibleRunDates);
+    }
+
+    return $closestDay;
+  }
+
+  /**
+   * Generates Recurring Contribution `Start date`
+   *
+   */
+  private function generateRecurringContributionStartDate() {
+    $startDateGenerator = new CRM_ManualDirectDebit_Hook_Custom_ContributionRecurStartDateGenerator($this->cycleDay, $this->mandateStartDate);
+    $this->start_date = $startDateGenerator->generate();
+  }
+
+  /**
+   * Saves all generated values
+   *
+   */
+  public function saveGeneratedContributionValues() {
+    civicrm_api3('ContributionRecur', 'get', [
+      'return' => "id",
+      'contact_id' => $this->entityID,
+      'options' => ['limit' => 1, 'sort' => "contribution_recur_id DESC"],
+      'api.ContributionRecur.create' => [
+        'id' => '$value.id',
+        'cycle_day' => $this->cycleDay,
+        'start_date' => $this->start_date,
+      ],
+    ]);
+
+    civicrm_api3('Contribution', 'get', [
+      'return' => "id",
+      'contact_id' => $this->entityID,
+      'options' => ['limit' => 1, 'sort' => "contribution_id DESC"],
+      'api.Contribution.create' => [
+        'id' => '$value.id',
+        'receive_date' => $this->start_date,
+      ],
+    ]);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/Custom/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/ContributionDataGenerator.php
@@ -56,7 +56,6 @@ class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
 
   /**
    * Launches generation of required contribution fields
-   *
    */
   public function generateContributionFieldsValues() {
     $this->generateCycleDate();
@@ -65,7 +64,6 @@ class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
 
   /**
    * Generates cycle date
-   *
    */
   private function generateCycleDate() {
     $mandateStartDateDayNumber = DateTime::createFromFormat('Y-m-d H:i:s', $this->mandateStartDate)->format('d');
@@ -102,7 +100,6 @@ class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
 
   /**
    * Generates Recurring Contribution `Start date`
-   *
    */
   private function generateRecurringContributionStartDate() {
     $startDateGenerator = new CRM_ManualDirectDebit_Hook_Custom_ContributionRecurStartDateGenerator($this->cycleDay, $this->mandateStartDate);
@@ -111,7 +108,6 @@ class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
 
   /**
    * Saves all generated values
-   *
    */
   public function saveGeneratedContributionValues() {
     civicrm_api3('ContributionRecur', 'get', [

--- a/CRM/ManualDirectDebit/Hook/Custom/ContributionRecurStartDateGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/ContributionRecurStartDateGenerator.php
@@ -3,7 +3,7 @@
 /**
  * Generates `Start Date` field if it wasn't filed by user
  */
-class CRM_ManualDirectDebit_Hook_Custom_MandateStartDateGenerator {
+class CRM_ManualDirectDebit_Hook_Custom_ContributionRecurStartDateGenerator {
 
   /**
    * Current year
@@ -27,11 +27,11 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateStartDateGenerator {
   private $day;
 
   /**
-   * Collection day
+   * Cycle day
    *
    * @var int
    */
-  private $collectionDay;
+  private $cycleDay;
 
   /**
    * Protects setting month bigger then 12, and in that case set it to 1
@@ -48,12 +48,12 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateStartDateGenerator {
     }
   }
 
-  public function __construct($collectionDay) {
-    $this->year = (new DateTime())->format('Y');
-    $this->month = (new DateTime())->format('m');
-    $this->day = (new DateTime())->format('d');
+  public function __construct($cycleDay, $mandateStartDate) {
+    $this->year = DateTime::createFromFormat('Y-m-d H:i:s', $mandateStartDate)->format('Y');
+    $this->month = DateTime::createFromFormat('Y-m-d H:i:s', $mandateStartDate)->format('m');
+    $this->day = DateTime::createFromFormat('Y-m-d H:i:s', $mandateStartDate)->format('d');
 
-    $this->collectionDay = $collectionDay;
+    $this->cycleDay = $cycleDay;
   }
 
   /**
@@ -62,10 +62,10 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateStartDateGenerator {
    * @return string
    */
   public function generate() {
-    if ($this->day > $this->collectionDay) {
+    if ($this->day > $this->cycleDay) {
       $this->setMonth($this->month + 1);
     }
-    $this->day = $this->collectionDay;
+    $this->day = $this->cycleDay;
 
     $this->generateClosestDate();
 

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -34,7 +34,6 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
 
   /**
    *  Sets `settings` property
-   *
    */
   private function setManualDirectDebitSettings() {
     $this->settings = $this->getManualDirectDebitSettings();
@@ -86,7 +85,6 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
 
   /**
    * Generates and saves the required fields values if they are not supplied by the user.
-   *
    */
   public function generate() {
     $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator($this->entityID, $this->settings, $this->savedFields);

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This class launch required fields generator for different entities
+ */
+class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
+
+  /**
+   * Array of extension settings
+   *
+   * @var array
+   */
+  private $settings;
+
+  /**
+   * Contact entity ID
+   *
+   * @var int
+   */
+  private $entityID;
+
+  /**
+   * Parameters which submitted by form
+   *
+   * @var array
+   */
+  private $savedFields;
+
+  public function __construct($entityID, &$params) {
+    $this->entityID = $entityID;
+    $this->savedFields = $params;
+    $this->setManualDirectDebitSettings();
+  }
+
+  /**
+   *  Sets `settings` property
+   *
+   */
+  private function setManualDirectDebitSettings() {
+    $this->settings = $this->getManualDirectDebitSettings();
+  }
+
+  /**
+   * Gets all extension settings
+   *
+   * @return array
+   */
+  private function getManualDirectDebitSettings() {
+    $settingFields = [
+      'manualdirectdebit_default_reference_prefix',
+      'manualdirectdebit_new_instruction_run_dates',
+      'manualdirectdebit_payment_collection_run_dates',
+      'manualdirectdebit_minimum_days_to_first_payment',
+    ];
+    $settingValues = civicrm_api3('setting', 'get', [
+      'return' => $settingFields,
+      'sequential' => 1,
+    ]);
+
+    $settings = [];
+    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
+    $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
+      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
+    $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
+      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
+    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
+
+    return $settings;
+  }
+
+  /**
+   * Iterates all value in array. Because the first date should starts from 1,
+   * but not from 0.
+   *
+   * @param $possibleRunDates
+   *
+   * @return mixed
+   */
+  private function incrementAllArrayValues($possibleRunDates) {
+    foreach ($possibleRunDates as $sequentialNumber => $value) {
+      $possibleRunDates[$sequentialNumber] = ++$value;
+    }
+
+    return $possibleRunDates;
+  }
+
+  /**
+   * Generates and saves the required fields values if they are not supplied by the user.
+   *
+   */
+  public function generate() {
+    $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator($this->entityID, $this->settings, $this->savedFields);
+    $mandateDataGenerator->generateMandateFieldsValues();
+    $mandateDataGenerator->saveGeneratedMandateValues();
+    $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator($this->entityID, $this->settings);
+    $contributionDataGenerator->setMandateStartDate($mandateDataGenerator->getMandateStartDate());
+    $contributionDataGenerator->generateContributionFieldsValues();
+    $contributionDataGenerator->saveGeneratedContributionValues();
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/Custom/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/MandateDataGenerator.php
@@ -46,15 +46,6 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
   public function __construct($entityID, $settings, &$params) {
     $this->settings = $settings;
     $this->savedFields = $params;
-    $this->setMandateId($entityID);
-  }
-
-  /**
-   * Sets `mandateId` property
-   *
-   * @param $entityID
-   */
-  private function setMandateId($entityID) {
     $this->mandateId = $this->getLastMandateId($entityID);
   }
 
@@ -125,7 +116,6 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
 
   /**
    * Saves all generated values
-   *
    */
   public function saveGeneratedMandateValues() {
     $setValueTemplateFields = [];

--- a/CRM/ManualDirectDebit/Hook/Custom/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/MandateDataGenerator.php
@@ -6,25 +6,11 @@
 class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
 
   /**
-   * Primary ID of Direct Debit Mandate
+   * Direct Debit Mandate table name
    *
-   * @var int
+   * @var string
    */
-  private $mandateId;
-
-  /**
-   * Contact entity ID
-   *
-   * @var int
-   */
-  private $entityID;
-
-  /**
-   * Parameters which submitted by form
-   *
-   * @var array
-   */
-  private $savedFields;
+  const MANDATE_TABLE_NAME = 'civicrm_value_dd_mandate';
 
   /**
    * List of the mandate fields to be generated
@@ -32,9 +18,7 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
    * @var array
    */
   private $fieldsToGenerate = [
-    'collection_day' => FALSE,
     'dd_ref' => FALSE,
-    'authorisation_date' => FALSE,
     'start_date' => FALSE,
   ];
 
@@ -45,32 +29,47 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
    */
   private $settings;
 
-  public function __construct($entityID, &$params) {
-    $this->entityID = $entityID;
+  /**
+   * Parameters which submitted by form
+   *
+   * @var array
+   */
+  private $savedFields;
+
+  /**
+   * Primary ID of Direct Debit Mandate
+   *
+   * @var int
+   */
+  private $mandateId;
+
+  public function __construct($entityID, $settings, &$params) {
+    $this->settings = $settings;
     $this->savedFields = $params;
-    $this->setMandateId();
-    $this->setManualDirectDebitSettings();
+    $this->setMandateId($entityID);
   }
 
   /**
    * Sets `mandateId` property
    *
+   * @param $entityID
    */
-  private function setMandateId() {
-    $this->mandateId = $this->getLastMandateId();
+  private function setMandateId($entityID) {
+    $this->mandateId = $this->getLastMandateId($entityID);
   }
 
   /**
    * Gets id of last inserted Direct Debit Mandate
    *
+   * @param $entityID
+   *
    * @return int
    */
-  private function getLastMandateId() {
-    $tableName = 'civicrm_value_dd_mandate';
-    $sqlSelectedDebitMandateID = "SELECT MAX(`id`) AS id FROM `$tableName` WHERE `entity_id` = %1";
+  private function getLastMandateId($entityID) {
+    $sqlSelectedDebitMandateID = "SELECT MAX(`id`) AS id FROM `" . self::MANDATE_TABLE_NAME . "` WHERE `entity_id` = %1";
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectedDebitMandateID, [
       1 => [
-        $this->entityID,
+        $entityID,
         'String',
       ],
     ]);
@@ -81,131 +80,28 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
   }
 
   /**
-   *  Sets `settings` property
-   *
-   */
-  private function setManualDirectDebitSettings() {
-    $this->settings = $this->getManualDirectDebitSettings();
-  }
-
-  /**
-   * Gets all extension settings
-   *
-   * @return array
-   */
-  private function getManualDirectDebitSettings() {
-    $settingFields = [
-      'manualdirectdebit_default_reference_prefix',
-      'manualdirectdebit_new_instruction_run_dates',
-      'manualdirectdebit_payment_collection_run_dates',
-      'manualdirectdebit_minimum_days_to_first_payment',
-    ];
-    $settingValues = civicrm_api3('setting', 'get', [
-      'return' => $settingFields,
-      'sequential' => 1,
-    ]);
-
-    $settings = [];
-    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
-    $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
-    $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
-    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
-
-    return $settings;
-  }
-
-  /**
-   * Iterates all value in array. Because the first date should starts from 1,
-   * but not from 0.
-   *
-   * @param $possibleRunDates
-   *
-   * @return mixed
-   */
-  private function incrementAllArrayValues($possibleRunDates) {
-    foreach ($possibleRunDates as $sequentialNumber => $value) {
-      $possibleRunDates[$sequentialNumber] = ++$value;
-    }
-
-    return $possibleRunDates;
-  }
-
-  /**
-   * Generates and saves the required mandate fields  values if they are not supplied by the user.
-   *
-   */
-  public function generate() {
-    $this->generateFieldsValues();
-    $this->saveGeneratedValues();
-    $this->updateContributionReceiveDate();
-  }
-
-  /**
    * Finds which of necessary fields have to be generated
    *
    */
-  private function generateFieldsValues() {
+  public function generateMandateFieldsValues() {
     foreach ($this->savedFields as $field) {
-      if (in_array($field['column_name'], $this->fieldsToGenerate)) {
+      if (array_key_exists($field['column_name'], $this->fieldsToGenerate)) {
         $this->fieldsToGenerate[$field['column_name']] = $field['value'];
       }
     }
 
-    if ($this->fieldsToGenerate['collection_day'] === FALSE) {
-      $this->fieldsToGenerate['collection_day'] = $this->generateCollectionDay();
-    }
-
-    if ($this->fieldsToGenerate['dd_ref'] === FALSE) {
+    if ($this->fieldsToGenerate['dd_ref'] == FALSE) {
       $this->fieldsToGenerate['dd_ref'] = $this->generateDirectDebitReference();
     }
 
-    if ($this->fieldsToGenerate['authorisation_date'] === FALSE) {
-      $this->fieldsToGenerate['authorisation_date'] = $this->generateAuthorizationDate();
+    if ($this->fieldsToGenerate['start_date'] == FALSE) {
+      $this->fieldsToGenerate['start_date'] = $this->generateStartDate();
+    } else{
+      $date = new DateTime();
+      $this->fieldsToGenerate['start_date'] = $date->setTimestamp(
+        strtotime($this->fieldsToGenerate['start_date'])
+      )->format('Y-m-d H:i:s');
     }
-
-    if ($this->fieldsToGenerate['start_date'] === FALSE) {
-      $startDateGenerator = new CRM_ManualDirectDebit_Hook_Custom_MandateStartDateGenerator($this->fieldsToGenerate['collection_day']);
-      $this->fieldsToGenerate['start_date'] = $startDateGenerator->generate();
-    }
-  }
-
-  /**
-   * Generates collection date
-   *
-   * @return int
-   */
-  private function generateCollectionDay() {
-    $closestNewInstructionRunDate = $this->findClosestDate($this->settings['new_instruction_run_dates'], date('Y-m-d'));
-    $closestNewInstructionRunDateWithOffset = $closestNewInstructionRunDate + $this->settings['minimum_days_to_first_payment'];
-
-    return $this->findClosestDate($this->settings['payment_collection_run_dates'], $closestNewInstructionRunDateWithOffset);
-  }
-
-  /**
-   * Gets closest date to 'selectedDate' in array 'possibleRunDates'. If it`s
-   * not exists it gets lowest value in 'possibleRunDates'
-   *
-   * @param $possibleRunDates
-   * @param $selectedDate
-   *
-   * @return int|mixed
-   */
-  private function findClosestDate($possibleRunDates, $selectedDate) {
-    $closestDay = 0;
-    foreach ($possibleRunDates as $possibleDate) {
-      if ($possibleDate > $selectedDate) {
-        $closestDay = $possibleDate;
-        break;
-      }
-    }
-
-    if ($closestDay === 0) {
-      $closestDay = min($possibleRunDates);
-    }
-
-    return $closestDay;
   }
 
   /**
@@ -223,42 +119,40 @@ class CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator {
    *
    * @return string
    */
-  private function generateAuthorizationDate() {
+  private function generateStartDate() {
     return (new DateTime())->format('Y-m-d H:i:s');
   }
 
   /**
    * Saves all generated values
+   *
    */
-  private function saveGeneratedValues() {
-    $tableName = "civicrm_value_dd_mandate";
+  public function saveGeneratedMandateValues() {
     $setValueTemplateFields = [];
     $fieldsValues = [];
     $i = 0;
     foreach ($this->fieldsToGenerate as $key => $field) {
-      $setValueTemplateFields[] = $tableName . "." . $key . " = %" . ($i);
+      $setValueTemplateFields[] = self::MANDATE_TABLE_NAME . "." . $key . " = %" . ($i);
       $fieldsValues[$i] = [$field, ucfirst(gettype($field))];
       $i++;
     }
     $setValueTemplate = implode(', ', $setValueTemplateFields);
 
-    $query = "UPDATE $tableName SET $setValueTemplate WHERE $tableName.id = $this->mandateId";
+    $query = "UPDATE " . self::MANDATE_TABLE_NAME . " SET $setValueTemplate WHERE " . self::MANDATE_TABLE_NAME . ".id = $this->mandateId";
     CRM_Core_DAO::executeQuery($query, $fieldsValues);
+
+    // sets mandate id, for saving dependency between mandate and contribution
+    $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+    $mandateContributionConnector->setMandateId($this->mandateId);
   }
 
   /**
-   * Sets contribution `receive_date` to mandate 'start date'
+   * Gets mandate start date
+   *
+   * @return object
    */
-  private function updateContributionReceiveDate() {
-    civicrm_api3('Contribution', 'get', [
-      'return' => "id",
-      'contact_id' => $this->entityID,
-      'options' => ['limit' => 1, 'sort' => "contribution_id DESC"],
-      'api.Contribution.create' => [
-        'id' => '$value.id',
-        'receive_date' => $this->fieldsToGenerate['start_date'],
-      ],
-    ]);
+  function getMandateStartDate(){
+    return $this->fieldsToGenerate['start_date'];
   }
 
 }

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -2,7 +2,6 @@
 
 /**
  * Class provide saving dependency between mandate and contribution
- *
  */
 class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
 
@@ -145,7 +144,6 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
 
   /**
    * Assigns a mandate into recurring contribution
-   *
    */
   private function assignRecurringContributionMandate() {
     $rows = [
@@ -157,7 +155,6 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
 
   /**
    * Assigns a mandate into contribution
-   *
    */
   private function assignContributionMandate() {
     $mandateIdCustomFieldId = civicrm_api3('CustomField', 'getvalue', [
@@ -176,17 +173,17 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
    * @return bool
    */
   private function isPaymentInstrumentDirectDebit() {
-    $paymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', array(
+    $paymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', [
       'return' => "value",
       'label' => "Direct Debit",
-    ));
+    ]);
 
     return $paymentInstrumentId == $this->currentPaymentInstrumentId;
   }
 
   /**
-   * Refreshes all properties after saving dependency for reusing instance of class
-   *
+   * Refreshes all properties after saving dependency for reusing instance of
+   * class
    */
   private function refreshProperties() {
     unset($this->mandateId);

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Class provide saving dependency between mandate and contribution
+ *
+ */
+class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
+
+  /**
+   * Instance of current class
+   *
+   * @var object
+   */
+  protected static $instance;
+
+  /**
+   * Id of current contribution
+   *
+   * @var int
+   */
+  private $contributionId;
+
+  /**
+   * Id of current recurring contribution
+   *
+   * @var int
+   */
+  private $contributionRecurId;
+
+  /**
+   * Id of current mandate
+   *
+   * @var int
+   */
+  private $mandateId;
+
+  /**
+   * Id of current payment Instrument
+   *
+   * @var int
+   */
+  private $currentPaymentInstrumentId;
+
+  /**
+   * Overrides constructor to prevent creating instance of class,
+   * according to `Singleton` Pattern
+   *
+   * @var int
+   */
+  private function __construct() {
+  }
+
+  /**
+   * Overrides clone to prevent creating instance of class,
+   * according to `Singleton` Pattern
+   *
+   * @var int
+   */
+  private function __clone() {
+  }
+
+  /**
+   * Overrides wakeup to prevent creating instance of class,
+   * according to `Singleton` Pattern
+   *
+   * @var int
+   */
+  private function __wakeup() {
+  }
+
+  /**
+   * Returns instance of current class, according to `Singleton` Pattern
+   *
+   * @return \CRM_ManualDirectDebit_Hook_MandateContributionConnector
+   */
+  public static function getInstance() {
+    if (is_null(self::$instance)) {
+      self::$instance = new self;
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Sets contribution properties
+   *
+   * @param $dao
+   */
+  public function setContributionProperties($dao) {
+    $this->contributionId = $dao->id;
+    $this->contributionRecurId = $dao->contribution_recur_id;
+    $this->currentPaymentInstrumentId = $dao->payment_instrument_id;
+  }
+
+  /**
+   * Sets mandate Id property, and if `contributionId` is exist launch process
+   * of saving dependency
+   *
+   * @param $mandateId
+   */
+  public function setMandateId($mandateId) {
+    $this->mandateId = $mandateId;
+
+    if (isset($this->contributionId)) {
+      $this->createDependency();
+    }
+  }
+
+  /**
+   * Checks types of dependency
+   *
+   */
+  public function createDependency() {
+    if (isset($this->contributionRecurId)) {
+      if ($this->isDirectDebitPaymentProcessor()) {
+        $this->assignRecurringContributionMandate();
+        $this->assignContributionMandate();
+      }
+    }
+    else {
+      if ($this->isPaymentInstrumentDirectDebit()) {
+        $this->assignContributionMandate();
+      }
+    }
+
+    $this->refreshProperties();
+  }
+
+  /**
+   * Checks if current contribution has Direct Debit Payment Processor
+   *
+   * @return bool
+   */
+  private function isDirectDebitPaymentProcessor() {
+    $currentPaymentProcessorId = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => "payment_processor_id",
+      'id' => $this->contributionRecurId,
+    ]);
+
+    $directDebitPaymentProcessorId = civicrm_api3('PaymentProcessor', 'getvalue', [
+      'return' => "id",
+      'name' => "Direct Debit",
+    ]);
+    return $directDebitPaymentProcessorId == $currentPaymentProcessorId;
+  }
+
+  /**
+   * Assigns a mandate into recurring contribution
+   *
+   */
+  private function assignRecurringContributionMandate() {
+    $rows = [
+      'recurr_id' => $this->contributionRecurId,
+      'mandate_id' => $this->mandateId,
+    ];
+    CRM_ManualDirectDebit_BAO_RecurrMandateRef::create($rows);
+  }
+
+  /**
+   * Assigns a mandate into contribution
+   *
+   */
+  private function assignContributionMandate() {
+    $mandateIdCustomFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => "id",
+      'name' => "mandate_id",
+    ]);
+    civicrm_api3('Contribution', 'create', [
+      "custom_$mandateIdCustomFieldId" => $this->mandateId,
+      'id' => $this->contributionId,
+    ]);
+  }
+
+  /**
+   * Checks if current contribution has Direct Debit Payment Instrument
+   *
+   * @return bool
+   */
+  private function isPaymentInstrumentDirectDebit() {
+    $paymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', array(
+      'return' => "value",
+      'label' => "Direct Debit",
+    ));
+
+    return $paymentInstrumentId == $this->currentPaymentInstrumentId;
+  }
+
+  /**
+   * Refreshes all properties after saving dependency for reusing instance of class
+   *
+   */
+  private function refreshProperties() {
+    unset($this->mandateId);
+    unset($this->contributionId);
+    unset($this->contributionRecurId);
+    unset($this->currentPaymentInstrumentId);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/PageRun/Contribution/DirectDebitInformation.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/Contribution/DirectDebitInformation.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ *  This class is responsible for displaying Direct Debit information block on the Contribution page
+ */
+class CRM_ManualDirectDebit_Hook_PageRun_Contribution_DirectDebitInformation {
+
+  /**
+   * Contribution Id
+   *
+   * @var
+   */
+  private $contributionId;
+
+  /**
+   *  Hides Direct Debit information if the contribution doesn't has mandate
+   *
+   */
+  public function analyzeView() {
+    if (isset($this->contributionId) && !empty($this->contributionId)) {
+
+      if ($this->isCustomFieldNeedToHide($this->contributionId)) {
+        CRM_Core_Resources::singleton()
+          ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/hideEmptyMandate.js');
+      }
+    }
+    else {
+      CRM_Core_Resources::singleton()
+        ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/hideEmptyMandate.js');
+    }
+  }
+
+  /**
+   * Checks if a mandate exist for current contribution
+   *
+   * @param $contributionId
+   *
+   * @return bool
+   */
+  private function isCustomFieldNeedToHide($contributionId) {
+    $customFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => "id",
+      'name' => "mandate_id",
+    ]);
+
+    $mandateId = civicrm_api3('Contribution', 'getvalue', [
+      'return' => "custom_$customFieldId",
+      'id' => $contributionId,
+    ]);
+
+    return $mandateId == 0;
+  }
+
+  /**
+   * Sets contribution Id
+   *
+   * @param $contributionId
+   */
+  public function setContributionId($contributionId) {
+    $this->contributionId = $contributionId;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
@@ -3,7 +3,7 @@
 /**
  *  This class is responsible for displaying Direct Debit information block on the Contribution page
  */
-class CRM_ManualDirectDebit_Hook_PageRun_Contribution_DirectDebitInformation {
+class CRM_ManualDirectDebit_Hook_PageRun_Contribution_TabPage {
 
   /**
    * Contribution Id
@@ -16,7 +16,7 @@ class CRM_ManualDirectDebit_Hook_PageRun_Contribution_DirectDebitInformation {
    *  Hides Direct Debit information if the contribution doesn't has mandate
    *
    */
-  public function analyzeView() {
+  public function hideDirectDebitFields() {
     if (isset($this->contributionId) && !empty($this->contributionId)) {
 
       if ($this->isCustomFieldNeedToHide($this->contributionId)) {

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -18,28 +18,33 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
 
   /**
    * Creates a new direct debit mandate and returns id of the last inserted one
-   *
-   * @return int
    */
   public function createMandate() {
     $tableName = 'civicrm_value_dd_mandate';
-    $sqlInsertedInDirectDebitMandate = "INSERT INTO `$tableName` (`entity_id`) VALUES (%1)";
-    CRM_Core_DAO::executeQuery($sqlInsertedInDirectDebitMandate, [
-      1 => [
-        $this->form->getVar('_contactID'),
-        'String',
-      ],
-    ]);
 
-    $sqlSelectedDebitMandateID = "SELECT MAX(`id`) AS id FROM `$tableName` WHERE `entity_id` = %1";
-    $queryResult = CRM_Core_DAO::executeQuery($sqlSelectedDebitMandateID, [
-      1 => [
-        $this->form->getVar('_contactID'),
-        'String',
-      ],
-    ]);
-    $queryResult->fetch();
-    $generatedMandateId = $queryResult->id;
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $sqlInsertedInDirectDebitMandate = "INSERT INTO `$tableName` (`entity_id`) VALUES (%1)";
+      CRM_Core_DAO::executeQuery($sqlInsertedInDirectDebitMandate, [
+        1 => [
+          $this->form->getVar('_contactID'),
+          'String',
+        ],
+      ]);
+
+      $sqlSelectedDebitMandateID = "SELECT MAX(`id`) AS id FROM `$tableName` WHERE `entity_id` = %1";
+      $queryResult = CRM_Core_DAO::executeQuery($sqlSelectedDebitMandateID, [
+        1 => [
+          $this->form->getVar('_contactID'),
+          'String',
+        ],
+      ]);
+      $queryResult->fetch();
+      $generatedMandateId = $queryResult->id;
+    } catch (Exception $exception) {
+      $transaction->rollback();
+      throw $exception;
+    }
 
     // sets mandate id, for saving dependency between mandate and contribution
     $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();

--- a/js/hideEmptyMandate.js
+++ b/js/hideEmptyMandate.js
@@ -1,0 +1,12 @@
+CRM.$(function ($) {
+  // hides `direct_debit_information` custom group from contribution detail
+  $('#direct_debit_information__').hide();
+
+  // hides `direct_debit_information` custom group from creating and editing contribution
+  CRM.$('.crm-block.crm-form-block.crm-contribution-form-block #customData').hide();
+
+  // hides `direct_debit_information` custom group if change financial type
+  $('#financial_type_id').change(function () {
+    CRM.$('.crm-block.crm-form-block.crm-contribution-form-block #customData').hide();
+  });
+});

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -187,10 +187,10 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 function manualdirectdebit_civicrm_pageRun(&$page) {
   if (get_class($page) == 'CRM_Contribute_Page_Tab') {
     $contributionId = $page->getVar('_id');
-    $hideDirectDebitField = new CRM_ManualDirectDebit_Hook_PageRun_Contribution_DirectDebitInformation();
-    $hideDirectDebitField->setContributionId($contributionId);
+    $pageProcessor = new CRM_ManualDirectDebit_Hook_PageRun_Contribution_TabPage();
+    $pageProcessor->setContributionId($contributionId);
+    $pageProcessor->hideDirectDebitFields();
 
-    $hideDirectDebitField->analyzeView();
   }
 
   if (get_class($page) == 'CRM_Contribute_Page_ContributionRecur') {

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -271,24 +271,6 @@
             <in_selector>1</in_selector>
         </CustomField>
         <CustomField>
-            <name>collection_day</name>
-            <label>Collection Day</label>
-            <data_type>Int</data_type>
-            <html_type>Text</html_type>
-            <is_required>1</is_required>
-            <is_searchable>1</is_searchable>
-            <is_search_range>0</is_search_range>
-            <weight>31</weight>
-            <is_active>1</is_active>
-            <is_view>0</is_view>
-            <text_length>64</text_length>
-            <note_columns>60</note_columns>
-            <note_rows>4</note_rows>
-            <column_name>collection_day</column_name>
-            <custom_group_name>direct_debit_mandate</custom_group_name>
-            <in_selector>1</in_selector>
-        </CustomField>
-        <CustomField>
             <name>mandate_id</name>
             <label>Mandate ID</label>
             <data_type>String</data_type>
@@ -612,22 +594,6 @@
             <in_selector>0</in_selector>
             <is_searchable>0</is_searchable>
             <label>Authorisation File</label>
-            <field_type>Contact</field_type>
-            <is_multi_summary>1</is_multi_summary>
-            <profile_group_name>direct_debit_mandate</profile_group_name>
-        </ProfileField>
-        <ProfileField>
-            <field_name>custom.civicrm_value_dd_mandate.collection_day</field_name>
-            <is_active>1</is_active>
-            <is_view>0</is_view>
-            <is_required>1</is_required>
-            <weight>16</weight>
-            <help_post></help_post>
-            <help_pre></help_pre>
-            <visibility>User and User Admin Only</visibility>
-            <in_selector>0</in_selector>
-            <is_searchable>0</is_searchable>
-            <label>Collection Day</label>
             <field_type>Contact</field_type>
             <is_multi_summary>1</is_multi_summary>
             <profile_group_name>direct_debit_mandate</profile_group_name>


### PR DESCRIPTION
## Overview

1. If the user is paying for a membership with "Direct Debit" payment processor via webform, a full direct debit mandate record is added to the contact with the information user filled in.
2. The mandate "DD Ref" is automatically generated if no value is submitted. 
3. The mandate "Start Date" is automatically generated if no value is submitted. 
4. The recurring contribution "Cycle Day" is automatically generated.
5.The recurring contribution "Start Date" is a date on the "Cycle Day" in current month or next month (whichever is the earliest in the future).
6. The first contribution's "Received date" is the recurring contribution "Start Date".

## Automatically generated
![dd-13 automatically generated](https://user-images.githubusercontent.com/36959503/38941136-91d67ee4-4334-11e8-8447-afab2634e198.gif)

## User input
![dd-13 user input](https://user-images.githubusercontent.com/36959503/38941585-87fd4514-4335-11e8-9fb5-e39972433d95.gif)

## DD-5: Remove “Collection Day”
“Collection Day” field is removed from Direct Debit Mandate form

## Before
![direct debit mandate before](https://user-images.githubusercontent.com/36959503/38941410-3042fc42-4335-11e8-8eca-8af3f0ff34f3.png)

## After 
![direct debit mandate after](https://user-images.githubusercontent.com/36959503/38941415-34312eb4-4335-11e8-8448-20166be126b4.png)

## DD-6: Show Mandate ID only for contributions made with Direct Debit Payment Processor / Method .
 Mandate ID is created and shown only for contributions made with Direct Debit Payment Processor or Method.

![dd-6 fix mandate id block](https://user-images.githubusercontent.com/36959503/38941512-5fb90cb4-4335-11e8-84dd-b577b23bcd9b.gif)
