### PR TITLE
BASW-194 : Ensure that all open transactions will be committed on success

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -106,6 +106,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
 
       throw $exception;
     }
+    $transaction->commit();
 
     $this->assignMandate($mandateId, $currentContactId);
 
@@ -148,6 +149,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
       $transaction->rollback();
       throw $exception;
     }
+    $transaction->commit();
 
     $this->setMandateForCreatingDependency($mandateId);
   }

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
@@ -119,6 +119,7 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
       $transaction->rollback();
       throw $exception;
     }
+    $transaction->commit();
   }
 
   /**


### PR DESCRIPTION
The code initialize MySQL transaction before certain operations but never commit it on success, the PR ensure that all successful transactions get committed so the data get actually stored.