### PR TITLE
BASW-211: Link the mandate to the new offline auto-renewal recurring contribution

### DIFF
--- a/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Mandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Mandate.php
@@ -1,0 +1,37 @@
+<?php
+
+use CRM_ManualDirectDebit_BAO_RecurrMandateRef as RecurrMandateRef;
+
+class  CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate {
+
+  private $contributionRecurId;
+
+  private $previousRecurContributionId;
+
+  public function __construct($contributionRecurId, $previousRecurContributionId) {
+    $this->contributionRecurId = $contributionRecurId;
+    $this->previousRecurContributionId = $previousRecurContributionId;
+  }
+
+  public function process() {
+    $this->linkMandateToTheNewRecurringContribution();
+  }
+
+  private function linkMandateToTheNewRecurringContribution() {
+    $isMandateAlreadyLinked = RecurrMandateRef::getMandateIdForRecurringContribution($this->contributionRecurId);
+    if ($isMandateAlreadyLinked) {
+      return;
+    }
+
+    $mandateId = RecurrMandateRef::getMandateIdForRecurringContribution($this->previousRecurContributionId);
+    if ($mandateId) {
+      $params = [
+        'recurr_id' => $this->contributionRecurId,
+        'mandate_id' => $mandateId,
+      ];
+
+      CRM_ManualDirectDebit_BAO_RecurrMandateRef::create($params);
+    }
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -346,9 +346,12 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
 /**
  * Implements hook_membershipextras_postOfflineAutoRenewal()
  */
-function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId) {
+function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId, $previousRecurContributionId) {
   $activity = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Activity($recurContributionId);
   $activity->process();
+
+  $mandate = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate($recurContributionId, $previousRecurContributionId);
+  $mandate->process();
 }
 
 function manualdirectdebit_civicrm_searchTasks( $objectName, &$tasks ){


### PR DESCRIPTION
## Before

Upon offline auto-renewal and in case that the membership is originaly paid using payment plan , then the newly created recurring contribution created due to the auto-renewal will not have a link to the previous mandate in case there was a mandate.

## After
The recurring contribution will link to the same mandate as the previous recurring contribution.