### PR TITLE
DD-30: Add overriden CiviCRM core files

### DIFF
--- a/OverridenCore/CRM/Activity/Form/Task/Email.php
+++ b/OverridenCore/CRM/Activity/Form/Task/Email.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+
+/**
+ * This class provides the functionality to email a group of contacts.
+ */
+class CRM_Activity_Form_Task_Email extends CRM_Activity_Form_Task {
+
+  /**
+   * Are we operating in "single mode", i.e. sending email to one
+   * specific contact?
+   *
+   * @var boolean
+   */
+  public $_single = FALSE;
+
+  public $_noEmails = FALSE;
+
+  /**
+   * All the existing templates in the system.
+   *
+   * @var array
+   */
+  public $_templates = NULL;
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess() {
+    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
+    parent::preProcess();
+
+    // we have all the contribution ids, so now we get the contact ids
+    parent::setContactIDs();
+
+    $this->assign('single', $this->_single);
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm() {
+    // Enable form element.
+    $this->assign('emailTask', TRUE);
+
+    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   */
+  public function postProcess() {
+    //start inject code
+    $messageTemplateId = $this->getVar('_submitValues')['template'];
+    if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId) && !empty($this->_activityHolderIds)) {
+      $notification = new CRM_ManualDirectDebit_Mail_Notification();
+      foreach ($this->_activityHolderIds as $activityId) {
+        $activityTypeName = CRM_ManualDirectDebit_Common_Activity::getActivityTypeName($activityId);
+        switch ($activityTypeName) {
+          case "direct_debit_mandate_update":
+            $mandateId = CRM_ManualDirectDebit_Common_Activity::getActivityRecordId($activityId);
+            if (!$mandateId) {break;}
+            $notification->notifyByMandateId($mandateId, $messageTemplateId);
+            break;
+
+          case "direct_debit_payment_reminder":
+            $contributionId = CRM_ManualDirectDebit_Common_Activity::getActivityRecordId($activityId);
+            if (!$contributionId) {break;}
+            $notification->notifyByContributionId($contributionId, $messageTemplateId);
+            break;
+
+          case "update_direct_debit_recurring_payment":
+          case "offline_direct_debit_auto_renewal":
+          case "new_direct_debit_recurring_payment":
+            $recurContributionId = CRM_ManualDirectDebit_Common_Activity::getActivityRecordId($activityId);
+            if (!$recurContributionId) {break;}
+            $notification->notifyByRecurContributionId($recurContributionId, $messageTemplateId);
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      return;
+    }
+    //end inject code
+
+    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * @return array
+   */
+  public function listTokens() {
+    $tokens = CRM_Core_SelectValues::contactTokens();
+    return $tokens;
+  }
+
+}

--- a/OverridenCore/CRM/Contribute/Form/Task/Email.php
+++ b/OverridenCore/CRM/Contribute/Form/Task/Email.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ */
+
+/**
+ * This class provides the functionality to email a group of contacts.
+ */
+class CRM_Contribute_Form_Task_Email extends CRM_Contribute_Form_Task {
+
+  /**
+   * Are we operating in "single mode", i.e. sending email to one
+   * specific contact?
+   *
+   * @var boolean
+   */
+  public $_single = FALSE;
+
+  public $_noEmails = FALSE;
+
+  /**
+   * All the existing templates in the system.
+   *
+   * @var array
+   */
+  public $_templates = NULL;
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess() {
+    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
+    parent::preProcess();
+
+
+    // we have all the contribution ids, so now we get the contact ids
+    parent::setContactIDs();
+
+    $this->assign('single', $this->_single);
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm() {
+    //enable form element
+    $this->assign('emailTask', TRUE);
+
+    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   */
+  public function postProcess() {
+    //start inject code
+    $messageTemplateId = $this->getVar('_submitValues')['template'];
+    if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId) && !empty($this->_contributionIds)) {
+      $notification = new CRM_ManualDirectDebit_Mail_Notification();
+      foreach ($this->_contributionIds as $contributionId) {
+        $notification->notifyByContributionId($contributionId, $messageTemplateId);
+      }
+
+      return;
+    }
+    //end inject code
+
+    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * @return array
+   */
+  public function listTokens() {
+    $tokens = CRM_Core_SelectValues::contactTokens();
+    $tokens = array_merge(CRM_Core_SelectValues::contributionTokens(), $tokens);
+
+    return $tokens;
+  }
+
+}

--- a/OverridenCore/CRM/Member/Form/Task/Email.php
+++ b/OverridenCore/CRM/Member/Form/Task/Email.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2017
+ * $Id: Email.php 45499 2013-02-08 12:31:05Z kurund $
+ *
+ */
+
+/**
+ * This class provides the functionality to email a group of
+ * contacts.
+ */
+class CRM_Member_Form_Task_Email extends CRM_Member_Form_Task {
+
+  /**
+   * Are we operating in "single mode", i.e. sending email to one
+   * specific contact?
+   *
+   * @var boolean
+   */
+  public $_single = FALSE;
+
+  /**
+   * Are we operating in "single mode", i.e. sending email to one
+   * specific contact?
+   *
+   * @var boolean
+   */
+  public $_noEmails = FALSE;
+
+  /**
+   * All the existing templates in the system.
+   *
+   * @var array
+   */
+  public $_templates = NULL;
+
+  /**
+   * Build all the data structures needed to build the form.
+   *
+   * @return void
+   */
+  public function preProcess() {
+    CRM_Contact_Form_Task_EmailCommon::preProcessFromAddress($this);
+    parent::preProcess();
+
+    // we have all the membership ids, so now we get the contact ids
+    parent::setContactIDs();
+
+    $this->assign('single', $this->_single);
+  }
+
+  /**
+   * Build the form object.
+   *
+   *
+   * @return void
+   */
+  public function buildQuickForm() {
+    //enable form element
+    $this->assign('emailTask', TRUE);
+
+    CRM_Contact_Form_Task_EmailCommon::buildQuickForm($this);
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   *
+   * @return void
+   */
+  public function postProcess() {
+    //start inject code
+    $messageTemplateId = $this->getVar('_submitValues')['template'];
+    if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId) && !empty($this->_memberIds)) {
+      $notification = new CRM_ManualDirectDebit_Mail_Notification();
+      foreach ($this->_memberIds as $membershipId) {
+        $notification->notifyByMembershipId($membershipId, $messageTemplateId);
+      }
+
+      return;
+    }
+    //end inject code
+
+    CRM_Contact_Form_Task_EmailCommon::postProcess($this);
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * @return array
+   */
+  public function listTokens() {
+    $tokens = CRM_Core_SelectValues::contactTokens();
+    return $tokens;
+  }
+
+}


### PR DESCRIPTION
We override 3 form:
1.“CRM_Activity_Form_Task_Email”
- Override postProcess() method.
- There we check if user select DD message template. 
- Then get contribution id/recurring contribution id/ mangate id  from “source_record_id”.
- Then send to email.


2.“CRM_Contribute_Form_Task_Email”
- Override postProcess() method.
-  There we check if user select DD message template. 
- Then send to email.


3.“CRM_Member_Form_Task_Email”
- Override postProcess() method. 
- There we check if user select DD message template. 
- Then send to email.


When we override we wrapped our code:
//start inject code
//end inject code
