### PR TITLE
DD-43: Mandate reference  improvement

### DIFF
--- a/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
@@ -78,7 +78,7 @@ class CRM_ManualDirectDebit_BAO_RecurrMandateRef extends CRM_ManualDirectDebit_D
   public static function getMandateIdForRecurringContribution($recurContributionId) {
     $sqlSelectDebitMandateID = "SELECT `mandate_id` AS id 
       FROM " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " 
-      WHERE `recurr_id` = %1";
+      WHERE `recurr_id` = %1 ORDER BY mandate_id DESC LIMIT 1";
 
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
       1 => [
@@ -93,17 +93,6 @@ class CRM_ManualDirectDebit_BAO_RecurrMandateRef extends CRM_ManualDirectDebit_D
     } else {
       return NULL;
     }
-  }
-
-  /**
-   * Changes mandate id for recurring contribution
-   *
-   * @param $mandateId
-   * @param $recurr
-   */
-  public static function changeMandateForRecurrContribution($mandateId, $recurr) {
-    $query = "UPDATE " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " SET mandate_id = $mandateId WHERE recurr_id = $recurr";
-    CRM_Core_DAO::executeQuery($query);
   }
 
 }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -39,84 +39,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    *
    * @var array
    */
-  protected $searchableFields = [
-    'entity_id' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.entity_id',
-    ],
-    'bank_name' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.bank_name',
-    ],
-    'bank_street_address' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.bank_street_address',
-    ],
-    'bank_city' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.bank_city',
-    ],
-    'bank_county' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.bank_county',
-    ],
-    'bank_postcode' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.bank_postcode',
-    ],
-    'account_holder_name' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.account_holder_name',
-    ],
-    'ac_number' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.ac_number',
-    ],
-    'sort_code' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.sort_code',
-    ],
-    'dd_code' => [
-      'op' => 'IN',
-      'field' => self::DD_MANDATE_TABLE . '.dd_code',
-    ],
-    'dd_ref' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.dd_ref',
-    ],
-    'start_date' => [
-      'op' => '<=',
-      'field' => self::DD_MANDATE_TABLE . '.start_date',
-    ],
-    'authorisation_date' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.authorisation_date',
-    ],
-    'collection_day' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.collection_day',
-    ],
-    'originator_number' => [
-      'op' => '=',
-      'field' => self::DD_MANDATE_TABLE . '.originator_number',
-    ],
-    'payment_instrument' => [
-      'op' => 'IN',
-      'field' => 'civicrm_contribution.payment_instrument_id',
-    ],
-    'contribution_status' => [
-      'op' => 'IN',
-      'field' => 'civicrm_contribution.contribution_status_id',
-    ],
-    'receive_date' => [
-      'op' => '<=',
-      'field' => 'civicrm_contribution.receive_date',
-    ],
-    'recur_status' => [
-      'op' => 'IN',
-      'field' => 'civicrm_contribution_recur.contribution_status_id',
-    ],
-  ];
+  protected $searchableFields = [];
 
   /**
    * What column does select in SQL query
@@ -177,6 +100,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $this->params['entityTable'] = self::DD_MANDATE_TABLE;
     }
 
+    $this->setSearchableFields();
+
     $this->setColumnHeader($columnHeader);
     $this->setReturnValues($returnValues);
 
@@ -185,6 +110,86 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     }
   }
 
+  private function setSearchableFields() {
+    $this->searchableFields = [
+      'entity_id' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.entity_id',
+      ],
+      'bank_name' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.bank_name',
+      ],
+      'bank_street_address' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.bank_street_address',
+      ],
+      'bank_city' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.bank_city',
+      ],
+      'bank_county' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.bank_county',
+      ],
+      'bank_postcode' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.bank_postcode',
+      ],
+      'account_holder_name' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.account_holder_name',
+      ],
+      'ac_number' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.ac_number',
+      ],
+      'sort_code' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.sort_code',
+      ],
+      'dd_code' => [
+        'op' => 'IN',
+        'field' => self::DD_MANDATE_TABLE . '.dd_code',
+      ],
+      'dd_ref' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.dd_ref',
+      ],
+      'start_date' => [
+        'op' => '<=',
+        'field' => self::DD_MANDATE_TABLE . '.start_date',
+      ],
+      'authorisation_date' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.authorisation_date',
+      ],
+      'collection_day' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.collection_day',
+      ],
+      'originator_number' => [
+        'op' => '=',
+        'field' => self::DD_MANDATE_TABLE . '.originator_number',
+      ],
+      'payment_instrument' => [
+        'op' => 'IN',
+        'field' => 'civicrm_contribution.payment_instrument_id',
+      ],
+      'contribution_status' => [
+        'op' => 'IN',
+        'field' => 'civicrm_contribution.contribution_status_id',
+      ],
+      'receive_date' => [
+        'op' => '<=',
+        'field' => 'civicrm_contribution.receive_date',
+      ],
+      'recur_status' => [
+        'op' => 'IN',
+        'field' => 'civicrm_contribution_recur.contribution_status_id',
+      ],
+    ];
+  }
 
   /**
    * Sets columns for rows

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -303,7 +303,13 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    * @param $oldMandateId
    */
   public function changeMandateForContribution($mandateId, $oldMandateId) {
-    $query = "UPDATE `civicrm_value_dd_information` SET mandate_id = $mandateId WHERE mandate_id = $oldMandateId";
+    $completedStatusId = CRM_ManualDirectDebit_Common_OptionValue::getValueForOptionValue('contribution_status', 'Completed');
+
+    $query = "UPDATE `civicrm_value_dd_information` AS dd_information 
+              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id 
+              SET dd_information.mandate_id = $mandateId 
+              WHERE dd_information.mandate_id = $oldMandateId 
+              AND contribution.contribution_status_id != $completedStatusId";
     CRM_Core_DAO::executeQuery($query);
   }
 

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -112,7 +112,13 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     }
 
     $this->mandateId = $this->mandateStorage->getLastInsertedMandateId($this->currentContactId);
-    CRM_ManualDirectDebit_BAO_RecurrMandateRef::changeMandateForRecurrContribution($this->mandateId, $recurringContributionId);
+
+    $params = [
+      'recurr_id' => $recurringContributionId,
+      'mandate_id' => $this->mandateId,
+    ];
+    CRM_ManualDirectDebit_BAO_RecurrMandateRef::create($params);
+
     $this->mandateStorage->changeMandateForContribution($this->mandateId, $oldMandateId);
 
     $this->redirectToContributionTab();


### PR DESCRIPTION
## Before

1- When there is more than one dd mandate ref linked to a recurring contribution via dd_contribution_recurr_mandate_ref table, on the view recurring contribution screen, the first mandate is shown.

2- When assigning a new mandate for a recurring contribution, the already completed (paid) contributions mandate reference will change to point to the last assigned mandate.

## After

1- When there is more than one dd mandate ref linked to a recurring contribution via dd_contribution_recurr_mandate_ref table, on the view recurring contribution screen and related contributions view screen, the last linked mandate is shown.

2- When assigning a new mandate for a recurring contribution, the already completed (paid) contributions related to the recurring contribution are now showing the mandate used at the time of completing the contribution.


## Other notes

in CRM/ManualDirectDebit/Batch/Transaction.php class, I changed $searchableFields  property to be initialized inside the constructor instead at the time of defining the property, because at PHP versions 
>= 5.5 class properties cannot be initialized using expressions that need to be evaluated at the run-time.