### PR TITLE
DD-6: Adding hover to Mandate ID and  created empty mandate only when Direct Debit Method is selected

### DIFF
--- a/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
@@ -25,6 +25,7 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
     $mandateId = $this->getMandateId();
 
     if ($mandateId) {
+      CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.manualdirectdebit', 'css/directDebitMandate.css');
       CRM_Core_Resources::singleton()
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/directDebitInformation.js')
         ->addSetting([

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -17,9 +17,32 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
   }
 
   /**
+   * Checks if payment option appropriate for creating mandate
+   */
+  public function checkPaymentOptionToCreateMandate() {
+    if (isset($this->form->getVar('_params')['is_recur']) && !empty($this->form->getVar('_params')['is_recur'])){
+      $directDebitPaymentProcessor = civicrm_api3('PaymentProcessor', 'getvalue', array(
+        'return' => "id",
+        'name' => "direct debit",
+      ));
+      if($this->form->getVar('_params')['payment_processor_id'] == $directDebitPaymentProcessor){
+        $this->createMandate();
+      }
+    } else {
+      $directDebitPaymentInstrument = civicrm_api3('OptionValue', 'getvalue', array(
+        'return' => "value",
+        'name' => "direct_debit",
+      ));
+      if ($this->form->getVar('_params')['payment_instrument_id'] == $directDebitPaymentInstrument){
+        $this->createMandate();
+      }
+    }
+  }
+
+  /**
    * Creates a new direct debit mandate and returns id of the last inserted one
    */
-  public function createMandate() {
+  private function createMandate() {
     $tableName = 'civicrm_value_dd_mandate';
 
     $transaction = new CRM_Core_Transaction();

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -20,20 +20,26 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
    * Checks if payment option appropriate for creating mandate
    */
   public function checkPaymentOptionToCreateMandate() {
-    if (isset($this->form->getVar('_params')['is_recur']) && !empty($this->form->getVar('_params')['is_recur'])){
+    $isRecurring = isset($this->form->getVar('_params')['is_recur']) && !empty($this->form->getVar('_params')['is_recur']);
+
+    if ($isRecurring){
+      $selectedPaymentProcessor = $this->form->getVar('_params')['payment_processor_id'];
       $directDebitPaymentProcessor = civicrm_api3('PaymentProcessor', 'getvalue', array(
         'return' => "id",
         'name' => "direct debit",
       ));
-      if($this->form->getVar('_params')['payment_processor_id'] == $directDebitPaymentProcessor){
+
+      if($selectedPaymentProcessor == $directDebitPaymentProcessor){
         $this->createMandate();
       }
     } else {
+      $selectedPaymentInstrument = $this->form->getVar('_params')['payment_instrument_id'];
       $directDebitPaymentInstrument = civicrm_api3('OptionValue', 'getvalue', array(
         'return' => "value",
         'name' => "direct_debit",
       ));
-      if ($this->form->getVar('_params')['payment_instrument_id'] == $directDebitPaymentInstrument){
+
+      if ($selectedPaymentInstrument == $directDebitPaymentInstrument){
         $this->createMandate();
       }
     }

--- a/css/directDebitMandate.css
+++ b/css/directDebitMandate.css
@@ -1,0 +1,9 @@
+#directDebitMandate:hover {
+  background-color: #ffffcc;
+}
+
+#directDebitMandate {
+  cursor: pointer;
+  transition: 0.3s;
+  color: #2786c2;
+}

--- a/js/directDebitInformation.js
+++ b/js/directDebitInformation.js
@@ -32,7 +32,7 @@ CRM.$(function ($) {
 '                     <tbody>' +
       '                 <tr>\n' +
 '                         <td class="label">Mandate ID</td>\n' +
-'                         <td class="html-adjust">' + urlData.mandateId + '</td>\n' +
+'                         <td class="html-adjust" id="directDebitMandate"><span>' + urlData.mandateId + '</span></td>\n' +
 '                       </tr>\n' +
 '                     </tbody>' +
       '             </table>\n' +
@@ -44,7 +44,7 @@ CRM.$(function ($) {
       '   </tbody>' +
       '</table>');
 
-    CRM.$('.crm-accordion-body').click(function () {
+    CRM.$('#directDebitMandate').click(function () {
       CRM.loadPage(url);
     });
   }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -176,7 +176,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 
   if ($formName == 'CRM_Contribute_Form_Contribution' && $action == CRM_Core_Action::ADD) {
     $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
-    $manualDirectDebit->createMandate();
+    $manualDirectDebit->checkPaymentOptionToCreateMandate();
   }
 }
 


### PR DESCRIPTION
## Overview

1. Add hover and hyperlink style to the Mandate ID on the recurring contribution

![mandate id hover](https://user-images.githubusercontent.com/36959503/39196436-cab5410e-47ea-11e8-8dba-1c6b635cbe39.png)

2. A Mandate ID is created only when Direct Debit Method is selected

![dd-6 creation of mandate id only with direct debit method](https://user-images.githubusercontent.com/36959503/39196464-e195b05c-47ea-11e8-8340-2ce9498ffab7.gif)