### PR TITLE
DD-44: Improvements and fixes

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -145,6 +145,19 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->createDirectDebitPaymentProcessor();
   }
 
+  public function upgrade_0005() {
+    $this->setDefaultMinimumMandateReferenceLength();
+    return TRUE;
+  }
+
+  private function setDefaultMinimumMandateReferenceLength() {
+    $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
+    civicrm_api3('setting', 'create', [
+        'manualdirectdebit_minimum_reference_prefix_length' =>
+        $configFields['manualdirectdebit_minimum_reference_prefix_length']['default']
+      ]);
+  }
+
   public function upgrade_0004() {
     try {
       $this->createMessageTemplates();

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -23,7 +23,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_reference_prefix_length',
-    'title' => 'Minimum prefix reference length',
+    'title' => 'Minimum mandate reference length',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
@@ -2,6 +2,23 @@
 	Help texts for Manual Direct Debit Settings.
 *}
 
+{htxt id="manualdirectdebit_minimum_reference_prefix_length-title"}
+  {ts} If the mandate prefix is "M" and you selected this value to be be for example 6 characters long, the generated mandate reference will appear as:
+      M000001
+      M000002
+      ...
+      ...
+      M000100
+
+    but if the mandate id exceeded this length, then it will appear as is :
+    M1000000
+    M1000001
+    ...
+    ...
+    M121312312441
+  {/ts}
+{/htxt}
+
 {htxt id="manualdirectdebit_minimum_days_to_first_payment-title"}
   {ts}For new mandates, Direct Debit first
 contribution date should be set to the nearest new instruction run


### PR DESCRIPTION
In this PR I : 

1- I've renamed 'Minimum prefix reference length' setting field to 'Minimum mandate reference length' 
2- I'v added a help text to the field that explains its purpose.
3- I'v added an upgrader that sets the 'Minimum mandate reference length'  field default value for existing sites.