### PR TITLE
DD-23: Manage mandate buttons

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class provide hiding "Save and New" button from Direct Debit modal window
+ */
+class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  private $form;
+
+  public function __construct($form) {
+    $this->form = $form;
+  }
+
+  /**
+   *  Checks if custom group 'Direct Debit Mandate' and launches hiding
+   */
+  public function run() {
+    if ($this->checkIfDirectDebitMandateInGroupTree()) {
+      $this->hideButton();
+    }
+  }
+
+  /**
+   * Checks if 'Direct Debit Mandate' exists in group tree
+   *
+   * @return bool
+   */
+  private function checkIfDirectDebitMandateInGroupTree() {
+    $directDebitMandateId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_mandate");
+    $customGroupTree = $this->form->getVar('_groupTree');
+
+    return array_key_exists($directDebitMandateId, $customGroupTree);
+  }
+
+  /**
+   *  Hides 'Save and New' button
+   */
+  private function hideButton() {
+    $buttonsGroup = $this->form->getElement('buttons');
+    foreach ($buttonsGroup->_elements as $key => $button) {
+      if ($button->_attributes['value'] == "Save and New") {
+        unset($buttonsGroup->_elements[$key]);
+      }
+    }
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Class provide hiding 'Direct Debit Information' custom group if it`s empty
+ */
+class CRM_ManualDirectDebit_Hook_BuildForm_CustomDataByType {
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  private $form;
+
+  /**
+   * List of custom group elements
+   *
+   * @var array
+   */
+  private $customGroupTree;
+
+  /**
+   * Id of 'Direct Debit Information' custom group id
+   *
+   * @var int
+   */
+  private $directDebitInformationId;
+
+  public function __construct($form) {
+    $this->form = $form;
+    $this->customGroupTree = $form->getVar('_groupTree');
+    $this->directDebitInformationId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_information");
+  }
+
+  /**
+   *  Checks if custom group 'Direct Debit Information' and launches hiding
+   */
+  public function run() {
+    if ($this->checkIfDirectDebitInformationInGroupTree()) {
+      $this->hideDirectDebitInformationIfEmpty();
+    }
+  }
+
+  /**
+   * Checks if Direct Debit Information exists in group tree
+   *
+   * @return bool
+   */
+  private function checkIfDirectDebitInformationInGroupTree() {
+    return array_key_exists($this->directDebitInformationId, $this->customGroupTree);
+  }
+
+  /**
+   *  Hides Direct Debit Information if it`s empty
+   */
+  private function hideDirectDebitInformationIfEmpty() {
+    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+    $mandateIdValue = $this->customGroupTree[$this->directDebitInformationId]['fields'][$customFieldId]['element_value'];
+
+    if (!isset($mandateIdValue) || empty($mandateIdValue)) {
+      $this->form->setVar('_groupTree')[$this->directDebitInformationId]['fields'][$customFieldId] = [];
+    }
+  }
+
+}

--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -1,0 +1,38 @@
+CRM.$('document').ready(function () {
+  var customGroupTitle = CRM.$('.section-shown.form-item .crm-accordion-header').first().text().trim();
+  if (customGroupTitle == "Direct Debit Mandate") {
+
+    CRM.$('.form-item a.button').parent().hide();
+
+    CRM.$('.crm-hover-button.crm-custom-value-del').each(function () {
+      var mandateTitle = CRM.$(this).attr('title').split(' ');
+      var cgCount = mandateTitle[mandateTitle.length - 1];
+
+      var isAlreadyEditButtonAdd = CRM.$(this).next('#edit_direct_debit_mandate_' + cgCount).length != 1;
+      if (isAlreadyEditButtonAdd) {
+        var mandateData = JSON.parse(CRM.$(this).attr('data-post'));
+
+        CRM.$('<a href=\"#\" class=\"crm-hover-button crm-custom-value\" id="edit_direct_debit_mandate_' + cgCount + '" title=\"Edit Direct Debit Mandate\" onclick=\"CRM.loadPage(\'' + getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId) + '\')\">Edit</a>').insertAfter(CRM.$(this));
+        CRM.$(this).hide();
+      }
+    });
+  }
+
+  function getUrlForUpdatingCurrentMandate(cgCount, groupId, contactId) {
+    var url = CRM.url(
+      'civicrm/contact/view/cd/edit',
+      {
+        reset: '1',
+        type: 'Individual',
+        groupID: groupId,
+        entityID: contactId,
+        cgcount: cgCount,
+        multiRecordDisplay: 'single',
+        mode: 'edit'
+      }
+    );
+
+    return url;
+  }
+
+});

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -257,18 +257,14 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
  * Implements hook_civicrm_buildForm()
  */
 function manualdirectdebit_civicrm_buildForm($formName, &$form) {
-  if ($formName == 'CRM_Custom_Form_CustomDataByType') {
-    $directDebitInformationId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_information");
-    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
-    $customGroupTree = $form->getVar('_groupTree');
+  if ($formName == 'CRM_Contact_Form_CustomData') {
+    $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);
+    $customData->run();
+  }
 
-    $isCustomGroupDirectDebitInformation = array_key_exists($directDebitInformationId, $customGroupTree);
-    if (isset($isCustomGroupDirectDebitInformation) && !empty($isCustomGroupDirectDebitInformation)) {
-      $mandateIdValue = $customGroupTree[$directDebitInformationId]['fields'][$customFieldId]['element_value'];
-      if (!isset($mandateIdValue) || empty($mandateIdValue)) {
-        $form->setVar('_groupTree')[$directDebitInformationId]['fields'][$customFieldId] = [];
-      }
-    }
+  if ($formName == 'CRM_Custom_Form_CustomDataByType') {
+    $customDataByType = new CRM_ManualDirectDebit_Hook_BuildForm_CustomDataByType($form);
+    $customDataByType->run();
   }
 
   if ($formName === 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
@@ -298,7 +294,6 @@ function manualdirectdebit_civicrm_postSave_civicrm_membership_payment($dao) {
 
 /**
  * Implements hook_civicrm_links().
- *
  */
 function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
 
@@ -314,6 +309,19 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
             break;
         }
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_alterContent().
+ */
+function manualdirectdebit_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  if ($tplName == 'CRM/Contact/Page/View/CustomData.tpl' && $context == "page") {
+    $path = CRM_ManualDirectDebit_ExtensionUtil::path() . '/js/mandateEdit.js';
+    if (file_exists($path)) {
+      $js = file_get_contents($path);
+      $content .= "<script type='text/javascript'>" . $js . "</script>";
     }
   }
 }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -232,6 +232,10 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
     $injectCustomGroup = new CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInjector($page);
     $injectCustomGroup->inject();
   }
+
+  if (get_class($page) == 'CRM_Contact_Page_View_CustomData') {
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
+  }
 }
 
 /**
@@ -309,19 +313,6 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
             break;
         }
       }
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_alterContent().
- */
-function manualdirectdebit_civicrm_alterContent(&$content, $context, $tplName, &$object) {
-  if ($tplName == 'CRM/Contact/Page/View/CustomData.tpl' && $context == "page") {
-    $path = CRM_ManualDirectDebit_ExtensionUtil::path() . '/js/mandateEdit.js';
-    if (file_exists($path)) {
-      $js = file_get_contents($path);
-      $content .= "<script type='text/javascript'>" . $js . "</script>";
     }
   }
 }


### PR DESCRIPTION
## Overview

1. Hide the "Edit Direct Debit Mandate" button.
2. Replace the "Delete" button on each Direct Debit Mandate with an "Edit" button that allows each Direct Debit Mandate to be edited.
3. Once clicked on the "Edit" button on a Direct Debit Mandate, a modal including all mandate fields should appear which allows the admin to modify the mandate information.

![mandate ui](https://user-images.githubusercontent.com/36959503/40731722-52b8fb48-643a-11e8-9a55-d57ec88d25a1.gif)
