### PR TITLE
BASW-253: Show 'Send mandate update notification' Checkbox Only For …

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -294,8 +294,10 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
     }
   }
   if ($formName == 'CRM_Contact_Form_CustomData') {
-    $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);
-    $customData->run();
+    if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'))) {
+      $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);
+      $customData->run();
+    }
   }
 
   if ($formName == 'CRM_Custom_Form_CustomDataByType') {


### PR DESCRIPTION
…Direct Debit Mandate Custom Fields

Overview
----------
When creating a new custom field set and choosing to display it as 'tab with table' then 'Send mandate update notification' checkbox is displayed. But it should only be shown for DD mandate custom fields.
![9cbc7490-a6e4-42f8-bfb9-9865d23772bf](https://user-images.githubusercontent.com/36624620/45289594-33047d00-b50b-11e8-9fdd-dc4ec9038892.png)

