### PR TITLE
DD-22: Create mandate for Direct Debit contributions on Admin screens

### DIFF
--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Class provide important information about 'Direct Debit Mandate' data structure
+ */
+class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
+
+  /**
+   * Prefix which added to all custom group field names
+   *
+   * @var string
+   */
+  const PREFIX = "directDebitMandate_";
+
+  /**
+   * Direct Debit Mandate custom group field
+   *
+   * @var array
+   */
+  private $directDebitMandateCustomGroupField;
+
+  /**
+   * CRM_ManualDirectDebit_Common_DirectDebitDataProvider constructor.
+   */
+  public function __construct() {
+    $this->directDebitMandateCustomGroupField = $this->getDirectDebitMandateFields();
+  }
+
+  /**
+   * Gets mandate custom group fields data
+   *
+   * @return array
+   */
+  private function getDirectDebitMandateFields() {
+    return civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => "direct_debit_mandate",
+    ]);
+  }
+
+  /**
+   * Gets converted information about custom group fields for building form
+   *
+   * @return array
+   */
+  public function getMandateCustomFieldDataForBuildingForm(){
+    $mandateCustomGroupFieldData = [];
+    foreach ($this->directDebitMandateCustomGroupField['values'] as $value) {
+      $params = [];
+      $optionGroupId = '';
+
+      if ($value['html_type'] == 'Select Date') {
+        $value['html_type'] = 'datepicker';
+
+        $params = [
+          'time' => FALSE,
+          'date' => 'dd/mm/yy',
+        ];
+      }
+
+      if ($value['html_type'] == 'Select' && $value['option_group_id'] != 0) {
+        $optionGroupId = $this->getOptionList($value['option_group_id']);
+      }
+
+      $mandateCustomGroupFieldData[] = [
+        'name' => self::PREFIX . $value['name'],
+        'label' => $value['label'],
+        'data_type' => $value['data_type'],
+        'html_type' => lcfirst($value['html_type']),
+        'is_required' => $value['is_required'],
+        'option_group_id' => $optionGroupId,
+        'params' => $params,
+      ];
+    }
+
+    return $mandateCustomGroupFieldData;
+  }
+
+  /**
+   * Gets list of option values
+   *
+   * @param $optionGroupId
+   *
+   * @return array
+   */
+  private function getOptionList($optionGroupId){
+    $optionValue = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "$optionGroupId",
+    ]);
+
+    $list = [];
+    foreach ($optionValue['values'] as $value) {
+      $list[$value['value']] = $value['label'];
+    }
+
+    return $list;
+  }
+
+  /**
+   * Gets direct Debit Mandate Custom Field names
+   *
+   * @return array
+   */
+  public function getMandateCustomFieldNames(){
+    $mandateCustomGroupFieldNames = [];
+    foreach ($this->directDebitMandateCustomGroupField['values'] as $value) {
+      $mandateCustomGroupFieldNames[] = self::PREFIX . $value['name'];
+    }
+
+    return $mandateCustomGroupFieldNames;
+  }
+
+  /**
+   * Checks if current payment method Id is Direct Debit Mandate
+   *
+   * @param $currentMethodId
+   *
+   * @return bool
+   */
+  public static function isPaymentMethodDirectDebit($currentMethodId) {
+    $directDebitPaymentMethod = civicrm_api3('OptionValue', 'getvalue', [
+      'return' => "value",
+      'name' => "direct_debit",
+    ]);
+
+    return $currentMethodId == $directDebitPaymentMethod;
+  }
+
+  /**
+   * Checks if current Payment Processor Id is Direct Debit
+   *
+   * @param $currentPaymentProcessor
+   *
+   * @return bool
+   */
+  public static function isDirectDebitPaymentProcessor($currentPaymentProcessor) {
+
+    $directDebitPaymentProcessorId = civicrm_api3('PaymentProcessor', 'getvalue', [
+      'return' => "id",
+      'name' => "Direct Debit",
+    ]);
+    return $directDebitPaymentProcessorId == $currentPaymentProcessor;
+  }
+
+  /**
+   * Checks if current group Id is Direct Debit Mandate
+   *
+   * @param $currentGroupId
+   *
+   * @return bool
+   */
+  public static function isDirectDebitCustomGroup($currentGroupId) {
+    $directDebitMandateId = civicrm_api3('CustomGroup', 'getvalue', [
+      'sequential' => 1,
+      'return' => "id",
+      'name' => "direct_debit_mandate",
+    ]);
+
+    return $currentGroupId == $directDebitMandateId;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -174,4 +174,59 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
     return $directDebitPaymentInstrumentId;
   }
 
+  /**
+   * Gets id of custom group by name
+   *
+   * @param $customGroupName
+   *
+   * @return int
+   */
+  public static function getGroupIDByName($customGroupName) {
+    return civicrm_api3('CustomGroup', 'getvalue', [
+      'return' => "id",
+      'name' => $customGroupName,
+    ]);
+  }
+
+  /**
+   * Gets id of custom field by name
+   *
+   * @param $customFieldName
+   *
+   * @return int
+   */
+  public static function getCustomFieldIdByName($customFieldName) {
+    return civicrm_api3('CustomField', 'getvalue', [
+      'return' => "id",
+      'name' => $customFieldName,
+    ]);
+  }
+
+  /**
+   * Gets Id of payment processor for current recurring contribution
+   *
+   * @param $contributionRecurId
+   *
+   * @return int
+   */
+  public static function getCurrentPaymentProcessorId($contributionRecurId) {
+    return civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => "payment_processor_id",
+      'id' => $contributionRecurId,
+    ]);
+  }
+
+  /**
+   * Gets id of current payment instrument
+   *
+   * @param $currentRecurringContributionId
+   *
+   * @return int
+   */
+  public static function getPaymentInstrumentIdOfRecurrContribution($currentRecurringContributionId) {
+    return civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => "payment_instrument_id",
+      'id' => $currentRecurringContributionId,
+    ]);
+  }
 }

--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -17,13 +17,13 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    *
    * @var array
    */
-  private $directDebitMandateCustomGroupField;
+  private $directDebitMandateCustomGroupFields;
 
   /**
    * CRM_ManualDirectDebit_Common_DirectDebitDataProvider constructor.
    */
   public function __construct() {
-    $this->directDebitMandateCustomGroupField = $this->getDirectDebitMandateFields();
+    $this->directDebitMandateCustomGroupFields = $this->getDirectDebitMandateFields();
   }
 
   /**
@@ -45,7 +45,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    */
   public function getMandateCustomFieldDataForBuildingForm(){
     $mandateCustomGroupFieldData = [];
-    foreach ($this->directDebitMandateCustomGroupField['values'] as $value) {
+    foreach ($this->directDebitMandateCustomGroupFields['values'] as $value) {
       $params = [];
       $optionGroupId = '';
 
@@ -104,7 +104,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    */
   public function getMandateCustomFieldNames(){
     $mandateCustomGroupFieldNames = [];
-    foreach ($this->directDebitMandateCustomGroupField['values'] as $value) {
+    foreach ($this->directDebitMandateCustomGroupFields['values'] as $value) {
       $mandateCustomGroupFieldNames[] = self::PREFIX . $value['name'];
     }
 
@@ -158,6 +158,20 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
     ]);
 
     return $currentGroupId == $directDebitMandateId;
+  }
+
+  /**
+   * Gets id od direct debit payment instrument
+   *
+   * @return int
+   */
+  public static function getDirectDebitPaymentInstrumentId() {
+    $directDebitPaymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', [
+      'return' => "value",
+      'name' => "direct_debit",
+    ]);
+
+    return $directDebitPaymentInstrumentId;
   }
 
 }

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Class provide reading and writing 'Direct Debit Mandate' and it`s dependency into Data Base
+ */
+class CRM_ManualDirectDebit_Common_MandateStorageManager {
+
+  /**
+   * Direct debit mandate table name
+   */
+  const DIRECT_DEBIT_TABLE_NAME = 'civicrm_value_dd_mandate';
+
+  /**
+   * Name of table which save dependency between recurring contribution and mandate
+   */
+  const DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME = 'dd_contribution_recurr_mandate_ref';
+
+  /**
+   * Assigns depandency between contribution and mandate
+   *
+   * @param $contributionId
+   * @param $mandateID
+   *
+   */
+  public function assignContributionMandate($contributionId, $mandateID) {
+    $mandateIdCustomFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => "id",
+      'name' => "mandate_id",
+    ]);
+
+    civicrm_api3('Contribution', 'create', [
+      'id' => $contributionId,
+      "custom_$mandateIdCustomFieldId" => $mandateID,
+    ]);
+  }
+
+  /**
+   * Assigns dependency between recurring contribution and mandate
+   *
+   * @param $contributionId
+   * @param $mandateId
+   */
+  public function assignRecurringContributionMandate($contributionId, $mandateId) {
+    $rows = [
+      'recurr_id' => $contributionId,
+      'mandate_id' => $mandateId,
+    ];
+
+    CRM_ManualDirectDebit_BAO_RecurrMandateRef::create($rows);
+  }
+
+  /**
+   * Gets mandate for last inserted id for current contact
+   *
+   * @param $currentContactId
+   *
+   * @return int|null
+   */
+  public function getLastInsertedMandateId($currentContactId) {
+    $sqlSelectDebitMandateID = "SELECT MAX(`id`) AS id FROM " . self::DIRECT_DEBIT_TABLE_NAME . " WHERE `entity_id` = %1";
+    $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
+      1 => [
+        $currentContactId,
+        'String',
+      ],
+    ]);
+    $queryResult->fetch();
+
+    return $queryResult->id;
+  }
+
+  /**
+   * Gets id of recurring contribution
+   *
+   * @return int|null
+   */
+  public function getMandateForCurrentRecurringContribution($recurContributionId) {
+    $sqlSelectDebitMandateID = "SELECT `mandate_id` AS id FROM " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " WHERE `recurr_id` = %1";
+    $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
+      1 => [
+        $recurContributionId,
+        'String',
+      ],
+    ]);
+    $queryResult->fetch();
+
+    return $queryResult->id;
+  }
+
+  /**
+   * Saves direct debit mandate data
+   *
+   * @param $currentContactId
+   * @param $mandateValues
+   */
+  public function saveDirectDebitMandate($currentContactId, $mandateValues) {
+    // protect Data from SQL injection
+    $columnName = [];
+    $valuesId = [];
+    $values = [];
+
+    $i = 0;
+    foreach ($mandateValues as $key => $value) {
+      $columnName[] = $key;
+      $valuesId[] = "%" . $i;
+      $values[$i] = [
+        $value,
+        ucfirst(gettype($value)),
+      ];
+
+      $i++;
+    }
+
+    $keys = implode(', ', $columnName);
+    $valuesId = implode(', ', $valuesId);
+
+    // write into Database
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $sqlInsertInDirectDebitMandate = "INSERT INTO " . self::DIRECT_DEBIT_TABLE_NAME . " ($keys) VALUES ($valuesId)";
+      CRM_Core_DAO::executeQuery($sqlInsertInDirectDebitMandate, $values);
+
+      $mandateId = $this->getLastInsertedMandateId($currentContactId);
+
+    } catch (Exception $exception) {
+      $transaction->rollback();
+
+      throw $exception;
+    }
+
+    $this->setMandateforCreatingDepandency($mandateId);
+  }
+
+  /**
+   * Creates a new empty direct debit mandate
+   *
+   * @param $currentContactId
+   */
+  public function createEmptyMandate($currentContactId) {
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $sqlInsertInDirectDebitMandate = "INSERT INTO " . self::DIRECT_DEBIT_TABLE_NAME . " (`entity_id`) VALUES (%1)";
+      CRM_Core_DAO::executeQuery($sqlInsertInDirectDebitMandate, [
+        1 => [
+          $currentContactId,
+          'String',
+        ],
+      ]);
+
+      $mandateId = $this->getLastInsertedMandateId($currentContactId);
+    } catch (Exception $exception) {
+      $transaction->rollback();
+      throw $exception;
+    }
+
+    $this->setMandateforCreatingDepandency($mandateId);
+  }
+
+  /**
+   * Updates mandate with generated value
+   *
+   * @param $mandateValues
+   * @param $mandateId
+   */
+  public function updateMandateId($mandateValues, $mandateId) {
+    // protect Data from SQL injection
+    $setValueTemplateFields = [];
+    $fieldsValues = [];
+
+    $i = 0;
+    foreach ($mandateValues as $key => $field) {
+      $setValueTemplateFields[] = self::DIRECT_DEBIT_TABLE_NAME . "." . $key . " = %" . ($i);
+      $fieldsValues[$i] = [$field, ucfirst(gettype($field))];
+      $i++;
+    }
+    $setValueTemplate = implode(', ', $setValueTemplateFields);
+
+    // write into Data Base
+    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . " SET $setValueTemplate WHERE " . self::DIRECT_DEBIT_TABLE_NAME . ".id = $mandateId";
+    CRM_Core_DAO::executeQuery($query, $fieldsValues);
+
+    $this->setMandateforCreatingDepandency($mandateId);
+  }
+
+  /**
+   * Sets mandate id, for saving dependency between mandate and contribution
+   *
+   * @param $mandateId
+   */
+  private function setMandateforCreatingDepandency($mandateId){
+    $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+    $mandateContributionConnector->setMandateId($mandateId);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -75,7 +75,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    * @return int|null
    */
   public function getMandateForCurrentRecurringContribution($recurContributionId) {
-    $sqlSelectDebitMandateID = "SELECT `mandate_id` AS id FROM " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " WHERE `recurr_id` = %1";
+    $sqlSelectDebitMandateID = "SELECT `mandate_id` AS id 
+      FROM " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " 
+      WHERE `recurr_id` = %1";
+
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
       1 => [
         $recurContributionId,
@@ -128,7 +131,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
       throw $exception;
     }
 
-    $this->setMandateforCreatingDepandency($mandateId);
+    $this->setMandateForCreatingDependency($mandateId);
   }
 
   /**
@@ -153,7 +156,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
       throw $exception;
     }
 
-    $this->setMandateforCreatingDepandency($mandateId);
+    $this->setMandateForCreatingDependency($mandateId);
   }
 
   /**
@@ -176,10 +179,12 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
     $setValueTemplate = implode(', ', $setValueTemplateFields);
 
     // write into Data Base
-    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . " SET $setValueTemplate WHERE " . self::DIRECT_DEBIT_TABLE_NAME . ".id = $mandateId";
+    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . " 
+    SET $setValueTemplate 
+    WHERE " . self::DIRECT_DEBIT_TABLE_NAME . ".id = $mandateId";
     CRM_Core_DAO::executeQuery($query, $fieldsValues);
 
-    $this->setMandateforCreatingDepandency($mandateId);
+    $this->setMandateForCreatingDependency($mandateId);
   }
 
   /**
@@ -187,7 +192,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    *
    * @param $mandateId
    */
-  private function setMandateforCreatingDepandency($mandateId){
+  private function setMandateForCreatingDependency($mandateId){
     $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
     $mandateContributionConnector->setMandateId($mandateId);
   }

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Class provide information about Direct Debit Mandate Settings
+ */
+class CRM_ManualDirectDebit_Common_SettingsManager {
+
+  public static $minimumDaysToFirstPayment;
+
+  /**
+   * Gets all extension settings
+   *
+   * @return array
+   */
+  public function getManualDirectDebitSettings() {
+    $settingFields = [
+      'manualdirectdebit_default_reference_prefix',
+      'manualdirectdebit_new_instruction_run_dates',
+      'manualdirectdebit_payment_collection_run_dates',
+      'manualdirectdebit_minimum_days_to_first_payment',
+    ];
+    $settingValues = civicrm_api3('setting', 'get', [
+      'return' => $settingFields,
+      'sequential' => 1,
+    ]);
+
+    $settings = [];
+    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
+    $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
+      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
+    $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
+      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
+    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
+
+    return $settings;
+  }
+
+  /**
+   * Iterates all value in array. Because the first date should starts from 1,
+   * but not from 0.
+   *
+   * @param $possibleRunDates
+   *
+   * @return mixed
+   */
+  private function incrementAllArrayValues($possibleRunDates) {
+    foreach ($possibleRunDates as $sequentialNumber => $value) {
+      $possibleRunDates[$sequentialNumber] = ++$value;
+    }
+
+    return $possibleRunDates;
+  }
+
+  /**
+   * Gets setting information about minimum days to first payment
+   *
+   * @return int|null
+   */
+  public static function getMinimumDayForFirstPayment() {
+    if (isset(self::$minimumDaysToFirstPayment) && !empty(self::$minimumDaysToFirstPayment)){
+      return self::$minimumDaysToFirstPayment;
+    }
+
+    $settingTitle = 'manualdirectdebit_minimum_days_to_first_payment';
+    $settingValues = civicrm_api3('setting', 'getsingle', [
+      'return' => $settingTitle,
+      'sequential' => 1,
+    ]);
+
+    if(isset($settingValues[$settingTitle]) && !empty($settingValues[$settingTitle])){
+      self::$minimumDaysToFirstPayment = $settingValues[$settingTitle];
+      return self::$minimumDaysToFirstPayment;
+    } else{
+      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"),'required_setting_not_configured');
+    }
+  }
+
+}

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -9,7 +9,6 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
 
   /**
    * PreProcess function.
-   *
    */
   public function preProcess() {
     parent::preProcess();

--- a/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
@@ -69,7 +69,6 @@ class CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup {
     try {
       $minimumDaysToFirstPayment = CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
     } catch (CiviCRM_API3_Exception $error) {
-      CRM_Core_Session::setStatus($error->getMessage(), $title = 'Error', $type = 'error');
       $minimumDaysToFirstPayment = 0;
     }
 

--- a/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Class provide injecting `Direct Debit Mandate` inside `Membership` form
+ */
+class CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup {
+
+  /**
+   * Path where template with new fields is stored.
+   *
+   * @var string
+   */
+  protected $templatePath;
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  protected $form;
+
+  public function __construct(&$form) {
+    $this->form = $form;
+    $this->templatePath = CRM_ManualDirectDebit_ExtensionUtil::path() . '/templates';
+  }
+
+  /**
+   *  Builds form
+   */
+  public function buildForm() {
+    $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
+    $mandateCustomGroupFieldData = $mandateDataProvider->getMandateCustomFieldDataForBuildingForm();
+
+    foreach ($mandateCustomGroupFieldData as $customField) {
+      $this->form->add(
+        $customField['html_type'],
+        $customField['name'],
+        $customField['label'],
+        $customField['option_group_id'],
+        $customField['is_required'],
+        $customField['params']
+      );
+
+      if ($customField['data_type'] == 'Int') {
+        $this->form->addRule($customField['name'], ts($customField['label'] . ' must be a number.'), 'numeric');
+      }
+    }
+
+    $inputNames = $mandateDataProvider->getMandateCustomFieldNames();
+    $this->form->assign('customInputNames', $inputNames);
+
+    $minimumDaysToFirstPayment = $this->getMinimumDayForFirstPayment();
+    $this->form->assign('minimumDaysToFirstPayment', $minimumDaysToFirstPayment);
+
+    $directDebitPaymentInstrumentId = $this->getDirectDebitPaymentInstrumentId();
+    $this->form->assign('directDebitPaymentInstrumentId', $directDebitPaymentInstrumentId);
+
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatePath}/CRM/ManualDirectDebit/Form/InjectCustomGroup.tpl",
+    ]);
+  }
+
+  /**
+   * Gets setting information about minimum days to first payment
+   *
+   * @return int
+   */
+  private function getMinimumDayForFirstPayment() {
+    $settingTitle = 'manualdirectdebit_minimum_days_to_first_payment';
+    $settingValues = civicrm_api3('setting', 'get', [
+      'return' => $settingTitle,
+      'sequential' => 1,
+    ]);
+    $minimumDaysToFirstPayment = $settingValues['values'][0][$settingTitle];
+
+    if (!isset($minimumDaysToFirstPayment) || empty($minimumDaysToFirstPayment)) {
+      CRM_Core_Session::setStatus(t("Please, configure minimum days to first payment"), $title = 'Error', $type = 'alert');
+      $minimumDaysToFirstPayment = 0;
+    }
+
+    return $minimumDaysToFirstPayment;
+  }
+
+  /**
+   * Gets id od direct debit payment instrument
+   *
+   * @return array
+   */
+  private function getDirectDebitPaymentInstrumentId() {
+    $directDebitPaymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', [
+      'return' => "value",
+      'name' => "direct_debit",
+    ]);
+
+    return $directDebitPaymentInstrumentId;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
@@ -52,7 +52,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup {
     $minimumDaysToFirstPayment = $this->getMinimumDayForFirstPayment();
     $this->form->assign('minimumDaysToFirstPayment', $minimumDaysToFirstPayment);
 
-    $directDebitPaymentInstrumentId = $this->getDirectDebitPaymentInstrumentId();
+    $directDebitPaymentInstrumentId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getDirectDebitPaymentInstrumentId();
     $this->form->assign('directDebitPaymentInstrumentId', $directDebitPaymentInstrumentId);
 
     CRM_Core_Region::instance('page-body')->add([
@@ -66,33 +66,14 @@ class CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup {
    * @return int
    */
   private function getMinimumDayForFirstPayment() {
-    $settingTitle = 'manualdirectdebit_minimum_days_to_first_payment';
-    $settingValues = civicrm_api3('setting', 'get', [
-      'return' => $settingTitle,
-      'sequential' => 1,
-    ]);
-    $minimumDaysToFirstPayment = $settingValues['values'][0][$settingTitle];
-
-    if (!isset($minimumDaysToFirstPayment) || empty($minimumDaysToFirstPayment)) {
-      CRM_Core_Session::setStatus(t("Please, configure minimum days to first payment"), $title = 'Error', $type = 'alert');
+    try {
+      $minimumDaysToFirstPayment = CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
+    } catch (CiviCRM_API3_Exception $error) {
+      CRM_Core_Session::setStatus($error->getMessage(), $title = 'Error', $type = 'error');
       $minimumDaysToFirstPayment = 0;
     }
 
     return $minimumDaysToFirstPayment;
-  }
-
-  /**
-   * Gets id od direct debit payment instrument
-   *
-   * @return array
-   */
-  private function getDirectDebitPaymentInstrumentId() {
-    $directDebitPaymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', [
-      'return' => "value",
-      'name' => "direct_debit",
-    ]);
-
-    return $directDebitPaymentInstrumentId;
   }
 
 }

--- a/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
@@ -3,7 +3,7 @@
 /**
  * This class automatically generates all required fields for contribution
  */
-class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
+class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
 
   /**
    * Recurring contribution cycle day
@@ -102,7 +102,7 @@ class CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator {
    * Generates Recurring Contribution `Start date`
    */
   private function generateRecurringContributionStartDate() {
-    $startDateGenerator = new CRM_ManualDirectDebit_Hook_Custom_ContributionRecurStartDateGenerator($this->cycleDay, $this->mandateStartDate);
+    $startDateGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionRecurStartDateGenerator($this->cycleDay, $this->mandateStartDate);
     $this->start_date = $startDateGenerator->generate();
   }
 

--- a/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionRecurStartDateGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionRecurStartDateGenerator.php
@@ -3,7 +3,7 @@
 /**
  * Generates `Start Date` field if it wasn't filed by user
  */
-class CRM_ManualDirectDebit_Hook_Custom_ContributionRecurStartDateGenerator {
+class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionRecurStartDateGenerator {
 
   /**
    * Current year

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -29,58 +29,8 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
   public function __construct($entityID, &$params) {
     $this->entityID = $entityID;
     $this->savedFields = $params;
-    $this->setManualDirectDebitSettings();
-  }
-
-  /**
-   *  Sets `settings` property
-   */
-  private function setManualDirectDebitSettings() {
-    $this->settings = $this->getManualDirectDebitSettings();
-  }
-
-  /**
-   * Gets all extension settings
-   *
-   * @return array
-   */
-  private function getManualDirectDebitSettings() {
-    $settingFields = [
-      'manualdirectdebit_default_reference_prefix',
-      'manualdirectdebit_new_instruction_run_dates',
-      'manualdirectdebit_payment_collection_run_dates',
-      'manualdirectdebit_minimum_days_to_first_payment',
-    ];
-    $settingValues = civicrm_api3('setting', 'get', [
-      'return' => $settingFields,
-      'sequential' => 1,
-    ]);
-
-    $settings = [];
-    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
-    $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
-    $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
-    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
-
-    return $settings;
-  }
-
-  /**
-   * Iterates all value in array. Because the first date should starts from 1,
-   * but not from 0.
-   *
-   * @param $possibleRunDates
-   *
-   * @return mixed
-   */
-  private function incrementAllArrayValues($possibleRunDates) {
-    foreach ($possibleRunDates as $sequentialNumber => $value) {
-      $possibleRunDates[$sequentialNumber] = ++$value;
-    }
-
-    return $possibleRunDates;
+    $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+    $this->settings = $settingsManager->getManualDirectDebitSettings();
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -87,10 +87,10 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
    * Generates and saves the required fields values if they are not supplied by the user.
    */
   public function generate() {
-    $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_MandateDataGenerator($this->entityID, $this->settings, $this->savedFields);
+    $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator($this->entityID, $this->settings, $this->savedFields);
     $mandateDataGenerator->generateMandateFieldsValues();
     $mandateDataGenerator->saveGeneratedMandateValues();
-    $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_ContributionDataGenerator($this->entityID, $this->settings);
+    $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator($this->entityID, $this->settings);
     $contributionDataGenerator->setMandateStartDate($mandateDataGenerator->getMandateStartDate());
     $contributionDataGenerator->generateContributionFieldsValues();
     $contributionDataGenerator->saveGeneratedContributionValues();

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -113,7 +113,7 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
 
     if (isset($this->contributionRecurId)) {
 
-      $currentPaymentProcessorId = $this->getCurrentPaymentProcessorId($this->contributionRecurId);
+      $currentPaymentProcessorId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCurrentPaymentProcessorId($this->contributionRecurId);
       if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitPaymentProcessor($currentPaymentProcessorId)) {
         $mandateStorage->assignRecurringContributionMandate($this->contributionRecurId, $this->mandateId);
         $mandateStorage->assignContributionMandate($this->contributionId, $this->mandateId);
@@ -126,20 +126,6 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
     }
 
     $this->refreshProperties();
-  }
-
-  /**
-   * Gets Id of payment processor for current recurring contribution
-   *
-   * @param $contributionRecurId
-   *
-   * @return int
-   */
-  private function getCurrentPaymentProcessorId($contributionRecurId) {
-    return civicrm_api3('ContributionRecur', 'getvalue', [
-      'return' => "payment_processor_id",
-      'id' => $contributionRecurId,
-    ]);
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
@@ -22,16 +22,16 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
   private $currentContributionId;
 
   /**
-   * Current payment processor Id
+   * Current payment method Id
    *
    * @var int
    */
-  private $currentPaymentProcessorId;
+  private $currentPaymentMethodId;
 
   public function __construct(&$page) {
     $this->page = $page;
     $this->currentContributionId = CRM_Utils_Request::retrieve('id', 'Integer', $this->page, FALSE);
-    $this->currentPaymentProcessorId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getPaymentInstrumentIdOfRecurrContribution($this->currentContributionId);
+    $this->currentPaymentMethodId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getPaymentInstrumentIdOfRecurrContribution($this->currentContributionId);
   }
 
   /**
@@ -41,7 +41,7 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
    * @return bool
    */
   public function inject() {
-    if(! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitPaymentProcessor($this->currentPaymentProcessorId)){
+    if(! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($this->currentPaymentMethodId)){
       return FALSE;
     }
 

--- a/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- *  Provides 'Direct Debit Information' integration into 'Recurring Contribution Detail' view
+ *  Provides 'Direct Debit Information' integration into 'Recurring
+ * Contribution Detail' view
  */
 class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInjector {
 
@@ -25,7 +26,8 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
     $mandateId = $this->getMandateId();
 
     if ($mandateId) {
-      CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.manualdirectdebit', 'css/directDebitMandate.css');
+      CRM_Core_Resources::singleton()
+        ->addStyleFile('uk.co.compucorp.manualdirectdebit', 'css/directDebitMandate.css');
       CRM_Core_Resources::singleton()
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/directDebitInformation.js')
         ->addSetting([
@@ -76,14 +78,15 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
     $mandateIdCustomFieldId = $this->getCustomFieldIdByName("mandate_id");
     $currentContributionId = CRM_Utils_Request::retrieve('id', 'Integer', $this->page, FALSE);
     try {
-      $mandateId = civicrm_api3('Contribution', 'getvalue', [
+      $mandateId = civicrm_api3('Contribution', 'get', [
+        'sequential' => 1,
+        'options' => ['limit' => 1],
         'return' => "custom_$mandateIdCustomFieldId",
         'contribution_recur_id' => $currentContributionId,
       ]);
 
-      return $mandateId;
-    }
-    catch (CiviCRM_API3_Exception $e) {
+      return $mandateId['values'][0]["custom_$mandateIdCustomFieldId"];
+    } catch (CiviCRM_API3_Exception $e) {
       CRM_Core_Session::setStatus(t("Contribution doesn't exist"), $title = 'Error', $type = 'alert');
 
       return FALSE;

--- a/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- *  This class is responsible for displaying Direct Debit information block on the Contribution page
+ *  This class is responsible for displaying Direct Debit information block on
+ *  the Contribution page
  */
 class CRM_ManualDirectDebit_Hook_PageRun_TabPage {
 

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
@@ -43,9 +43,9 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
   }
 
   /**
-   * Fetches Direct Debit Mandate Data
+   * Saves Direct Debit Mandate Data
    */
-  public function fetchMandateData() {
+  public function saveMandateData() {
     $this->setMandateValues();
 
     $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
@@ -77,12 +77,12 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
   /**
    * Checks if the `field` is a part of Direct Debit Mandate Custom Group
    *
-   * @param $field
+   * @param string $fieldName
    *
    * @return bool
    */
-  private function isFieldIsPartOfDirectDebitCustomGroup($field) {
-    return in_array($field, $this->listOfDirectDebitMandateCustomGroupFields);
+  private function isFieldIsPartOfDirectDebitCustomGroup($fieldName) {
+    return in_array($fieldName, $this->listOfDirectDebitMandateCustomGroupFields);
   }
 
   /**
@@ -104,9 +104,11 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
    * @return string
    */
   private function getColumnName($fieldName) {
-    if (substr($fieldName, 0, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX)) == CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX) {
+    $fieldNamePrefix = substr($fieldName, 0, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
+    if ($fieldNamePrefix == CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX) {
       $columnName = substr($fieldName, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
     }
+
     return $columnName;
   }
 

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Class provide fetching Direct Debit Mandate Data from Membership form
+ * and launch saving in Database
+ */
+class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  private $form;
+
+  /**
+   * List Of mandate custom group fields
+   *
+   * @var array
+   */
+  private $listOfDirectDebitMandateCustomGroupFields;
+
+  /**
+   * List of mandate date
+   *
+   * @var array
+   */
+  private $mandateValues;
+
+  /**
+   * Id of current mandate
+   *
+   * @var int
+   */
+  private $currentContactId;
+
+  public function __construct($form) {
+    $this->form = $form;
+    $this->currentContactId = $this->form->getVar('_contactID');
+
+    $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
+    $this->listOfDirectDebitMandateCustomGroupFields = $mandateDataProvider->getMandateCustomFieldNames();
+  }
+
+  /**
+   * Fetches Direct Debit Mandate Data
+   */
+  public function fetchMandateData() {
+    $this->setMandateValues();
+
+    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $storageManager->saveDirectDebitMandate($this->currentContactId, $this->mandateValues);
+  }
+
+  /**
+   * Sets direct debit mandate values
+   */
+  private function setMandateValues() {
+    $this->setMandateContacId();
+
+    $submitValues = $this->form->getVar('_submitValues');
+
+    foreach ($submitValues as $field => $value) {
+      if ($this->isFieldIsPartOfDirectDebitCustomGroup($field) && $this->isValueNotEmpty($value)) {
+        $this->mandateValues[$this->getColumnName($field)] = $value;
+      }
+    }
+  }
+
+  /**
+   * Sets contact id
+   */
+  private function setMandateContacId() {
+    $this->mandateValues['entity_id'] = $this->currentContactId;
+  }
+
+  /**
+   * Checks if the `field` is a part of Direct Debit Mandate Custom Group
+   *
+   * @param $field
+   *
+   * @return bool
+   */
+  private function isFieldIsPartOfDirectDebitCustomGroup($field) {
+    return in_array($field, $this->listOfDirectDebitMandateCustomGroupFields);
+  }
+
+  /**
+   * Checks if `value` is not empty
+   *
+   * @param $value
+   *
+   * @return bool
+   */
+  private function isValueNotEmpty($value) {
+    return isset($value) && !empty($value);
+  }
+
+  /**
+   * Cleans 'fieldName' from prefix
+   *
+   * @param $fieldName
+   *
+   * @return string
+   */
+  private function getColumnName($fieldName) {
+    if (substr($fieldName, 0, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX)) == CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX) {
+      $columnName = substr($fieldName, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
+    }
+    return $columnName;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
+++ b/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Class provide assigning appropriate 'Mandate' for each Contribution which assign
+ *   to 'Membership Payment'
+ */
+class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
+
+  /**
+   * Id of current contribution
+   *
+   * @var int
+   */
+  private $contributionId;
+
+  /**
+   * Id of current recurring contribution
+   *
+   * @var int
+   */
+  private $recurContributionId;
+
+  /**
+   * Id of current contact
+   *
+   * @var int
+   */
+  private $contactId;
+
+  /**
+   * Object which manage writing and reading Data from DB
+   *
+   * @var CRM_ManualDirectDebit_Common_MandateStorageManager
+   */
+  private $mandateStorage;
+
+  public function __construct($dao) {
+    $this->contributionId = $dao->contribution_id;
+    $this->contactId = $this->getContactId();
+    $this->recurContributionId = $this->getRecurringContributionId();
+    $this->mandateStorage = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+  }
+
+  /**
+   * Gets id of current Contact
+   *
+   * @return int
+   */
+  private function getContactId() {
+    return civicrm_api3('Contribution', 'getvalue', [
+      'return' => "contact_id",
+      'id' => $this->contributionId,
+    ]);
+
+  }
+
+  /**
+   * Gets id of current recurring contribution
+   *
+   * @return int
+   */
+  private function getRecurringContributionId() {
+    return civicrm_api3('Contribution', 'getvalue', [
+      'return' => "contribution_recur_id",
+      'id' => $this->contributionId,
+    ]);
+  }
+
+  /**
+   * Assign mandate for contribution
+   *
+   */
+  public function assignMandateForContributions() {
+
+    if (! $this->isContributionRecurring() || ! $this->isCurrentPaymentInstrumentDirectDebit()) {
+      return FALSE;
+    }
+
+    $mandateId = $this->mandateStorage->getMandateForCurrentRecurringContribution($this->recurContributionId);
+
+    if (isset($mandateId) && !empty($mandateId)) {
+      $this->mandateStorage->assignContributionMandate($this->contributionId, $mandateId);
+    }
+    else {
+      $this->findMandateForContributions();
+    }
+  }
+
+  /**
+   * Checks if current contribution is recurring
+   *
+   * @return bool
+   */
+  private function isContributionRecurring() {
+    return isset($this->recurContributionId) && !empty($this->recurContributionId);
+  }
+
+  /**
+   *  Checks if current payment processor is Direct Debit
+   *
+   * @return bool
+   */
+  function isCurrentPaymentInstrumentDirectDebit() {
+    $currentPaymentInstrument = civicrm_api3('Contribution', 'getvalue', [
+      'sequential' => 1,
+      'return' => "payment_instrument_id",
+      'contribution_recur_id' => $this->recurContributionId,
+      'options' => ['limit' => 1],
+    ]);
+
+    return CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrument);
+  }
+
+  /**
+   * Finds appropriate mandate for current contributions
+   */
+  private function findMandateForContributions() {
+    $lastInsertedMandateId = $this->mandateStorage->getLastInsertedMandateId($this->contactId);
+
+    if (isset($lastInsertedMandateId)) {
+      $this->mandateStorage->assignRecurringContributionMandate($this->recurContributionId, $lastInsertedMandateId);
+      $this->mandateStorage->assignContributionMandate($this->contributionId, $lastInsertedMandateId);
+    }
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
+++ b/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
@@ -51,7 +51,6 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
       'return' => "contact_id",
       'id' => $this->contributionId,
     ]);
-
   }
 
   /**
@@ -68,7 +67,6 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
 
   /**
    * Assign mandate for contribution
-   *
    */
   public function assignMandateForContributions() {
 
@@ -100,7 +98,7 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
    *
    * @return bool
    */
-  function isCurrentPaymentInstrumentDirectDebit() {
+  private function isCurrentPaymentInstrumentDirectDebit() {
     $currentPaymentInstrument = civicrm_api3('Contribution', 'getvalue', [
       'sequential' => 1,
       'return' => "payment_instrument_id",

--- a/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
+++ b/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
@@ -79,9 +79,6 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
     if (isset($mandateId) && !empty($mandateId)) {
       $this->mandateStorage->assignContributionMandate($this->contributionId, $mandateId);
     }
-    else {
-      $this->findMandateForContributions();
-    }
   }
 
   /**
@@ -107,18 +104,6 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
     ]);
 
     return CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrument);
-  }
-
-  /**
-   * Finds appropriate mandate for current contributions
-   */
-  private function findMandateForContributions() {
-    $lastInsertedMandateId = $this->mandateStorage->getLastInsertedMandateId($this->contactId);
-
-    if (isset($lastInsertedMandateId)) {
-      $this->mandateStorage->assignRecurringContributionMandate($this->recurContributionId, $lastInsertedMandateId);
-      $this->mandateStorage->assignContributionMandate($this->contributionId, $lastInsertedMandateId);
-    }
   }
 
 }

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Class provide validation of `Direct Debit Mandate` custom group as part of the form
+ */
+class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  private $form;
+
+  public function __construct($form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Checks necessary of validation
+   */
+  public function checkValidation() {
+    $currentPaymentInstrumentId = $this->getCurrentPaymentInstrumentId();
+
+    if ( ! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrumentId)) {
+      $this->turnOffDirectDebitValidation();
+    }
+  }
+
+  /**
+   * Gets current payment instrument Id
+   *
+   * @return int
+   */
+  private function getCurrentPaymentInstrumentId() {
+    if ($this->form->elementExists('payment_instrument_id')) {
+      $paymentInstrumentElement = $this->form->getElement('payment_instrument_id');
+      $paymentInstrumentValue = $paymentInstrumentElement->getValue()[0];
+    }
+
+    return $paymentInstrumentValue;
+  }
+
+  /**
+   * Turns off all validation fir direct debit
+   */
+  private function turnOffDirectDebitValidation() {
+    $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
+    $directDebitMandateCustomFieldNames = $mandateDataProvider->getMandateCustomFieldNames();
+    $currentError = $this->form->getVar('_errors');
+
+    foreach ($currentError as $error => $value) {
+      if (in_array($error, $directDebitMandateCustomFieldNames)) {
+        unset($currentError[$error]);
+      }
+    }
+    $this->form->setVar('_errors', $currentError);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -69,6 +69,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
       $currentError = $this->form->getVar('_errors');
       $currentError[] = ['directDebitMandate' => "Please, configure minimum days to first payment"];
       $this->form->setVar('_errors', $currentError);
+      CRM_Core_Session::setStatus($error->getMessage(), $title = 'Error', $type = 'error');
     }
   }
 

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -12,7 +12,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
    */
   private $form;
 
-  public function __construct($form) {
+  public function __construct(&$form) {
     $this->form = $form;
   }
 
@@ -24,6 +24,8 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
 
     if ( ! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrumentId)) {
       $this->turnOffDirectDebitValidation();
+    } else{
+      $this->checkSettings();
     }
   }
 
@@ -42,7 +44,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
   }
 
   /**
-   * Turns off all validation fir direct debit
+   * Turns off all validation for direct debit
    */
   private function turnOffDirectDebitValidation() {
     $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
@@ -55,6 +57,19 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
       }
     }
     $this->form->setVar('_errors', $currentError);
+  }
+
+  /**
+   * Checks if necessary setting is configured for creating mandate
+   */
+  private function checkSettings() {
+    try {
+      CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
+    } catch (CiviCRM_API3_Exception $error) {
+      $currentError = $this->form->getVar('_errors');
+      $currentError[] = ['directDebitMandate' => "Please, configure minimum days to first payment"];
+      $this->form->setVar('_errors', $currentError);
+    }
   }
 
 }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -202,7 +202,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
         $paymentInstrumentId = $form->getVar('_submitValues') ['payment_instrument_id'];
         if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId)) {
           $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate($form);
-          $manualDirectDebit->fetchMandateData();
+          $manualDirectDebit->saveMandateData();
         }
       }
     break;
@@ -212,7 +212,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
         $paymentInstrumentId = $form->getVar('_submitValues') ['payment_instrument_id'];
         if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId)) {
           $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate($form);
-          $manualDirectDebit->fetchMandateData();
+          $manualDirectDebit->saveMandateData();
         }
       }
     break;

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -186,11 +186,36 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
  *
  */
 function manualdirectdebit_civicrm_postProcess($formName, &$form) {
+
   $action = $form->getAction();
 
-  if ($formName == 'CRM_Contribute_Form_Contribution' && $action == CRM_Core_Action::ADD) {
-    $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
-    $manualDirectDebit->checkPaymentOptionToCreateMandate();
+  switch ($formName){
+    case "CRM_Contribute_Form_Contribution":
+      if($action == CRM_Core_Action::ADD){
+        $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
+        $manualDirectDebit->checkPaymentOptionToCreateMandate();
+      }
+    break;
+
+    case "CRM_Member_Form_Membership":
+      if($action == CRM_Core_Action::ADD){
+        $paymentInstrumentId = $form->getVar('_submitValues') ['payment_instrument_id'];
+        if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId)) {
+          $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate($form);
+          $manualDirectDebit->fetchMandateData();
+        }
+      }
+    break;
+
+    case "CRM_Member_Form_MembershipRenewal":
+      if($action == CRM_Core_Action::RENEW){
+        $paymentInstrumentId = $form->getVar('_submitValues') ['payment_instrument_id'];
+        if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId)) {
+          $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate($form);
+          $manualDirectDebit->fetchMandateData();
+        }
+      }
+    break;
   }
 }
 
@@ -204,7 +229,6 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
     $pageProcessor = new CRM_ManualDirectDebit_Hook_PageRun_TabPage();
     $pageProcessor->setContributionId($contributionId);
     $pageProcessor->hideDirectDebitFields();
-
   }
 
   if (get_class($page) == 'CRM_Contribute_Page_ContributionRecur') {
@@ -218,27 +242,46 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
  *
  */
 function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
-  if (_manualdirectdebit_isDirectDebitCustomGroup($groupID) && ($op == 'create' || $op == 'edit')) {
+  if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID) && ($op == 'create' || $op == 'edit')) {
     $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
     $mandateDataGenerator->generate();
   }
 }
 
 /**
- * Checks if group ID is Direct Debit Mandate
- *
- * @param $groupID
- *
- * @return bool
+ * Implements hook_civicrm_postSave_civicrm_contribution().
  */
-function _manualdirectdebit_isDirectDebitCustomGroup($groupID) {
-  $directDebitMandateId = civicrm_api3('CustomGroup', 'getvalue', [
-    'sequential' => 1,
-    'return' => "id",
-    'name' => "direct_debit_mandate",
-  ]);
+function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
+  $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+  $mandateContributionConnector->setContributionProperties($dao);
+}
 
-  return $groupID == $directDebitMandateId;
+/**
+ * Implements hook_civicrm_buildForm()
+ */
+function manualdirectdebit_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
+    $customGroupInjector = new CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup($form);
+    $customGroupInjector->buildForm();
+  }
+}
+
+/**
+ * Implements hook_civicrm_validateForm()
+ */
+function manualdirectdebit_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+
+  if ($formName == 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
+    $directDebitValidator = new CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator($form);
+    $directDebitValidator->checkValidation();
+  }
+}
+/**
+ * Implements hook_civicrm_postSave_civicrm_membership_payment().
+ */
+function manualdirectdebit_civicrm_postSave_civicrm_membership_payment($dao) {
+    $mandateCreator = new CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator($dao);
+    $mandateCreator->assignMandateForContributions();
 }
 
 /**
@@ -261,12 +304,4 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
       }
     }
   }
-}
-
-/**
- * Implements hook_civicrm_postSave_civicrm_contribution().
- */
-function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao){
-  $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
-  $mandateContributionConnector->setContributionProperties($dao);
 }

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -49,7 +49,7 @@ return [
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(30),
+    'html_attributes' => generateSequenceNumbers(31),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',

--- a/templates/CRM/ManualDirectDebit/Form/InjectCustomGroup.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/InjectCustomGroup.tpl
@@ -1,0 +1,77 @@
+<div id="directDebitMandate" class="crm-accordion-wrapper crm-custom-accordion">
+  <div class="crm-accordion-header">
+    Direct Debit Mandate
+  </div>
+
+  <div id="customData1" class="crm-accordion-body">
+    <table class="form-layout-compressed">
+      <tbody>
+      {foreach from=$customInputNames item=inputName}
+        <tr>
+          <td class="label"><label>{$form.$inputName.label}</label></td>
+          <td class="html-adjust">
+            {$form.$inputName.html}
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    moveDirectDebitMandateFormFields();
+    setDirectDebitStartDate();
+
+    CRM.$('input[name=receive_date]').parent().change(function () {
+      setDirectDebitStartDate();
+    });
+
+    function moveDirectDebitMandateFormFields(){
+      CRM.$('#directDebitMandate').insertAfter(CRM.$('#billing-payment-block'));
+
+      var directDebitID = {/literal}{$directDebitPaymentInstrumentId}{literal};
+
+      if (CRM.$('#payment_instrument_id option:selected').val() != directDebitID) {
+        CRM.$('#directDebitMandate').hide();
+      }
+
+      CRM.$('#payment_instrument_id').change(function () {
+        if (CRM.$('#payment_instrument_id option:selected').val() == directDebitID) {
+          CRM.$('#directDebitMandate').show();
+        } else {
+          CRM.$('#directDebitMandate').hide();
+        }
+      });
+    }
+
+    function setDirectDebitStartDate() {
+      var receiveFieldValue = CRM.$('input[name=receive_date]').length > 0 ? CRM.$('input[name=receive_date]').val() : false;
+      var mandateStartDateField = CRM.$('#directDebitMandate_start_date').length > 0 ? CRM.$('#directDebitMandate_start_date') : false;
+
+      if(receiveFieldValue === false || mandateStartDateField === false){
+        return false;
+      }
+
+      receiveFieldValue = receiveFieldValue.split('/');
+      // converts `receive Date` to js Date object, so we have to decrease month because in js month begin count from 0
+      var receiveDate = new Date(receiveFieldValue[2], receiveFieldValue[0]-1, receiveFieldValue[1]);
+
+      var minimumDaysToFirstPayment = {/literal}{$minimumDaysToFirstPayment}{literal};
+
+      if (typeof minimumDaysToFirstPayment === 'undefined'){
+          minimumDaysToFirstPayment = 0;
+      }
+      var mandateStartDate = new Date(receiveDate.setDate(receiveDate.getDate() - minimumDaysToFirstPayment));
+
+      // converts js date object `mandateStartDate` to human readable value, so we have to increase month
+      var startDateField = mandateStartDate.getFullYear() + '-' + (mandateStartDate.getMonth() + 1) + '-' + mandateStartDate.getDate();
+      mandateStartDateField.val(startDateField).change();
+    }
+
+  });
+</script>
+{/literal}
+


### PR DESCRIPTION
## Overview

1. Inject the following functionality on admin "New membership" and "Renew Membership" screens so that when the admin records a contribution or payment plan with payment method "Direct Debit", a set of mandate fields will appear underneath the contribution and payment plan section.
2. The "Start Date" field should be automatically adjust according to "Payment Plan Start Date" minus "Minimum days from new instruction to first payment". However, user can also manually change this.
3. Once submitted successfully, a mandate should be generated and the mandate should be linked to both contributions and payment plans (if applicable).

- Creating Mandate for DD contribution from New Membership 

![dd-22 creating mandate for dd contribution from new membership](https://user-images.githubusercontent.com/36959503/39934553-dde45ca8-554e-11e8-8cc0-ce63cbd559a6.gif)

- Creating Mandate for DD contribution from Renew Membership

![dd-22 creating mandate for dd contribution from renew membership](https://user-images.githubusercontent.com/36959503/39934580-fadec500-554e-11e8-95f3-80ae66609a98.gif)
