### PR TITLE
DD-6 fix: The contribution custom fields do not disappear in edit mode when the Direct Debit extension is enabled

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
@@ -58,7 +58,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomDataByType {
     $mandateIdValue = $this->customGroupTree[$this->directDebitInformationId]['fields'][$customFieldId]['element_value'];
 
     if (!isset($mandateIdValue) || empty($mandateIdValue)) {
-      $this->form->setVar('_groupTree')[$this->directDebitInformationId]['fields'][$customFieldId] = [];
+      unset($this->form->_groupTree[$this->directDebitInformationId]);
     }
   }
 


### PR DESCRIPTION
## Overview

- The contribution custom fields do not disappear in edit mode when the Direct Debit extension is enabled

![custom fields do not disappear when dd extension](https://user-images.githubusercontent.com/36959503/40963809-2098a0c4-68b2-11e8-8367-13e016387c83.gif)
