### PR TITLE
DD-19: Adding permission definition for managing direct debt batches

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -125,6 +125,16 @@ function manualdirectdebit_civicrm_alterSettingsFolders(&$metaDataFolders = NULL
 }
 
 /**
+ * Implements hook_civicrm_permission().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/
+ */
+function manualdirectdebit_civicrm_permission(&$permissions) {
+  $permissionsPrefix = 'CiviCRM : ';
+  $permissions['can manage direct debit batches'] = $permissionsPrefix . ts('Can manage Direct Debit Batches');
+}
+
+/**
  * Implements hook_civicrm_navigationMenu().
  *
  */


### PR DESCRIPTION
## Overview

This PR adds the definition for a new permission called : 

```
Can manage Direct Debit Batches
```

that will be users to allow users to manage direct debit batches.



## Technical Notes

the machine name for this permission is : 

```
can manage direct debit batches
```
