### PR TITLE
DD-59: Allow users to edit the mandate ref from UI

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -38,7 +38,6 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
   public function run() {
     if ($this->checkIfDirectDebitMandateInGroupTree()) {
       $this->hideSaveAndNewButton();
-      $this->hideDdRef();
     }
 
     $this->checkRecurringContribution();
@@ -66,21 +65,6 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
     foreach ($buttonsGroup->_elements as $key => $button) {
       if ($button->_attributes['value'] == "Save and New") {
         unset($buttonsGroup->_elements[$key]);
-      }
-    }
-  }
-
-  /**
-   *  Hides 'DD ref' custom field
-   */
-  private function hideDdRef() {
-    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("dd_ref");
-    $ddRefElementNameId = $this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]['element_name'];
-
-    unset($this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]);
-    foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName){
-      if ($requiredFieldsName == $ddRefElementNameId){
-        unset($this->form->_required[$requiredFieldsId]);
       }
     }
   }


### PR DESCRIPTION
## Problem
Currently mandate ref field is hidden from all forms, e.g. new membership form, use a new mandate form and edit mandate form.

We want to expose the mandate ref field on edit mandate form so after a mandate is created, staff can manually edit the mandate ref afterwards.

## Solution

I altered CRM_ManualDirectDebit_Hook_BuildForm_CustomDatar::run() method  to stop calling hideDdRef() method that hides the mandate reference field. 