### PR TITLE
DD-50 : change Payment Status Selected Option To Pending When DD Payment Method Is Selected

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
@@ -1,0 +1,48 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_DirectDebitDataProvider as DirectDebitDataProvider;
+
+class CRM_ManualDirectDebit_Hook_BuildForm_Membership {
+
+  protected $templatesPath;
+
+  /**
+   * Form object that is being altered.
+   *
+   * @var object
+   */
+  protected $form;
+
+  public function __construct(&$form) {
+    $this->form = $form;
+    $this->templatesPath = CRM_ManualDirectDebit_ExtensionUtil::path() . '/templates';
+  }
+
+  /**
+   *  Builds form
+   */
+  public function buildForm() {
+    $this->changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected();
+  }
+
+  private function changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected() {
+    $directDebitPaymentInstrumentId = DirectDebitDataProvider::getDirectDebitPaymentInstrumentId();
+    $this->form->assign('directDebitPaymentInstrumentId', $directDebitPaymentInstrumentId);
+
+    $pendingPaymentStatusID = $this->getPendingPaymentStatusID();
+    $this->form->assign('pendingPaymentStatusID', $pendingPaymentStatusID);
+
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatesPath}/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl",
+    ]);
+  }
+
+  private function getPendingPaymentStatusID() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'contribution_status',
+      'name' => 'Pending',
+    ]);
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -304,8 +304,11 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName === 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
-    $customGroupInjector = new CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup($form);
-    $customGroupInjector->buildForm();
+    $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup($form);
+    $formBuilder->buildForm();
+
+    $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_Membership($form);
+    $formBuilder->buildForm();
   }
 }
 

--- a/templates/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl
@@ -1,0 +1,17 @@
+<script type="text/javascript">
+  var directDebitID = '{$directDebitPaymentInstrumentId}';
+  var pendingPaymentStatusID = '{$pendingPaymentStatusID}';
+
+  {literal}
+  CRM.$('#payment_instrument_id').change(function () {
+    changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected();
+  });
+
+  function changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected() {
+    if (CRM.$('#payment_instrument_id option:selected').val() == directDebitID) {
+      CRM.$('#contribution_status_id').val(pendingPaymentStatusID);
+    }
+  }
+  {/literal}
+</script>
+


### PR DESCRIPTION
On "New Membership" and "Membership Renew" pages/ modals, if "Direct Debit" is selected in the payment method, in the "Contribution Status" field, "Pending" option should be automatically be selected.


![aaaaaa](https://user-images.githubusercontent.com/6275540/43412221-6dec261e-9424-11e8-9a7d-6760690282b5.gif)
