### PR TITLE
DD-18/19: Fix wrong batch mechanism, pagination and view link

### DIFF
--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -117,6 +117,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $session = CRM_Core_Session::singleton();
     $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id');
     $params = $this->controller->exportValues($this->_name);
+
     $params['data'] = json_encode(['values' => ['originator_number' => $params['originator_number']]]);
     $params['modified_date'] = date('YmdHis');
     $params['modified_id'] = $session->get('userID');

--- a/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
@@ -25,10 +25,6 @@ class CRM_ManualDirectDebit_Hook_PageRun_TabPage {
           ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/hideEmptyMandate.js');
       }
     }
-    else {
-      CRM_Core_Resources::singleton()
-        ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/hideEmptyMandate.js');
-    }
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -47,7 +47,7 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     } else {
       $selectedPaymentInstrument = $this->form->getVar('_params')['payment_instrument_id'];
 
-      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitPaymentProcessor($selectedPaymentInstrument)){
+      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($selectedPaymentInstrument)){
         $this->mandateStorage->createEmptyMandate($this->currentContactId);
       }
     }

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -8,6 +8,7 @@ use CRM_ManualDirectDebit_ExtensionUtil as E;
 class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base {
 
   public function install() {
+    $this->createDirectDebitNavigationMenu();
     $this->createDirectDebitPaymentInstrument();
     $this->createDirectDebitPaymentProcessorType();
     $this->createDirectDebitPaymentProcessor();
@@ -130,6 +131,88 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'payment_instrument_id' => 'direct_debit',
     ];
     civicrm_api3('PaymentProcessor', 'create', $paymentProcessor);
+  }
+
+  /**
+   * Creates Direct Debit navigation menu items
+   */
+  private function createDirectDebitNavigationMenu() {
+    $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
+    $menuItems = [
+        [
+          'label' => ts('Direct Debit'),
+          'name' => 'direct_debit',
+          'url' => NULL,
+          'permission' => 'can manage direct debit batches',
+          'separator' => NULL,
+          'parent_name' => 'menumain',
+        ],
+        [
+          'label' => ts('Create New Instructions Batch'),
+          'name' => 'create_new_instructions_batch',
+          'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('instructions_batch', $batchTypes),
+          'permission' => 'can manage direct debit batches',
+          'separator' => 1,
+          'parent_name' => 'direct_debit',
+        ],
+        [
+          'label' => ts('Export Direct Debit Payments'),
+          'name' => 'export_direct_debit_payments',
+          'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('dd_payments', $batchTypes),
+          'permission' => 'can manage direct debit batches',
+          'operator' => NULL,
+          'separator' => NULL,
+          'parent_name' => 'direct_debit',
+        ],
+        [
+          'label' => ts('View New Instruction Batches'),
+          'name' => 'view_new_instruction_batches',
+          'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('instructions_batch', $batchTypes),
+          'permission' => 'can manage direct debit batches',
+          'operator' => NULL,
+          'separator' => 1,
+          'parent_name' => 'direct_debit',
+        ],
+        [
+          'label' => ts('View Payment Batches'),
+          'name' => 'view_payment_batches',
+          'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('dd_payments', $batchTypes),
+          'permission' => 'can manage direct debit batches',
+          'operator' => NULL,
+          'separator' => NULL,
+          'parent_name' => 'direct_debit',
+        ],
+      ];
+
+    foreach ($menuItems as $item) {
+      $this->addNav($item);
+    }
+    CRM_Core_BAO_Navigation::resetNavigation();
+  }
+
+  /**
+   * Adds navigation menu item
+   *
+   * @param array $menuItem
+   */
+  private function addNav($menuItem) {
+    $this->removeNav($menuItem['name']);
+    $menuItem['is_active'] = 1;
+    $menuItem['parent_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $menuItem['parent_name'], 'id', 'name');
+    unset($menuItem['parent_name']);
+    CRM_Core_BAO_Navigation::add($menuItem);
+  }
+
+  /**
+   * Removes navigation menu item
+   *
+   * @param string $name
+   *   The name of the item in `civicrm_navigation`.
+   */
+  private function removeNav($name) {
+    CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN (%1)", [
+      1 => [$name, 'String'],
+    ]);
   }
 
 }

--- a/js/hideEmptyMandate.js
+++ b/js/hideEmptyMandate.js
@@ -1,12 +1,4 @@
 CRM.$(function ($) {
   // hides `direct_debit_information` custom group from contribution detail
   $('#direct_debit_information__').hide();
-
-  // hides `direct_debit_information` custom group from creating and editing contribution
-  CRM.$('.crm-block.crm-form-block.crm-contribution-form-block #customData').hide();
-
-  // hides `direct_debit_information` custom group if change financial type
-  $('#financial_type_id').change(function () {
-    CRM.$('.crm-block.crm-form-block.crm-contribution-form-block #customData').hide();
-  });
 });

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -290,35 +290,5 @@ function bulkAssignRemove( action ) {
     }
   }, 'json');
 }
-
-function contactMandate(recId, cid) {
-  var url = CRM.url(
-    'civicrm/contact/view/cd',
-    {
-      reset: '1',
-      gid: {/literal}{$customGroup}{literal},
-      cid: cid,
-      recId: recId,
-      multiRecordDisplay: 'single',
-      mode: 'view'
-    }
-  );
-  CRM.loadPage(url);
-  return false;
-}
-
-function contactRecurContribution(recId, cid) {
-  var url = CRM.url(
-    'civicrm/contact/view/contributionrecur',
-    {
-      reset: '1',
-      id: recId,
-      cid: cid,
-      context: 'contribution',
-    }
-  );
-  CRM.loadPage(url);
-  return false;
-}
 </script>
 {/literal}

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -2,7 +2,7 @@
 <div class="batch-list">
   {include file="CRM/common/pager.tpl" location="top"}
     {strip}
-  <table id="crm-transaction-selector-assign-{$entityID}" cellpadding="0" cellspacing="0" border="0">
+  <table class="batchPaginator" id="crm-transaction-selector-assign-{$entityID}" cellpadding="0" cellspacing="0" border="0">
     <thead>
     <tr>
       <th class="crm-batch-name">{ts}Batch Name{/ts}</th>
@@ -45,6 +45,18 @@
 
 {literal}
 <script type="text/javascript">
+
+  CRM.$('.batchPaginator').dataTable({
+    destroy: true,
+    bFilter: false,
+    bAutoWidth: false,
+    bProcessing: false,
+    bLengthChange: true,
+    sPaginationType: "full_numbers",
+    sDom: '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
+    bJQueryUI: true,
+    order: []
+  });
 
   function assignRemove(recordID, op) {
     if (op == 'submit') {


### PR DESCRIPTION
## Overview

1. Fix batch mechanism- Batch keeps a snapshot of the data at the time when the batch is created.

![batch mechanism](https://user-images.githubusercontent.com/36959503/40555384-91d632ec-6051-11e8-9c90-9d8043ba72f7.gif)



2. Add pagination to the View New Instruction Batches and View Payment Batches pages

![view payment_pagination](https://user-images.githubusercontent.com/36959503/40555407-b3a8567a-6051-11e8-9eff-202a6d933ecd.png)

3.View link goes to:
 -to view the mandate on the contact page - View New Instruction Batches


![view link_new instruction](https://user-images.githubusercontent.com/36959503/40555549-2ee992f4-6052-11e8-9cc2-c643bb83b14f.gif)

 -the contribution on the contact page - View Payment Batches 


![view link_payment](https://user-images.githubusercontent.com/36959503/40555559-330c2be4-6052-11e8-8696-ec6470456a31.gif)

4. Add a new menu item “Direct Debit” 


![dd_menu](https://user-images.githubusercontent.com/36959503/40555599-4e8e8a74-6052-11e8-9b3c-533412f974b4.png)



