### PR TITLE
SPAB-832: Fix markup for edit DD mandate button

### DIFF
--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -12,7 +12,7 @@ CRM.$('document').ready(function () {
       if (isAlreadyEditButtonAdd) {
         var mandateData = JSON.parse(CRM.$(this).attr('data-post'));
 
-        CRM.$('<a href=\"#\" class=\"crm-hover-button crm-custom-value\" id="edit_direct_debit_mandate_' + cgCount + '" title=\"Edit Direct Debit Mandate\" onclick=\"CRM.loadPage(\'' + getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId, mandateData.valueID) + '\')\">Edit</a>').insertAfter(CRM.$(this));
+        CRM.$('<a href=\"#\" class=\"button edit\" id="edit_direct_debit_mandate_' + cgCount + '" title=\"Edit Direct Debit Mandate\" onclick=\"CRM.loadPage(\'' + getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId, mandateData.valueID) + '\')\"><span><i class="crm-i fa-pencil"></i> Edit </span></a>').insertAfter(CRM.$(this));
         CRM.$(this).hide();
       }
     });


### PR DESCRIPTION
### Overview
This PR contains HTML fix for edit button so that it picks the default civicrm edit button styles.

### Before
<img width="1680" alt="spab-832 - before" src="https://user-images.githubusercontent.com/3340537/43638045-f5306546-9734-11e8-8896-9750cbcba63f.png">

### After
<img width="1606" alt="spab-832 - after" src="https://user-images.githubusercontent.com/3340537/43638052-ff1dbd74-9734-11e8-9b48-05475ddeeb6c.png">



***Note**:This change is encouraged from the changes requested in SPAB-832 (https://compucorp.atlassian.net/browse/SPAB-832).*
