### PR TITLE
DD-45: Add save button to batch export pages

### DIFF
--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -179,7 +179,8 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form {
     if (CRM_Batch_BAO_Batch::checkBatchPermission('close', $this->_values['created_id'])) {
       if (CRM_Batch_BAO_Batch::checkBatchPermission('export', $this->_values['created_id'])) {
         $this->add('submit', 'export_batch', ts('Export Batch'), ['formtarget' => '_blank']);
-        $this->add('submit', 'done_and_export_batch', ts('Done and Export Batch'), ['formtarget' => '_blank']);
+        $this->add('submit', 'save_batch', ts('Save'));
+        $this->add('submit', 'save_and_export_batch', ts('Save and Export Batch'), ['formtarget' => '_blank']);
         $this->add('submit', 'submitted', ts('Submit'));
         $this->add('submit', 'discard', ts('Discard'));
       }
@@ -264,10 +265,19 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form {
       $this->updateBatchValues($batchSerializedValues, $mandateCurrentState);
     }
 
-    if (isset($params['export_batch']) || isset($params['done_and_export_batch'])) {
+    if (isset($params['export_batch']) || isset($params['save_and_export_batch'])) {
       $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID);
       $batch->createExportFile();
     }
+
+    $this->redirectToBatchViewPage();
+  }
+
+  private function redirectToBatchViewPage() {
+    $redirectPath = 'civicrm/direct_debit/batch-list';
+    $redirectParams = http_build_query(['reset' => 1, 'type_id' => $this->_values['type_id']]);
+    $redirectURL = CRM_Utils_System::url($redirectPath, $redirectParams);
+    CRM_Utils_System::redirect($redirectURL);
   }
 
   /**

--- a/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
@@ -40,7 +40,10 @@
     </div>
   {else}
     <div class="float-left">
-      {$form.done_and_export_batch.html}
+      {$form.save_batch.html}
+    </div>
+    <div class="float-left">
+      {$form.save_and_export_batch.html}
     </div>
   {/if}
 


### PR DESCRIPTION
## Before

In export batch pages, we had only one button called "Done and Export Batch" that both save then export the batch.

![2018-07-17 19_10_00-new direct debit instructions _ dmaster14](https://user-images.githubusercontent.com/6275540/42837120-0b0c3cde-89f5-11e8-8f6b-9dba0768c488.png)



## After

A new button is added called "save" that only save the batch and redirect to view batches list page, and "Done and Export Batch"  button is renamed to "Save and Export Batch" that both save the batch and export the batch.

![2018-07-17 19_09_27-calendar](https://user-images.githubusercontent.com/6275540/42837185-41b785ae-89f5-11e8-8e24-bd3916875155.png)
