### PR TITLE
DD-31: Mandate update activity

### DIFF
--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -232,9 +232,9 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
   }
 
   /**
-   * Gets max mandate id
+   * Gets max id of 'direct debit mandate'
    *
-   * @return mixed
+   * @return int
    */
   public static function getMaxMandateId() {
     $sqlSelectDebitMandateID = "SELECT MAX(`id`) as id FROM `civicrm_value_dd_mandate`";
@@ -243,4 +243,5 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
 
     return $queryResult->id;
   }
+
 }

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -6,6 +6,13 @@
 class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
 
   /**
+   * Path where template with new fields is stored.
+   *
+   * @var string
+   */
+  private $templatePath;
+
+  /**
    * Form object that is being altered.
    *
    * @var object
@@ -14,6 +21,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
 
   public function __construct($form) {
     $this->form = $form;
+    $this->templatePath = CRM_ManualDirectDebit_ExtensionUtil::path() . '/templates';
   }
 
   /**
@@ -25,6 +33,9 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
     }
 
     $this->checkRecurringContribution();
+    $this->addMandateIdHiddenValue();
+
+    $this->addSendMailCheckbox();
   }
 
   /**
@@ -61,5 +72,28 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
       $this->form->add('hidden', 'recurrId', $recurrForUpdate);
     }
   }
+
+  /**
+   *  Adds hidden mandate id
+   */
+  private function addMandateIdHiddenValue() {
+    $mandateId = CRM_Utils_Request::retrieve('mandateId', 'Integer', $this->form, FALSE);
+
+    if (isset($mandateId) && !empty($mandateId)) {
+      $this->form->add('hidden', 'mandateId', $mandateId);
+    }
+  }
+
+  /**
+   *  Adds send mail checkbox
+   */
+  private function addSendMailCheckbox() {
+    $this->form->add('checkbox', 'send_mandate_update_notification_to_the_contact', ts('Send mandate update notification to the contact?'), NULL);
+
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatePath}/CRM/ManualDirectDebit/Form/SendMandateNotification.tpl",
+    ]);
+  }
+
 
 }

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -138,16 +138,14 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     $valueOfSendMailCheckbox = $this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'];
 
     if (!isset($valueOfSendMailCheckbox) || empty($valueOfSendMailCheckbox)) {
-      return FALSE;
+      return;
     }
 
     $isSendMailCheckboxTurnedOn = $valueOfSendMailCheckbox == 1;
 
     if ($isSendMailCheckboxTurnedOn) {
-
-//      TODO: Sending mail process will be implemented in DD-30
-//      $notification = new CRM_ManualDirectDebit_Mail_Notification();
-//      $notification->sendMandateUpdateNotification($this->mandateId);
+      $notification = new CRM_ManualDirectDebit_Mail_Notification();
+      $notification->sendMandateUpdateNotification($this->mandateId);
     }
   }
 

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -51,8 +51,10 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
    *  Sets id of current mandate
    */
   public function setCurrentMandateId() {
-    if (isset($this->form->getVar('_submitValues')['mandateId']) && !empty($this->form->getVar('_submitValues')['mandateId'])) {
-      $this->mandateId = $this->form->getVar('_submitValues')['mandateId'];
+    $mandateId = $this->form->getVar('_submitValues')['mandateId'];
+
+    if (isset($mandateId) && !empty($mandateId)) {
+      $this->mandateId = $mandateId;
     }
   }
 
@@ -96,11 +98,11 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
    * @return bool
    */
   public function checkChangingMandateContribution() {
-    if (!isset($this->form->getVar('_submitValues')['recurrId']) || empty($this->form->getVar('_submitValues')['recurrId'])) {
+    $recurringContributionId = $this->form->getVar('_submitValues')['recurrId'];
+    if (!isset($recurringContributionId) || empty($recurringContributionId)) {
       return FALSE;
     }
 
-    $recurringContributionId = $this->form->getVar('_submitValues')['recurrId'];
     $oldMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionId);
 
     if (is_null($oldMandateId)) {
@@ -133,11 +135,12 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
    * Sends mail if appropriate checkbox is checked on
    */
   public function checkMailNotification() {
-    if (!isset($this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact']) || empty($this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'])) {
+    $valueOfSendMailCheckbox = $this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'];
+
+    if (!isset($valueOfSendMailCheckbox) || empty($valueOfSendMailCheckbox)) {
       return FALSE;
     }
 
-    $valueOfSendMailCheckbox = $this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'];
     $isSendMailCheckboxTurnedOn = $valueOfSendMailCheckbox == 1;
 
     if ($isSendMailCheckboxTurnedOn) {

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -26,10 +26,34 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
    */
   private $currentContactId;
 
+  /**
+   * Id of current mandate
+   *
+   * @var int
+   */
+  private $mandateId;
+
   public function __construct(&$form) {
     $this->mandateStorage = new CRM_ManualDirectDebit_Common_MandateStorageManager();
     $this->form = $form;
-    $this->currentContactId = $this->form->getVar('_contactID');
+  }
+
+  /**
+   * Sets Id of current contact
+   *
+   * @param $contactId
+   */
+  public function setCurrentContactId($contactId) {
+    $this->currentContactId = $contactId;
+  }
+
+  /**
+   *  Sets id of current mandate
+   */
+  public function setCurrentMandateId() {
+    if (isset($this->form->getVar('_submitValues')['mandateId']) && !empty($this->form->getVar('_submitValues')['mandateId'])) {
+      $this->mandateId = $this->form->getVar('_submitValues')['mandateId'];
+    }
   }
 
   /**
@@ -55,24 +79,39 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
   }
 
   /**
+   *  Launches all required processes after saving mandate
+   */
+  public function run() {
+    $this->setCurrentContactId($this->form->getVar('_entityId'));
+    $this->setCurrentMandateId();
+
+    $this->checkChangingMandateContribution();
+    $this->checkMailNotification();
+    $this->createMandateActivity();
+  }
+
+  /**
    * Changes mandate for recurring contribution
    *
    * @return bool
    */
-  public function changeMandateForRecurringContribution() {
+  public function checkChangingMandateContribution() {
+    if (!isset($this->form->getVar('_submitValues')['recurrId']) || empty($this->form->getVar('_submitValues')['recurrId'])) {
+      return FALSE;
+    }
+
     $recurringContributionId = $this->form->getVar('_submitValues')['recurrId'];
     $oldMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionId);
 
-    if (is_null($oldMandateId)){
+    if (is_null($oldMandateId)) {
       CRM_Core_Session::setStatus(t("Mandate doesn't exist"), $title = 'Error', $type = 'alert');
 
       return FALSE;
     }
 
-    $mandateId = $this->mandateStorage->getLastInsertedMandateId( $this->form->getVar('_entityId'));
-
-    CRM_ManualDirectDebit_BAO_RecurrMandateRef::changeMandateForRecurrContribution($mandateId, $recurringContributionId);
-    $this->mandateStorage->changeMandateForContribution($mandateId, $oldMandateId);
+    $this->mandateId = $this->mandateStorage->getLastInsertedMandateId($this->currentContactId);
+    CRM_ManualDirectDebit_BAO_RecurrMandateRef::changeMandateForRecurrContribution($this->mandateId, $recurringContributionId);
+    $this->mandateStorage->changeMandateForContribution($this->mandateId, $oldMandateId);
 
     $this->redirectToContributionTab();
   }
@@ -84,10 +123,43 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     $this->form->controller->setDestination(CRM_Utils_System::url('civicrm/contact/view', http_build_query([
         'action' => 'browse',
         'reset' => 1,
-        'cid' => $this->form->getVar('_entityId'),
+        'cid' => $this->currentContactId,
         'selectedChild' => 'contribute',
       ])
     ));
+  }
+
+  /**
+   * Sends mail if appropriate checkbox is checked on
+   */
+  public function checkMailNotification() {
+    if (!isset($this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact']) || empty($this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'])) {
+      return FALSE;
+    }
+
+    $valueOfSendMailCheckbox = $this->form->getVar('_submitValues')['send_mandate_update_notification_to_the_contact'];
+    $isSendMailCheckboxTurnedOn = $valueOfSendMailCheckbox == 1;
+
+    if ($isSendMailCheckboxTurnedOn) {
+
+//      TODO: Sending mail process will be implemented in DD-30
+//      $notification = new CRM_ManualDirectDebit_Mail_Notification();
+//      $notification->sendMandateUpdateNotification($this->mandateId);
+    }
+  }
+
+  /**
+   * Creates mandate activity
+   */
+  public function createMandateActivity() {
+    $contactRelatedToContribution = $this->currentContactId;
+    CRM_ManualDirectDebit_Common_Activity::create(
+      "Direct Debit Mandate Update",
+      "direct_debit_mandate_update",
+      $this->mandateId,
+      CRM_ManualDirectDebit_Common_User::getAdminContactId(),
+      $contactRelatedToContribution
+    );
   }
 
 }

--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -12,13 +12,13 @@ CRM.$('document').ready(function () {
       if (isAlreadyEditButtonAdd) {
         var mandateData = JSON.parse(CRM.$(this).attr('data-post'));
 
-        CRM.$('<a href=\"#\" class=\"crm-hover-button crm-custom-value\" id="edit_direct_debit_mandate_' + cgCount + '" title=\"Edit Direct Debit Mandate\" onclick=\"CRM.loadPage(\'' + getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId) + '\')\">Edit</a>').insertAfter(CRM.$(this));
+        CRM.$('<a href=\"#\" class=\"crm-hover-button crm-custom-value\" id="edit_direct_debit_mandate_' + cgCount + '" title=\"Edit Direct Debit Mandate\" onclick=\"CRM.loadPage(\'' + getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId, mandateData.valueID) + '\')\">Edit</a>').insertAfter(CRM.$(this));
         CRM.$(this).hide();
       }
     });
   }
 
-  function getUrlForUpdatingCurrentMandate(cgCount, groupId, contactId) {
+  function getUrlForUpdatingCurrentMandate(cgCount, groupId, contactId, mandateId) {
     var url = CRM.url(
       'civicrm/contact/view/cd/edit',
       {
@@ -28,7 +28,8 @@ CRM.$('document').ready(function () {
         entityID: contactId,
         cgcount: cgCount,
         multiRecordDisplay: 'single',
-        mode: 'edit'
+        mode: 'edit',
+        mandateId: mandateId
       }
     );
 

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -188,15 +188,16 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 
   switch ($formName) {
     case "CRM_Contact_Form_CustomData":
-      if (isset($form->getVar('_submitValues')['recurrId']) && !empty($form->getVar('_submitValues')['recurrId'])) {
+      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'))) {
         $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
-        $manualDirectDebit->changeMandateForRecurringContribution();
-      };
+        $manualDirectDebit->run();
+      }
       break;
 
     case "CRM_Contribute_Form_Contribution":
       if ($action == CRM_Core_Action::ADD) {
         $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
+        $manualDirectDebit->setCurrentContactId($form->getVar('_contactID'));
         $manualDirectDebit->checkPaymentOptionToCreateMandate();
       }
       break;

--- a/templates/CRM/ManualDirectDebit/Form/SendMandateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SendMandateNotification.tpl
@@ -1,0 +1,16 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    CRM.$('#send_mandate_update_notification_to_the_contact').insertAfter(CRM.$('.custom-group.custom-group-direct_debit_mandate .spacer'));
+  });
+  {/literal}
+</script>
+
+<table>
+  <tr id="send_mandate_update_notification_to_the_contact">
+    <td class="label">
+      {$form.send_mandate_update_notification_to_the_contact.label}
+      {$form.send_mandate_update_notification_to_the_contact.html}
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Overview

 1. A "Send mandate update notification to the contact?" checkbox is added to the bottom of the "Edit Direct Debit Mandate Record" modal (edit mandate directly) and "New Direct Debit Mandate Record".
2. Adding a postprocessing in the extension so when any change is made to an existing mandate or when a new mandate is used for an existing recurring contribution, a "Direct Debit Mandate Update" activity is generated

![dd-31 mandate update activity](https://user-images.githubusercontent.com/36959503/41777783-31546b24-7635-11e8-9305-eb9a14f10f81.gif)
