### PR TITLE
DD-44: Update the mandate refernce calculation so it also take effect on the prefix too

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
@@ -91,9 +91,14 @@ class CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator {
    * @return string
    */
   private function generateDirectDebitReference() {
-    $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-    $minimumReferencePrefixLength = (int) $settingsManager->getManualDirectDebitSettings()['minimum_reference_prefix_length'];
-    return $this->settings['default_reference_prefix'] . str_pad($this->mandateId, $minimumReferencePrefixLength, '0', STR_PAD_LEFT);
+    $prefixLength = strlen($this->settings['default_reference_prefix']);
+    $mandateIdLength = 0;
+    if ($this->settings['minimum_reference_prefix_length'] > $prefixLength) {
+      $mandateIdLength = $this->settings['minimum_reference_prefix_length'] - $prefixLength;
+    }
+    $mandateIdPart = str_pad($this->mandateId, $mandateIdLength, '0', STR_PAD_LEFT);
+
+    return $this->settings['default_reference_prefix'] . $mandateIdPart;
   }
 
   /**


### PR DESCRIPTION
## Before

We where applying the Minimum mandate reference length setting on the mandate id part only and ignoring the prefix, so for example if the prefix = 'M' and Minimum mandate reference length  = 6 and the mandate ID = 65 then the generated mandate reference will be : 

```
M000065
```

so the total reference mandate as you can see above is 7 and not 6 which makes the Minimum mandate reference length concept confusing to the user.


## Solution

The calculation is fixed to also take the prefix  itself length  into the account, so using the example above, the generated mandate reference will be : 

```
M00065
```
