### PR TITLE
ASE-257: Ensure Created Jobs are Disabled

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -297,7 +297,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'api_action' => 'run',
       'run_frequency' => 'Daily',
       'domain_id' => $domainID,
-      'is_active' => '0',
+      'is_active' => 0,
       'parameters' => '',
     ];
 


### PR DESCRIPTION
## Overview
We need to check the extension's process to see if any of the scheduled jobs created by the extension are automatically turned on during the installation process.
We need to make sure all scheduled jobs created by these extensions are turned off by default.

## Before
Jobs created by this extension were enabled by default after installation on some setups because `'0'` is being passed to `is_active` as a string instead of as an integer

## After
Jobs created by the extension are now disabled on extension installation on all setups.