### PR TITLE
DD-58: Improvments and fixes to DD message templates data and format

### DIFF
--- a/CRM/ManualDirectDebit/Common/MessageTemplate.php
+++ b/CRM/ManualDirectDebit/Common/MessageTemplate.php
@@ -5,15 +5,46 @@
  */
 class CRM_ManualDirectDebit_Common_MessageTemplate {
 
-  const SIGN_UP_MSG_TITLE = 'Direct Debit Payment Sign Up Notification';
+  const SIGN_UP_MSG_NAME = 'payment_sign_up_notification';
 
-  const PAYMENT_UPDATE_MSG_TITLE = 'Direct Debit Payment Update Notification';
+  const PAYMENT_UPDATE_MSG_NAME = 'payment_update_notification';
 
-  const COLLECTION_REMINDER_MSG_TITLE = 'Direct Debit Payment Collection Reminder';
+  const COLLECTION_REMINDER_MSG_NAME = 'payment_collection_reminder';
 
-  const AUTO_RENEW_MSG_TITLE = 'Direct Debit Auto-renew Notification';
+  const AUTO_RENEW_MSG_NAME = 'auto_renew_notification';
 
-  const MANDATE_UPDATE_MSG_TITLE = 'Direct Debit Mandate Update Notification';
+  const MANDATE_UPDATE_MSG_NAME = 'mandate_update_notification';
+
+
+  public static function getDefaultDirectDebitTemplates() {
+    return [
+        [
+          'name' => self::SIGN_UP_MSG_NAME,
+          'templateFile' => 'PaymentSignUpNotification.tpl',
+          'title' => 'Direct Debit Payment Sign Up Notification'
+        ],
+        [
+          'name' => self::PAYMENT_UPDATE_MSG_NAME,
+          'templateFile' => 'PaymentUpdateNotification.tpl',
+          'title' => 'Direct Debit Payment Update Notification'
+        ],
+        [
+          'name' => self::COLLECTION_REMINDER_MSG_NAME,
+          'templateFile' => 'PaymentCollectionReminder.tpl',
+          'title' => 'Direct Direct Debit Payment Collection Reminder'
+        ],
+        [
+          'name' => self::AUTO_RENEW_MSG_NAME,
+          'templateFile' => 'AutoRenewNotification.tpl',
+          'title' => 'Direct Debit Auto-renew Notification'
+        ],
+        [
+          'name' => self::MANDATE_UPDATE_MSG_NAME,
+          'templateFile' => 'MandateUpdateNotification.tpl',
+          'title' => 'Direct Debit Mandate Update Notification'
+        ],
+    ];
+  }
 
   /**
    * Checks if template is direct debit template
@@ -23,61 +54,53 @@ class CRM_ManualDirectDebit_Common_MessageTemplate {
    * @return bool
    */
   public static function isDirectDebitTemplate($templateId) {
-    $query = "
-      SELECT template.id
-      FROM civicrm_msg_template AS template
-      WHERE template.id = %1 
-        AND template.msg_title in (%2, %3, %4, %5, %6)
-    ";
-
-    $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$templateId, 'Integer'],
-      2 => [self::SIGN_UP_MSG_TITLE, 'String'],
-      3 => [self::PAYMENT_UPDATE_MSG_TITLE, 'String'],
-      4 => [self::COLLECTION_REMINDER_MSG_TITLE, 'String'],
-      5 => [self::AUTO_RENEW_MSG_TITLE, 'String'],
-      6 => [self::MANDATE_UPDATE_MSG_TITLE, 'String'],
+    $isDDTemplateCustomFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => 'id',
+      'custom_group_id' => 'direct_debit_message_template',
+      'name' => 'is_direct_debit_template',
     ]);
 
-    while ($dao->fetch()) {
-      return TRUE;
+    $template = civicrm_api3('MessageTemplate', 'get', [
+      'sequential' => 1,
+      'id' => $templateId,
+      'custom_' . $isDDTemplateCustomFieldId => 1,
+    ]);
+
+    if(empty($template['id'])) {
+      return FALSE;
     }
 
-    return FALSE;
+
+    return TRUE;
   }
 
-  /**
-   * Gets 'message template id' by title
-   *
-   * @param $title
-   *
-   * @return int|bool
-   */
-  public static function getMessageTemplateId($title) {
+  public static function getMessageTemplateIdByTitle($title) {
     $messageTemplate = civicrm_api3('MessageTemplate', 'get', [
       'sequential' => 1,
-      'return' => ["id"],
+      'return' => ['id'],
       'msg_title' => $title
     ]);
 
     return $messageTemplate['count'] == 1 ? $messageTemplate['values'][0]['id'] : FALSE;
   }
 
-  /**
-   * Gets 'message template title' by id
-   *
-   * @param $idMessageTemplate
-   *
-   * @return int|bool
-   */
-  public static function getMessageTemplateTitle($idMessageTemplate) {
-    $messageTemplate = civicrm_api3('MessageTemplate', 'get', [
-      'sequential' => 1,
-      'return' => ["msg_title"],
-      'id' => $idMessageTemplate
+  public static function getTemplateIdByName($templateName) {
+    $machineNameCustomFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => 'id',
+      'custom_group_id' => 'direct_debit_message_template',
+      'name' => 'template_machine_name',
     ]);
 
-    return $messageTemplate['count'] == 1 ? $messageTemplate['values'][0]['msg_title'] : FALSE;
+    $template = civicrm_api3('MessageTemplate', 'get', [
+      'sequential' => 1,
+      'custom_' . $machineNameCustomFieldId => $templateName,
+    ]);
+
+    if (empty($template['id'])) {
+      return NULL;
+    }
+
+    return $template['id'];
   }
 
 }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -13,13 +13,6 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
   protected $contributionId;
 
   /**
-   * Membership id
-   *
-   * @var int
-   */
-  protected $membershipId;
-
-  /**
    * Template params
    *
    * @var array
@@ -29,8 +22,10 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     'mandateData' => FALSE,
     'recurringContributionData' => FALSE,
     'currency' => FALSE,
-    'membershipData' => FALSE,
+    'paymentPlanMemberships' => FALSE,
+    'activeMemberships' => FALSE,
     'nextMembershipPayment' => FALSE,
+    'orderLineItems' => FALSE,
   ];
 
   /**
@@ -64,11 +59,13 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $this->loadContributionData();
     $this->setContactEmailData();
     $this->setRecurringContributionId();
-    $this->setMembershipId();
 
     $this->collectRecurringContributionData();
     $this->collectMandateData();
-    $this->collectMembershipData();
+    $this->collectOrderLineItems();
+    $this->collectPaymentPlanMembershipsData();
+    $this->collectActiveMembershipsData();
+    $this->collectNextMembershipPayment();
     $this->collectImageSrc();
     $this->collectCurrency();
 
@@ -119,19 +116,6 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       $this->recurringContributionId = $this->contributionData['contribution_recur_id'];
     }
   }
-
-  /**
-   * Sets membership id
-   */
-  private function setMembershipId() {
-    $result = civicrm_api3('MembershipPayment', 'get', [
-      'sequential' => 1,
-      'contribution_id' => $this->contributionId,
-    ]);
-
-    $this->membershipId = $result['count'] == 1 ? $result['values'][0]['membership_id'] : FALSE;
-  }
-
   /**
    * Collects mandate data
    */
@@ -188,24 +172,25 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     }
 
     $recurringContributionBao = CRM_Contribute_BAO_ContributionRecur::findById($this->recurringContributionId);
-    $recurringContributionRows = $this->collectRecurringContributionRows();
+    $installmentsCount = empty($recurringContributionBao->installments) ? 1 : $recurringContributionBao->installments;
+    $recurringContributionRows = $this->collectRecurringContributionRows($installmentsCount);
     $total = 0;
     $recurringContributionPlan = array();
     foreach ($recurringContributionRows as $index => $recurringContributionRow) {
       $total += $recurringContributionRow['amount'];
       $dueDate = DateTime::createFromFormat('Y-m-d H:i:s', $recurringContributionRow['receive_date']);
       $recurringContributionPlan[$index]['index'] = $index+1;
-      $recurringContributionPlan[$index]['amount'] = $recurringContributionRow['amount'];
+      $recurringContributionPlan[$index]['amount'] = $this->formatAmount($recurringContributionRow['amount']);
       $recurringContributionPlan[$index]['due_date'] = $dueDate->format('Y-m-d');
     }
     $recurringContributionRows['recurringInstallmentsTable'] = $this->buildRecuringContributionTable($recurringContributionPlan);
-    $total = round($total, 2);
+    $total = $this->formatAmount($total);
 
     $this->tplParams['recurringContributionData'] = [
       'recurringContributionRows' => $recurringContributionRows,
       'total' => $total,
-      'installments' => $recurringContributionBao->installments,
-      'installments_paid' => $recurringContributionBao->amount
+      'installments' => $installmentsCount,
+      'installments_paid' => $this->formatAmount($recurringContributionBao->amount),
     ];
   }
 
@@ -254,7 +239,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
    *
    * @return array
    */
-  private function collectRecurringContributionRows() {
+  private function collectRecurringContributionRows($installmentsCount) {
     $query = "
       SELECT 
         contribution.total_amount AS amount,
@@ -273,6 +258,10 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         ON contribution.contribution_recur_id = contribution_recur.id  
       WHERE contribution.contribution_recur_id = %1
     ";
+
+    if ($installmentsCount == 1) {
+      $query .= ' ORDER BY contribution.id DESC LIMIT 1 ';
+    }
 
     $dao = CRM_Core_DAO::executeQuery($query, [
       1 => [$this->recurringContributionId, 'Integer']
@@ -296,39 +285,89 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     return $rows;
   }
 
-  /**
-   * Collects membership data
-   */
-  private function collectMembershipData() {
-    if ($this->membershipId === FALSE) {
+  private function collectOrderLineItems() {
+    $lineItems = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $this->contributionId,
+      'options' => ['limit' => 0],
+    ]);
+
+    if (empty($lineItems['count'])) {
       return;
     }
 
-    $query = "
-      SELECT
-        membership_type.duration_unit AS duration_unit,
-        membership_type.name AS membership_name,
-        membership_type.minimum_fee AS amount_per_unit
-      FROM civicrm_membership AS membership 
-      LEFT JOIN civicrm_membership_type AS membership_type
-        ON membership.membership_type_id = membership_type.id
-      WHERE membership.id = %1
-      LIMIT 1
-    ";
-
-    $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->membershipId, 'Integer']
-    ]);
-
-    while ($dao->fetch()) {
-      $this->tplParams['membershipData'] = [
-        'durationUnit' => $dao->duration_unit,
-        'amountPerUnit' => round($dao->amount_per_unit, 2),
-        'membershipName' => $dao->membership_name
+    $installmentsCount = $this->tplParams['recurringContributionData']['installments'];
+    $orderLineItems = [];
+    foreach ($lineItems['values'] as $lineItem) {
+      $orderLineItems[] = [
+        'label' => $lineItem['label'],
+        'price' => $this->formatAmount($lineItem['line_total'] * $installmentsCount),
+        'entityTable' => $lineItem['entity_table'],
+        'entityId' => $lineItem['entity_id'],
       ];
     }
 
-    $this->collectNextMembershipPayment();
+    $this->tplParams['orderLineItems'] = $orderLineItems;
+  }
+
+  private function collectPaymentPlanMembershipsData() {
+    if (empty($this->tplParams['orderLineItems'])) {
+      return;
+    }
+
+    $paymentPlanMemberships = [];
+    $membershipIds = [];
+    foreach ($this->tplParams['orderLineItems'] as $lineItem) {
+      if ($lineItem['entityTable'] == 'civicrm_membership') {
+        $membershipIds[] = $lineItem['entityId'];
+        $paymentPlanMemberships[$lineItem['entityId']]['label'] = $lineItem['label'];
+        $paymentPlanMemberships[$lineItem['entityId']]['price'] = $lineItem['price'];
+      }
+    }
+
+    if (empty($membershipIds)) {
+      return;
+    }
+
+    $membershipsResponse = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'id' => ['IN' => $membershipIds],
+      'options' => ['limit' => 0],
+      'api.MembershipType.get' => ['id' => '$value.membership_type_id'],
+    ]);
+
+    foreach ($membershipsResponse['values'] as $membership) {
+      $paymentPlanMemberships[$membership['id']]['id'] = $membership['id'];
+      $paymentPlanMemberships[$membership['id']]['startDate'] = $membership['start_date'];
+      $paymentPlanMemberships[$membership['id']]['endDate'] = $membership['end_date'];
+      $paymentPlanMemberships[$membership['id']]['durationUnit'] = $membership['api.MembershipType.get']['values'][0]['duration_unit'];
+    }
+
+    $this->tplParams['paymentPlanMemberships'] = array_values($paymentPlanMemberships);
+  }
+
+  private function collectActiveMembershipsData() {
+    $activeMembershipsResponse = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'contact_id' => $this->contributionData['contact_id'],
+      'active_only' => 1,
+    ]);
+
+    if (empty($activeMembershipsResponse['count'])) {
+      return;
+    }
+
+    $activeMemberships = [];
+    $i = 0;
+    foreach ($activeMembershipsResponse['values'] as $membership) {
+      $activeMemberships[] = [
+        'name' => $membership['membership_name'],
+        'startDate' => $membership['start_date'],
+        'endDate' => $membership['end_date'],
+      ];
+    }
+
+    $this->tplParams['activeMemberships'] = $activeMemberships;
   }
 
   /**
@@ -351,8 +390,12 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       LIMIT 1
     ";
 
+    if (empty($this->tplParams['paymentPlanMemberships'])) {
+      return;
+    }
+
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->membershipId, 'Integer'],
+      1 => [$this->tplParams['paymentPlanMemberships'][0]['id'], 'Integer'],
       2 => [$cancelledStatus, 'Integer'],
       3 => [$completedStatus, 'Integer'],
     ]);
@@ -406,6 +449,11 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     ]);
 
     return $result['values'][0]['api.OptionValue.getValue'];
+  }
+
+  private function formatAmount($amount) {
+    $roundedAmount = round($amount, 2);
+    return number_format($roundedAmount, 2);
   }
 
 }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -298,16 +298,20 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
     $installmentsCount = $this->tplParams['recurringContributionData']['installments'];
     $orderLineItems = [];
+    $total = 0;
     foreach ($lineItems['values'] as $lineItem) {
+      $price = $this->formatAmount($lineItem['line_total'] * $installmentsCount);
       $orderLineItems[] = [
         'label' => $lineItem['label'],
-        'price' => $this->formatAmount($lineItem['line_total'] * $installmentsCount),
+        'price' => $price,
         'entityTable' => $lineItem['entity_table'],
         'entityId' => $lineItem['entity_id'],
       ];
+      $total += (float) $price;
     }
 
     $this->tplParams['orderLineItems'] = $orderLineItems;
+    $this->tplParams['recurringContributionData']['total'] = $this->formatAmount($total);
   }
 
   private function collectPaymentPlanMembershipsData() {

--- a/CRM/ManualDirectDebit/Mail/Notification.php
+++ b/CRM/ManualDirectDebit/Mail/Notification.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_ManualDirectDebit_Common_MessageTemplate as MessageTemplate;
+
 /**
 * Sends mails
 */
@@ -74,8 +76,9 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function sendPaymentSignUpNotify($recurringContributionId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution($recurringContributionId);
+    $templateId = MessageTemplate::getTemplateIdByName(MessageTemplate::SIGN_UP_MSG_NAME);
 
-    return $this->sendEmail($dataCollector, CRM_ManualDirectDebit_Common_MessageTemplate::SIGN_UP_MSG_TITLE);
+    return $this->sendEmail($dataCollector, $templateId);
   }
 
   /**
@@ -87,8 +90,9 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function sendPaymentUpdateNotification($recurringContributionId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution($recurringContributionId);
+    $templateId = MessageTemplate::getTemplateIdByName(MessageTemplate::PAYMENT_UPDATE_MSG_NAME);
 
-    return $this->sendEmail($dataCollector, CRM_ManualDirectDebit_Common_MessageTemplate::PAYMENT_UPDATE_MSG_TITLE);
+    return $this->sendEmail($dataCollector, $templateId);
   }
 
   /**
@@ -100,8 +104,9 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function sendPaymentCollectionReminder($contributionId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($contributionId);
+    $templateId = MessageTemplate::getTemplateIdByName(MessageTemplate::COLLECTION_REMINDER_MSG_NAME);
 
-    return $this->sendEmail($dataCollector, CRM_ManualDirectDebit_Common_MessageTemplate::COLLECTION_REMINDER_MSG_TITLE);
+    return $this->sendEmail($dataCollector, $templateId);
   }
 
   /**
@@ -113,8 +118,9 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function sendAutoRenewNotification($recurringContributionId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution($recurringContributionId);
+    $templateId = MessageTemplate::getTemplateIdByName(MessageTemplate::AUTO_RENEW_MSG_NAME);
 
-    return $this->sendEmail($dataCollector, CRM_ManualDirectDebit_Common_MessageTemplate::AUTO_RENEW_MSG_TITLE);
+    return $this->sendEmail($dataCollector, $templateId);
   }
 
   /**
@@ -126,8 +132,9 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function sendMandateUpdateNotification($mandateId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Mandate($mandateId);
+    $templateId = MessageTemplate::getTemplateIdByName(MessageTemplate::MANDATE_UPDATE_MSG_NAME);
 
-    return $this->sendEmail($dataCollector, CRM_ManualDirectDebit_Common_MessageTemplate::MANDATE_UPDATE_MSG_TITLE);
+    return $this->sendEmail($dataCollector, $templateId);
   }
 
   /**
@@ -140,9 +147,7 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function notifyByContributionId($contributionId, $messageTemplateId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($contributionId);
-    $messageTemplateTitle = CRM_ManualDirectDebit_Common_MessageTemplate::getMessageTemplateTitle($messageTemplateId);
-
-    return $this->sendEmail($dataCollector, $messageTemplateTitle);
+    return $this->sendEmail($dataCollector, $messageTemplateId);
   }
 
   /**
@@ -155,9 +160,7 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function notifyByMembershipId($membershipId, $messageTemplateId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Membership($membershipId);
-    $messageTemplateTitle = CRM_ManualDirectDebit_Common_MessageTemplate::getMessageTemplateTitle($messageTemplateId);
-
-    return $this->sendEmail($dataCollector, $messageTemplateTitle);
+    return $this->sendEmail($dataCollector, $messageTemplateId);
   }
 
   /**
@@ -170,9 +173,7 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function notifyByRecurContributionId($recurContributionId, $messageTemplateId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution($recurContributionId);
-    $messageTemplateTitle = CRM_ManualDirectDebit_Common_MessageTemplate::getMessageTemplateTitle($messageTemplateId);
-
-    return $this->sendEmail($dataCollector, $messageTemplateTitle);
+    return $this->sendEmail($dataCollector, $messageTemplateId);
   }
 
   /**
@@ -185,22 +186,19 @@ class CRM_ManualDirectDebit_Mail_Notification {
    */
   public function notifyByMandateId($mandateId, $messageTemplateId) {
     $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Mandate($mandateId);
-    $messageTemplateTitle = CRM_ManualDirectDebit_Common_MessageTemplate::getMessageTemplateTitle($messageTemplateId);
-
-    return $this->sendEmail($dataCollector, $messageTemplateTitle);
+    return $this->sendEmail($dataCollector, $messageTemplateId);
   }
 
   /**
    * Sends mail
    *
    * @param CRM_ManualDirectDebit_Mail_DataCollector_Base $collector
-   * @param $templateTitle
+   * @param $templateId
    *
    * @return bool
    *
    */
-  private function sendEmail($collector, $templateTitle) {
-    $templateId = CRM_ManualDirectDebit_Common_MessageTemplate::getMessageTemplateId($templateTitle);
+  private function sendEmail($collector, $templateId) {
     $tplParams = $collector->retrieve();
     $contactEmailData = $collector->retrieveContactEmailData();
 

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
@@ -4,169 +4,197 @@
 <body>
 <div style="color: black;">
 
-  {if isset($recurringContributionData) and $recurringContributionData}
-    <!-- Start of 1st section for custom text.  -->
-    <div>
-      <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-    </div>
-    <!-- End of 1st section for custom text.  -->
-
-    <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-    <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-      <tr style="border: 1px solid black;background: rgb(162,162,162)">
-        <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-        <th><p></p></th>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membershipData.membershipName}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-        <td style="padding-left: 10px;"><p></p></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating payment plan schedule information. -->
-  {/if}
-
-  <!-- if payment method = direct debit. -->
-  {if isset($mandateData) and $mandateData}
-
-    <!-- Start of 2nd section for custom text.  -->
-    <div style="max-width: 600px; width: 100%;" >
-      <p style="color: black;">
-        {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-      </p>
-    </div>
-    <!-- End of 2nd section for custom text.  -->
-
-    <!-- Start of code block for generating mandate information. Edit with caution. -->
-    <table>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating mandate information. -->
-  {/if}
-
-  {if isset($membershipData) and $membershipData}
-    <!-- Start of 3rd section for custom text.  -->
-    <div>
-      <p style="color: black;">
-        {ts}Your order contains the following membership(s):{/ts}
-      </p>
-    </div>
-    <!-- End of 3rd section for custom text.  -->
-
-    <!-- Start of code block for generating membership information. Edit with caution. -->
-    <div>
-      <p style="color: black;">
-        {ts 1=$membershipData.amountPerUnit 2=$membershipData.durationUnit 3=$currency }{$membershipData.membershipName} at %3%1 per %2.{/ts}
-      </p>
-    </div>
-    <!-- End of code block for generating membership information. -->
-
-    <!-- Start of code block for generating recurring contribution installments -->
-    {if $recurringContributionData.installments gt 0}
-      <p>You can find your installment schedule below:</p>
-      {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
-    {/if}
-    <!-- End of code block for generating recurring contribution installments -->
-
-    {if isset($nextMembershipPayment) and $nextMembershipPayment}
-      <!-- Start of 4th section for custom text.  -->
+    {if isset($recurringContributionData) and $recurringContributionData}
+      <!-- Start of 1st section for custom text.  -->
       <div>
-        <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 4th section for custom text.  -->
+      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating next contribution information. Edit with caution. -->
-      <div>
-        <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-      </div>
-      <!-- End of code block for generating next contribution information. -->
-    {/if}
-  {/if}
-
-  {if isset($mandateData) and $mandateData}
-    <!-- Start of Direct Debit Guarantee.  -->
-    <div style="padding-top: 60px">
-      <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-        <tr >
-          <th style="text-align: left; padding-left: 40px;">
-            <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-          </th>
-          <th>
-            <div style="margin-right: 10px;">
-              <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-            </div>
-          </th>
+      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+          <th><p></p></th>
         </tr>
-        <tr>
-          <td>
-            <ul>
-              <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-              <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-              <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-              <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-              <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-            </ul>
-          </td>
-          <td></td>
+
+      {foreach from=$orderLineItems item=lineItem}
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+        </tr>
+      {/foreach}
+
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        </tr>
+        <tr style="border: 1px solid black;">
+          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+          <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-    </div>
-    <!-- End of Direct Debit Guarantee.  -->
-  {/if}
+      <!-- End of code block for generating payment plan schedule information. -->
+    {/if}
+
+  <!-- if payment method = direct debit. -->
+    {if isset($mandateData) and $mandateData}
+
+      <!-- Start of 2nd section for custom text.  -->
+      <div style="max-width: 600px; width: 100%;" >
+        <p style="color: black;">
+            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+        </p>
+      </div>
+      <!-- End of 2nd section for custom text.  -->
+
+      <!-- Start of code block for generating mandate information. Edit with caution. -->
+      <table>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+        </tr>
+      </table>
+      <!-- End of code block for generating mandate information. -->
+    {/if}
+
+    {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
+      <!-- Start of 3rd section for custom text.  -->
+      <div>
+        <p style="color: black;">
+            {ts}Your order contains the following membership(s):{/ts}
+        </p>
+      </div>
+      <!-- End of 3rd section for custom text.  -->
+
+      <!-- Start of code block for generating membership information. Edit with caution. -->
+      {foreach from=$paymentPlanMemberships item=membership}
+      <div>
+        <p style="color: black;">
+            {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+        </p>
+      </div>
+      {/foreach}
+      <!-- End of code block for generating membership information. -->
+
+      <!-- Start of code block for generating recurring contribution installments -->
+        {if $recurringContributionData.installments gt 0}
+          <p>You can find your installment schedule below:</p>
+            {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
+        {/if}
+      <!-- End of code block for generating recurring contribution installments -->
+
+        {if isset($nextMembershipPayment) and $nextMembershipPayment}
+          <!-- Start of 4th section for custom text.  -->
+          <div>
+            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+          </div>
+          <!-- End of 4th section for custom text.  -->
+
+          <!-- Start of code block for generating next contribution information. Edit with caution. -->
+          <div>
+            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+          </div>
+          <!-- End of code block for generating next contribution information. -->
+        {/if}
+    {/if}
+
+    {if isset($activeMemberships) and $activeMemberships}
+      <div>
+        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+      </div>
+
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
+        </tr>
+
+          {foreach from=$activeMemberships item=membership}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            </tr>
+          {/foreach}
+      </table>
+    {/if}
+
+    {if isset($mandateData) and $mandateData}
+      <!-- Start of Direct Debit Guarantee.  -->
+      <div style="padding-top: 60px">
+        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+          <tr >
+            <th style="text-align: left; padding-left: 40px;">
+              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+            </th>
+            <th>
+              <div style="margin-right: 10px;">
+                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+              </div>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+              </ul>
+            </td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+      <!-- End of Direct Debit Guarantee.  -->
+    {/if}
 </div>
 </body>
 </html>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
@@ -5,13 +5,12 @@
 <div style="color: black;">
 
     {if isset($recurringContributionData) and $recurringContributionData}
-      <!-- Start of 1st section for custom text.  -->
+
       <div>
         <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+
       <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
         <tr style="border: 1px solid black;background: rgb(162,162,162)">
           <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
@@ -34,21 +33,16 @@
           <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-      <!-- End of code block for generating payment plan schedule information. -->
     {/if}
 
-  <!-- if payment method = direct debit. -->
     {if isset($mandateData) and $mandateData}
 
-      <!-- Start of 2nd section for custom text.  -->
       <div style="max-width: 600px; width: 100%;" >
         <p style="color: black;">
             {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
         </p>
       </div>
-      <!-- End of 2nd section for custom text.  -->
 
-      <!-- Start of code block for generating mandate information. Edit with caution. -->
       <table>
         <tr>
           <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
@@ -99,19 +93,15 @@
           <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
         </tr>
       </table>
-      <!-- End of code block for generating mandate information. -->
     {/if}
 
     {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
-      <!-- Start of 3rd section for custom text.  -->
       <div>
         <p style="color: black;">
             {ts}Your order contains the following membership(s):{/ts}
         </p>
       </div>
-      <!-- End of 3rd section for custom text.  -->
 
-      <!-- Start of code block for generating membership information. Edit with caution. -->
       {foreach from=$paymentPlanMemberships item=membership}
       <div>
         <p style="color: black;">
@@ -119,27 +109,20 @@
         </p>
       </div>
       {/foreach}
-      <!-- End of code block for generating membership information. -->
 
-      <!-- Start of code block for generating recurring contribution installments -->
         {if $recurringContributionData.installments gt 0}
           <p>You can find your installment schedule below:</p>
             {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
         {/if}
-      <!-- End of code block for generating recurring contribution installments -->
 
         {if isset($nextMembershipPayment) and $nextMembershipPayment}
-          <!-- Start of 4th section for custom text.  -->
           <div>
             <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
           </div>
-          <!-- End of 4th section for custom text.  -->
 
-          <!-- Start of code block for generating next contribution information. Edit with caution. -->
           <div>
             <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
           </div>
-          <!-- End of code block for generating next contribution information. -->
         {/if}
     {/if}
 
@@ -166,7 +149,6 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-      <!-- Start of Direct Debit Guarantee.  -->
       <div style="padding-top: 60px">
         <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
           <tr >
@@ -193,7 +175,6 @@
           </tr>
         </table>
       </div>
-      <!-- End of Direct Debit Guarantee.  -->
     {/if}
 </div>
 </body>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
@@ -4,169 +4,197 @@
 <body>
 <div style="color: black;">
 
-  {if isset($recurringContributionData) and $recurringContributionData}
-    <!-- Start of 1st section for custom text.  -->
-    <div>
-      <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-    </div>
-    <!-- End of 1st section for custom text.  -->
-
-    <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-    <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-      <tr style="border: 1px solid black;background: rgb(162,162,162)">
-        <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-        <th><p></p></th>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membershipData.membershipName}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-        <td style="padding-left: 10px;"><p></p></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating payment plan schedule information. -->
-  {/if}
-
-  <!-- if payment method = direct debit. -->
-  {if isset($mandateData) and $mandateData}
-
-    <!-- Start of 2nd section for custom text.  -->
-    <div style="max-width: 600px; width: 100%;" >
-      <p style="color: black;">
-        {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-      </p>
-    </div>
-    <!-- End of 2nd section for custom text.  -->
-
-    <!-- Start of code block for generating mandate information. Edit with caution. -->
-    <table>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating mandate information. -->
-  {/if}
-
-  {if isset($membershipData) and $membershipData}
-    <!-- Start of 3rd section for custom text.  -->
-    <div>
-      <p style="color: black;">
-        {ts}Your order contains the following membership(s):{/ts}
-      </p>
-    </div>
-    <!-- End of 3rd section for custom text.  -->
-
-    <!-- Start of code block for generating membership information. Edit with caution. -->
-    <div>
-      <p style="color: black;">
-        {ts 1=$membershipData.amountPerUnit 2=$membershipData.durationUnit 3=$currency }{$membershipData.membershipName} at %3%1 per %2.{/ts}
-      </p>
-    </div>
-    <!-- End of code block for generating membership information. -->
-
-    <!-- Start of code block for generating recurring contribution installments -->
-    {if $recurringContributionData.installments gt 0}
-      <p>You can find your installment schedule below:</p>
-      {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
-    {/if}
-    <!-- End of code block for generating recurring contribution installments -->
-
-    {if isset($nextMembershipPayment) and $nextMembershipPayment}
-      <!-- Start of 4th section for custom text.  -->
+    {if isset($recurringContributionData) and $recurringContributionData}
+      <!-- Start of 1st section for custom text.  -->
       <div>
-        <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 4th section for custom text.  -->
+      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating next contribution information. Edit with caution. -->
-      <div>
-        <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-      </div>
-      <!-- End of code block for generating next contribution information. -->
-    {/if}
-  {/if}
-
-  {if isset($mandateData) and $mandateData}
-    <!-- Start of Direct Debit Guarantee.  -->
-    <div style="padding-top: 60px">
-      <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-        <tr >
-          <th style="text-align: left; padding-left: 40px;">
-            <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-          </th>
-          <th>
-            <div style="margin-right: 10px;">
-              <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-            </div>
-          </th>
+      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+          <th><p></p></th>
         </tr>
-        <tr>
-          <td>
-            <ul>
-              <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-              <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-              <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-              <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-              <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-            </ul>
-          </td>
-          <td></td>
+
+          {foreach from=$orderLineItems item=lineItem}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+            </tr>
+          {/foreach}
+
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        </tr>
+        <tr style="border: 1px solid black;">
+          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+          <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-    </div>
-    <!-- End of Direct Debit Guarantee.  -->
-  {/if}
+      <!-- End of code block for generating payment plan schedule information. -->
+    {/if}
+
+  <!-- if payment method = direct debit. -->
+    {if isset($mandateData) and $mandateData}
+
+      <!-- Start of 2nd section for custom text.  -->
+      <div style="max-width: 600px; width: 100%;" >
+        <p style="color: black;">
+            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+        </p>
+      </div>
+      <!-- End of 2nd section for custom text.  -->
+
+      <!-- Start of code block for generating mandate information. Edit with caution. -->
+      <table>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+        </tr>
+      </table>
+      <!-- End of code block for generating mandate information. -->
+    {/if}
+
+    {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
+      <!-- Start of 3rd section for custom text.  -->
+      <div>
+        <p style="color: black;">
+            {ts}Your order contains the following membership(s):{/ts}
+        </p>
+      </div>
+      <!-- End of 3rd section for custom text.  -->
+
+      <!-- Start of code block for generating membership information. Edit with caution. -->
+        {foreach from=$paymentPlanMemberships item=membership}
+          <div>
+            <p style="color: black;">
+                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+            </p>
+          </div>
+        {/foreach}
+      <!-- End of code block for generating membership information. -->
+
+      <!-- Start of code block for generating recurring contribution installments -->
+        {if $recurringContributionData.installments gt 0}
+          <p>You can find your installment schedule below:</p>
+            {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
+        {/if}
+      <!-- End of code block for generating recurring contribution installments -->
+
+        {if isset($nextMembershipPayment) and $nextMembershipPayment}
+          <!-- Start of 4th section for custom text.  -->
+          <div>
+            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+          </div>
+          <!-- End of 4th section for custom text.  -->
+
+          <!-- Start of code block for generating next contribution information. Edit with caution. -->
+          <div>
+            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+          </div>
+          <!-- End of code block for generating next contribution information. -->
+        {/if}
+    {/if}
+
+    {if isset($activeMemberships) and $activeMemberships}
+      <div>
+        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+      </div>
+
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
+        </tr>
+
+          {foreach from=$activeMemberships item=membership}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            </tr>
+          {/foreach}
+      </table>
+    {/if}
+
+    {if isset($mandateData) and $mandateData}
+      <!-- Start of Direct Debit Guarantee.  -->
+      <div style="padding-top: 60px">
+        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+          <tr >
+            <th style="text-align: left; padding-left: 40px;">
+              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+            </th>
+            <th>
+              <div style="margin-right: 10px;">
+                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+              </div>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+              </ul>
+            </td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+      <!-- End of Direct Debit Guarantee.  -->
+    {/if}
 </div>
 </body>
 </html>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
@@ -5,195 +5,176 @@
 <div style="color: black;">
 
     {if isset($recurringContributionData) and $recurringContributionData}
-      <!-- Start of 1st section for custom text.  -->
-      <div>
-        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-      </div>
-      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-          <th><p></p></th>
-        </tr>
+        <div>
+            <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
+        </div>
 
-          {foreach from=$orderLineItems item=lineItem}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+                <th><p></p></th>
             </tr>
-          {/foreach}
 
-        <tr style="border: 1px solid black;">
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-        </tr>
-        <tr style="border: 1px solid black;">
-          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-          <td style="padding-left: 10px;"><p></p></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating payment plan schedule information. -->
+            {foreach from=$orderLineItems item=lineItem}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+                </tr>
+            {/foreach}
+
+            <tr style="border: 1px solid black;">
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+            </tr>
+            <tr style="border: 1px solid black;">
+                <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+                <td style="padding-left: 10px;"><p></p></td>
+            </tr>
+        </table>
     {/if}
 
-  <!-- if payment method = direct debit. -->
     {if isset($mandateData) and $mandateData}
 
-      <!-- Start of 2nd section for custom text.  -->
-      <div style="max-width: 600px; width: 100%;" >
-        <p style="color: black;">
-            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-        </p>
-      </div>
-      <!-- End of 2nd section for custom text.  -->
+        <div style="max-width: 600px; width: 100%;" >
+            <p style="color: black;">
+                {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+            </p>
+        </div>
 
-      <!-- Start of code block for generating mandate information. Edit with caution. -->
-      <table>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating mandate information. -->
+        <table>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+            </tr>
+        </table>
     {/if}
 
     {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
-      <!-- Start of 3rd section for custom text.  -->
-      <div>
-        <p style="color: black;">
-            {ts}Your order contains the following membership(s):{/ts}
-        </p>
-      </div>
-      <!-- End of 3rd section for custom text.  -->
-
-      <!-- Start of code block for generating membership information. Edit with caution. -->
-        {foreach from=$paymentPlanMemberships item=membership}
-          <div>
+        <div>
             <p style="color: black;">
-                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                {ts}Your order contains the following membership(s):{/ts}
             </p>
-          </div>
-        {/foreach}
-      <!-- End of code block for generating membership information. -->
+        </div>
 
-      <!-- Start of code block for generating recurring contribution installments -->
+        {foreach from=$paymentPlanMemberships item=membership}
+            <div>
+                <p style="color: black;">
+                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                </p>
+            </div>
+        {/foreach}
+
         {if $recurringContributionData.installments gt 0}
-          <p>You can find your installment schedule below:</p>
+            <p>You can find your installment schedule below:</p>
             {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
         {/if}
-      <!-- End of code block for generating recurring contribution installments -->
 
         {if isset($nextMembershipPayment) and $nextMembershipPayment}
-          <!-- Start of 4th section for custom text.  -->
-          <div>
-            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
-          </div>
-          <!-- End of 4th section for custom text.  -->
+            <div>
+                <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+            </div>
 
-          <!-- Start of code block for generating next contribution information. Edit with caution. -->
-          <div>
-            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-          </div>
-          <!-- End of code block for generating next contribution information. -->
+            <div>
+                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+            </div>
         {/if}
     {/if}
 
     {if isset($activeMemberships) and $activeMemberships}
-      <div>
-        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
-      </div>
+        <div>
+            <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+        </div>
 
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
-        </tr>
-
-          {foreach from=$activeMemberships item=membership}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
             </tr>
-          {/foreach}
-      </table>
+
+            {foreach from=$activeMemberships item=membership}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+                </tr>
+            {/foreach}
+        </table>
     {/if}
 
     {if isset($mandateData) and $mandateData}
-      <!-- Start of Direct Debit Guarantee.  -->
-      <div style="padding-top: 60px">
-        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-          <tr >
-            <th style="text-align: left; padding-left: 40px;">
-              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-            </th>
-            <th>
-              <div style="margin-right: 10px;">
-                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-              </div>
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-              </ul>
-            </td>
-            <td></td>
-          </tr>
-        </table>
-      </div>
-      <!-- End of Direct Debit Guarantee.  -->
+        <div style="padding-top: 60px">
+            <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+                <tr >
+                    <th style="text-align: left; padding-left: 40px;">
+                        <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+                    </th>
+                    <th>
+                        <div style="margin-right: 10px;">
+                            <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+                        </div>
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <ul>
+                            <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                            <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                            <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                            <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                            <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+                        </ul>
+                    </td>
+                    <td></td>
+                </tr>
+            </table>
+        </div>
     {/if}
 </div>
 </body>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
@@ -4,169 +4,197 @@
 <body>
 <div style="color: black;">
 
-  {if isset($recurringContributionData) and $recurringContributionData}
-    <!-- Start of 1st section for custom text.  -->
-    <div>
-      <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-    </div>
-    <!-- End of 1st section for custom text.  -->
-
-    <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-    <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-      <tr style="border: 1px solid black;background: rgb(162,162,162)">
-        <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-        <th><p></p></th>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membershipData.membershipName}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-        <td style="padding-left: 10px;"><p></p></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating payment plan schedule information. -->
-  {/if}
-
-  <!-- if payment method = direct debit. -->
-  {if isset($mandateData) and $mandateData}
-
-    <!-- Start of 2nd section for custom text.  -->
-    <div style="max-width: 600px; width: 100%;" >
-      <p style="color: black;">
-        {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-      </p>
-    </div>
-    <!-- End of 2nd section for custom text.  -->
-
-    <!-- Start of code block for generating mandate information. Edit with caution. -->
-    <table>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating mandate information. -->
-  {/if}
-
-  {if isset($membershipData) and $membershipData}
-    <!-- Start of 3rd section for custom text.  -->
-    <div>
-      <p style="color: black;">
-        {ts}Your order contains the following membership(s):{/ts}
-      </p>
-    </div>
-    <!-- End of 3rd section for custom text.  -->
-
-    <!-- Start of code block for generating membership information. Edit with caution. -->
-    <div>
-      <p style="color: black;">
-        {ts 1=$membershipData.amountPerUnit 2=$membershipData.durationUnit 3=$currency }{$membershipData.membershipName} at %3%1 per %2.{/ts}
-      </p>
-    </div>
-    <!-- End of code block for generating membership information. -->
-
-    <!-- Start of code block for generating recurring contribution installments -->
-    {if $recurringContributionData.installments gt 0}
-      <p>You can find your installment schedule below:</p>
-      {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
-    {/if}
-    <!-- End of code block for generating recurring contribution installments -->
-
-    {if isset($nextMembershipPayment) and $nextMembershipPayment}
-      <!-- Start of 4th section for custom text.  -->
+    {if isset($recurringContributionData) and $recurringContributionData}
+      <!-- Start of 1st section for custom text.  -->
       <div>
-        <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 4th section for custom text.  -->
+      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating next contribution information. Edit with caution. -->
-      <div>
-        <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-      </div>
-      <!-- End of code block for generating next contribution information. -->
-    {/if}
-  {/if}
-
-  {if isset($mandateData) and $mandateData}
-    <!-- Start of Direct Debit Guarantee.  -->
-    <div style="padding-top: 60px">
-      <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-        <tr >
-          <th style="text-align: left; padding-left: 40px;">
-            <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-          </th>
-          <th>
-            <div style="margin-right: 10px;">
-              <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-            </div>
-          </th>
+      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+          <th><p></p></th>
         </tr>
-        <tr>
-          <td>
-            <ul>
-              <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-              <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-              <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-              <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-              <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-            </ul>
-          </td>
-          <td></td>
+
+          {foreach from=$orderLineItems item=lineItem}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+            </tr>
+          {/foreach}
+
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        </tr>
+        <tr style="border: 1px solid black;">
+          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+          <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-    </div>
-    <!-- End of Direct Debit Guarantee.  -->
-  {/if}
+      <!-- End of code block for generating payment plan schedule information. -->
+    {/if}
+
+  <!-- if payment method = direct debit. -->
+    {if isset($mandateData) and $mandateData}
+
+      <!-- Start of 2nd section for custom text.  -->
+      <div style="max-width: 600px; width: 100%;" >
+        <p style="color: black;">
+            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+        </p>
+      </div>
+      <!-- End of 2nd section for custom text.  -->
+
+      <!-- Start of code block for generating mandate information. Edit with caution. -->
+      <table>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+        </tr>
+      </table>
+      <!-- End of code block for generating mandate information. -->
+    {/if}
+
+    {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
+      <!-- Start of 3rd section for custom text.  -->
+      <div>
+        <p style="color: black;">
+            {ts}Your order contains the following membership(s):{/ts}
+        </p>
+      </div>
+      <!-- End of 3rd section for custom text.  -->
+
+      <!-- Start of code block for generating membership information. Edit with caution. -->
+        {foreach from=$paymentPlanMemberships item=membership}
+          <div>
+            <p style="color: black;">
+                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+            </p>
+          </div>
+        {/foreach}
+      <!-- End of code block for generating membership information. -->
+
+      <!-- Start of code block for generating recurring contribution installments -->
+        {if $recurringContributionData.installments gt 0}
+          <p>You can find your installment schedule below:</p>
+            {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
+        {/if}
+      <!-- End of code block for generating recurring contribution installments -->
+
+        {if isset($nextMembershipPayment) and $nextMembershipPayment}
+          <!-- Start of 4th section for custom text.  -->
+          <div>
+            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+          </div>
+          <!-- End of 4th section for custom text.  -->
+
+          <!-- Start of code block for generating next contribution information. Edit with caution. -->
+          <div>
+            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+          </div>
+          <!-- End of code block for generating next contribution information. -->
+        {/if}
+    {/if}
+
+    {if isset($activeMemberships) and $activeMemberships}
+      <div>
+        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+      </div>
+
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
+        </tr>
+
+          {foreach from=$activeMemberships item=membership}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            </tr>
+          {/foreach}
+      </table>
+    {/if}
+
+    {if isset($mandateData) and $mandateData}
+      <!-- Start of Direct Debit Guarantee.  -->
+      <div style="padding-top: 60px">
+        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+          <tr >
+            <th style="text-align: left; padding-left: 40px;">
+              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+            </th>
+            <th>
+              <div style="margin-right: 10px;">
+                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+              </div>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+              </ul>
+            </td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+      <!-- End of Direct Debit Guarantee.  -->
+    {/if}
 </div>
 </body>
 </html>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -5,195 +5,176 @@
 <div style="color: black;">
 
     {if isset($recurringContributionData) and $recurringContributionData}
-      <!-- Start of 1st section for custom text.  -->
-      <div>
-        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-      </div>
-      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-          <th><p></p></th>
-        </tr>
+        <div>
+            <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
+        </div>
 
-          {foreach from=$orderLineItems item=lineItem}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+                <th><p></p></th>
             </tr>
-          {/foreach}
 
-        <tr style="border: 1px solid black;">
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-        </tr>
-        <tr style="border: 1px solid black;">
-          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-          <td style="padding-left: 10px;"><p></p></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating payment plan schedule information. -->
+            {foreach from=$orderLineItems item=lineItem}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+                </tr>
+            {/foreach}
+
+            <tr style="border: 1px solid black;">
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+            </tr>
+            <tr style="border: 1px solid black;">
+                <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+                <td style="padding-left: 10px;"><p></p></td>
+            </tr>
+        </table>
     {/if}
 
-  <!-- if payment method = direct debit. -->
     {if isset($mandateData) and $mandateData}
 
-      <!-- Start of 2nd section for custom text.  -->
-      <div style="max-width: 600px; width: 100%;" >
-        <p style="color: black;">
-            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-        </p>
-      </div>
-      <!-- End of 2nd section for custom text.  -->
+        <div style="max-width: 600px; width: 100%;" >
+            <p style="color: black;">
+                {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+            </p>
+        </div>
 
-      <!-- Start of code block for generating mandate information. Edit with caution. -->
-      <table>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating mandate information. -->
+        <table>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+            </tr>
+        </table>
     {/if}
 
     {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
-      <!-- Start of 3rd section for custom text.  -->
-      <div>
-        <p style="color: black;">
-            {ts}Your order contains the following membership(s):{/ts}
-        </p>
-      </div>
-      <!-- End of 3rd section for custom text.  -->
-
-      <!-- Start of code block for generating membership information. Edit with caution. -->
-        {foreach from=$paymentPlanMemberships item=membership}
-          <div>
+        <div>
             <p style="color: black;">
-                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                {ts}Your order contains the following membership(s):{/ts}
             </p>
-          </div>
-        {/foreach}
-      <!-- End of code block for generating membership information. -->
+        </div>
 
-      <!-- Start of code block for generating recurring contribution installments -->
+        {foreach from=$paymentPlanMemberships item=membership}
+            <div>
+                <p style="color: black;">
+                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                </p>
+            </div>
+        {/foreach}
+
         {if $recurringContributionData.installments gt 0}
-          <p>You can find your installment schedule below:</p>
+            <p>You can find your installment schedule below:</p>
             {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
         {/if}
-      <!-- End of code block for generating recurring contribution installments -->
 
         {if isset($nextMembershipPayment) and $nextMembershipPayment}
-          <!-- Start of 4th section for custom text.  -->
-          <div>
-            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
-          </div>
-          <!-- End of 4th section for custom text.  -->
+            <div>
+                <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+            </div>
 
-          <!-- Start of code block for generating next contribution information. Edit with caution. -->
-          <div>
-            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-          </div>
-          <!-- End of code block for generating next contribution information. -->
+            <div>
+                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+            </div>
         {/if}
     {/if}
 
     {if isset($activeMemberships) and $activeMemberships}
-      <div>
-        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
-      </div>
+        <div>
+            <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+        </div>
 
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
-        </tr>
-
-          {foreach from=$activeMemberships item=membership}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
             </tr>
-          {/foreach}
-      </table>
+
+            {foreach from=$activeMemberships item=membership}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+                </tr>
+            {/foreach}
+        </table>
     {/if}
 
     {if isset($mandateData) and $mandateData}
-      <!-- Start of Direct Debit Guarantee.  -->
-      <div style="padding-top: 60px">
-        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-          <tr >
-            <th style="text-align: left; padding-left: 40px;">
-              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-            </th>
-            <th>
-              <div style="margin-right: 10px;">
-                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-              </div>
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-              </ul>
-            </td>
-            <td></td>
-          </tr>
-        </table>
-      </div>
-      <!-- End of Direct Debit Guarantee.  -->
+        <div style="padding-top: 60px">
+            <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+                <tr >
+                    <th style="text-align: left; padding-left: 40px;">
+                        <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+                    </th>
+                    <th>
+                        <div style="margin-right: 10px;">
+                            <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+                        </div>
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <ul>
+                            <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                            <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                            <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                            <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                            <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+                        </ul>
+                    </td>
+                    <td></td>
+                </tr>
+            </table>
+        </div>
     {/if}
 </div>
 </body>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -4,169 +4,197 @@
 <body>
 <div style="color: black;">
 
-  {if isset($recurringContributionData) and $recurringContributionData}
-    <!-- Start of 1st section for custom text.  -->
-    <div>
-      <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-    </div>
-    <!-- End of 1st section for custom text.  -->
-
-    <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-    <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-      <tr style="border: 1px solid black;background: rgb(162,162,162)">
-        <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-        <th><p></p></th>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membershipData.membershipName}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-        <td style="padding-left: 10px;"><p></p></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating payment plan schedule information. -->
-  {/if}
-
-  <!-- if payment method = direct debit. -->
-  {if isset($mandateData) and $mandateData}
-
-    <!-- Start of 2nd section for custom text.  -->
-    <div style="max-width: 600px; width: 100%;" >
-      <p style="color: black;">
-        {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-      </p>
-    </div>
-    <!-- End of 2nd section for custom text.  -->
-
-    <!-- Start of code block for generating mandate information. Edit with caution. -->
-    <table>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating mandate information. -->
-  {/if}
-
-  {if isset($membershipData) and $membershipData}
-    <!-- Start of 3rd section for custom text.  -->
-    <div>
-      <p style="color: black;">
-        {ts}Your order contains the following membership(s):{/ts}
-      </p>
-    </div>
-    <!-- End of 3rd section for custom text.  -->
-
-    <!-- Start of code block for generating membership information. Edit with caution. -->
-    <div>
-      <p style="color: black;">
-        {ts 1=$membershipData.amountPerUnit 2=$membershipData.durationUnit 3=$currency }{$membershipData.membershipName} at %3%1 per %2.{/ts}
-      </p>
-    </div>
-    <!-- End of code block for generating membership information. -->
-
-    <!-- Start of code block for generating recurring contribution installments -->
-    {if $recurringContributionData.installments gt 0}
-      <p>You can find your installment schedule below:</p>
-      {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
-    {/if}
-    <!-- End of code block for generating recurring contribution installments -->
-
-    {if isset($nextMembershipPayment) and $nextMembershipPayment}
-      <!-- Start of 4th section for custom text.  -->
+    {if isset($recurringContributionData) and $recurringContributionData}
+      <!-- Start of 1st section for custom text.  -->
       <div>
-        <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 4th section for custom text.  -->
+      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating next contribution information. Edit with caution. -->
-      <div>
-        <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-      </div>
-      <!-- End of code block for generating next contribution information. -->
-    {/if}
-  {/if}
-
-  {if isset($mandateData) and $mandateData}
-    <!-- Start of Direct Debit Guarantee.  -->
-    <div style="padding-top: 60px">
-      <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-        <tr >
-          <th style="text-align: left; padding-left: 40px;">
-            <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-          </th>
-          <th>
-            <div style="margin-right: 10px;">
-              <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-            </div>
-          </th>
+      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+          <th><p></p></th>
         </tr>
-        <tr>
-          <td>
-            <ul>
-              <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-              <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-              <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-              <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-              <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-            </ul>
-          </td>
-          <td></td>
+
+          {foreach from=$orderLineItems item=lineItem}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+            </tr>
+          {/foreach}
+
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        </tr>
+        <tr style="border: 1px solid black;">
+          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+          <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-    </div>
-    <!-- End of Direct Debit Guarantee.  -->
-  {/if}
+      <!-- End of code block for generating payment plan schedule information. -->
+    {/if}
+
+  <!-- if payment method = direct debit. -->
+    {if isset($mandateData) and $mandateData}
+
+      <!-- Start of 2nd section for custom text.  -->
+      <div style="max-width: 600px; width: 100%;" >
+        <p style="color: black;">
+            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+        </p>
+      </div>
+      <!-- End of 2nd section for custom text.  -->
+
+      <!-- Start of code block for generating mandate information. Edit with caution. -->
+      <table>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+        </tr>
+      </table>
+      <!-- End of code block for generating mandate information. -->
+    {/if}
+
+    {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
+      <!-- Start of 3rd section for custom text.  -->
+      <div>
+        <p style="color: black;">
+            {ts}Your order contains the following membership(s):{/ts}
+        </p>
+      </div>
+      <!-- End of 3rd section for custom text.  -->
+
+      <!-- Start of code block for generating membership information. Edit with caution. -->
+        {foreach from=$paymentPlanMemberships item=membership}
+          <div>
+            <p style="color: black;">
+                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+            </p>
+          </div>
+        {/foreach}
+      <!-- End of code block for generating membership information. -->
+
+      <!-- Start of code block for generating recurring contribution installments -->
+        {if $recurringContributionData.installments gt 0}
+          <p>You can find your installment schedule below:</p>
+            {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
+        {/if}
+      <!-- End of code block for generating recurring contribution installments -->
+
+        {if isset($nextMembershipPayment) and $nextMembershipPayment}
+          <!-- Start of 4th section for custom text.  -->
+          <div>
+            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+          </div>
+          <!-- End of 4th section for custom text.  -->
+
+          <!-- Start of code block for generating next contribution information. Edit with caution. -->
+          <div>
+            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+          </div>
+          <!-- End of code block for generating next contribution information. -->
+        {/if}
+    {/if}
+
+    {if isset($activeMemberships) and $activeMemberships}
+      <div>
+        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+      </div>
+
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
+        </tr>
+
+          {foreach from=$activeMemberships item=membership}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            </tr>
+          {/foreach}
+      </table>
+    {/if}
+
+    {if isset($mandateData) and $mandateData}
+      <!-- Start of Direct Debit Guarantee.  -->
+      <div style="padding-top: 60px">
+        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+          <tr >
+            <th style="text-align: left; padding-left: 40px;">
+              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+            </th>
+            <th>
+              <div style="margin-right: 10px;">
+                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+              </div>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+              </ul>
+            </td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+      <!-- End of Direct Debit Guarantee.  -->
+    {/if}
 </div>
 </body>
 </html>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
@@ -5,195 +5,176 @@
 <div style="color: black;">
 
     {if isset($recurringContributionData) and $recurringContributionData}
-      <!-- Start of 1st section for custom text.  -->
-      <div>
-        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-      </div>
-      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-          <th><p></p></th>
-        </tr>
+        <div>
+            <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
+        </div>
 
-          {foreach from=$orderLineItems item=lineItem}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+                <th><p></p></th>
             </tr>
-          {/foreach}
 
-        <tr style="border: 1px solid black;">
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-        </tr>
-        <tr style="border: 1px solid black;">
-          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-          <td style="padding-left: 10px;"><p></p></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating payment plan schedule information. -->
+            {foreach from=$orderLineItems item=lineItem}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+                </tr>
+            {/foreach}
+
+            <tr style="border: 1px solid black;">
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+                <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+            </tr>
+            <tr style="border: 1px solid black;">
+                <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+                <td style="padding-left: 10px;"><p></p></td>
+            </tr>
+        </table>
     {/if}
 
-  <!-- if payment method = direct debit. -->
     {if isset($mandateData) and $mandateData}
 
-      <!-- Start of 2nd section for custom text.  -->
-      <div style="max-width: 600px; width: 100%;" >
-        <p style="color: black;">
-            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-        </p>
-      </div>
-      <!-- End of 2nd section for custom text.  -->
+        <div style="max-width: 600px; width: 100%;" >
+            <p style="color: black;">
+                {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+            </p>
+        </div>
 
-      <!-- Start of code block for generating mandate information. Edit with caution. -->
-      <table>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-        </tr>
-        <tr>
-          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-        </tr>
-      </table>
-      <!-- End of code block for generating mandate information. -->
+        <table>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+            </tr>
+            <tr>
+                <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+            </tr>
+        </table>
     {/if}
 
     {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
-      <!-- Start of 3rd section for custom text.  -->
-      <div>
-        <p style="color: black;">
-            {ts}Your order contains the following membership(s):{/ts}
-        </p>
-      </div>
-      <!-- End of 3rd section for custom text.  -->
-
-      <!-- Start of code block for generating membership information. Edit with caution. -->
-        {foreach from=$paymentPlanMemberships item=membership}
-          <div>
+        <div>
             <p style="color: black;">
-                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                {ts}Your order contains the following membership(s):{/ts}
             </p>
-          </div>
-        {/foreach}
-      <!-- End of code block for generating membership information. -->
+        </div>
 
-      <!-- Start of code block for generating recurring contribution installments -->
+        {foreach from=$paymentPlanMemberships item=membership}
+            <div>
+                <p style="color: black;">
+                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                </p>
+            </div>
+        {/foreach}
+
         {if $recurringContributionData.installments gt 0}
-          <p>You can find your installment schedule below:</p>
+            <p>You can find your installment schedule below:</p>
             {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
         {/if}
-      <!-- End of code block for generating recurring contribution installments -->
 
         {if isset($nextMembershipPayment) and $nextMembershipPayment}
-          <!-- Start of 4th section for custom text.  -->
-          <div>
-            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
-          </div>
-          <!-- End of 4th section for custom text.  -->
+            <div>
+                <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+            </div>
 
-          <!-- Start of code block for generating next contribution information. Edit with caution. -->
-          <div>
-            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-          </div>
-          <!-- End of code block for generating next contribution information. -->
+            <div>
+                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+            </div>
         {/if}
     {/if}
 
     {if isset($activeMemberships) and $activeMemberships}
-      <div>
-        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
-      </div>
+        <div>
+            <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+        </div>
 
-      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-        <tr style="border: 1px solid black;background: rgb(162,162,162)">
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
-          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
-        </tr>
-
-          {foreach from=$activeMemberships item=membership}
-            <tr style="border: 1px solid black;">
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
-              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+        <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+            <tr style="border: 1px solid black;background: rgb(162,162,162)">
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+                <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
             </tr>
-          {/foreach}
-      </table>
+
+            {foreach from=$activeMemberships item=membership}
+                <tr style="border: 1px solid black;">
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+                    <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+                </tr>
+            {/foreach}
+        </table>
     {/if}
 
     {if isset($mandateData) and $mandateData}
-      <!-- Start of Direct Debit Guarantee.  -->
-      <div style="padding-top: 60px">
-        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-          <tr >
-            <th style="text-align: left; padding-left: 40px;">
-              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-            </th>
-            <th>
-              <div style="margin-right: 10px;">
-                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-              </div>
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-              </ul>
-            </td>
-            <td></td>
-          </tr>
-        </table>
-      </div>
-      <!-- End of Direct Debit Guarantee.  -->
+        <div style="padding-top: 60px">
+            <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+                <tr >
+                    <th style="text-align: left; padding-left: 40px;">
+                        <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+                    </th>
+                    <th>
+                        <div style="margin-right: 10px;">
+                            <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+                        </div>
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <ul>
+                            <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                            <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                            <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                            <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                            <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+                        </ul>
+                    </td>
+                    <td></td>
+                </tr>
+            </table>
+        </div>
     {/if}
 </div>
 </body>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
@@ -4,169 +4,197 @@
 <body>
 <div style="color: black;">
 
-  {if isset($recurringContributionData) and $recurringContributionData}
-    <!-- Start of 1st section for custom text.  -->
-    <div>
-      <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
-    </div>
-    <!-- End of 1st section for custom text.  -->
-
-    <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
-    <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
-      <tr style="border: 1px solid black;background: rgb(162,162,162)">
-        <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
-        <th><p></p></th>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membershipData.membershipName}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
-      </tr>
-      <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
-        <td style="padding-left: 10px;"><p></p></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating payment plan schedule information. -->
-  {/if}
-
-  <!-- if payment method = direct debit. -->
-  {if isset($mandateData) and $mandateData}
-
-    <!-- Start of 2nd section for custom text.  -->
-    <div style="max-width: 600px; width: 100%;" >
-      <p style="color: black;">
-        {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
-      </p>
-    </div>
-    <!-- End of 2nd section for custom text.  -->
-
-    <!-- Start of code block for generating mandate information. Edit with caution. -->
-    <table>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
-      </tr>
-      <tr>
-        <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-        <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
-      </tr>
-    </table>
-    <!-- End of code block for generating mandate information. -->
-  {/if}
-
-  {if isset($membershipData) and $membershipData}
-    <!-- Start of 3rd section for custom text.  -->
-    <div>
-      <p style="color: black;">
-        {ts}Your order contains the following membership(s):{/ts}
-      </p>
-    </div>
-    <!-- End of 3rd section for custom text.  -->
-
-    <!-- Start of code block for generating membership information. Edit with caution. -->
-    <div>
-      <p style="color: black;">
-        {ts 1=$membershipData.amountPerUnit 2=$membershipData.durationUnit 3=$currency }{$membershipData.membershipName} at %3%1 per %2.{/ts}
-      </p>
-    </div>
-    <!-- End of code block for generating membership information. -->
-
-    <!-- Start of code block for generating recurring contribution installments -->
-    {if $recurringContributionData.installments gt 0}
-      <p>You can find your installment schedule below:</p>
-      {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
-    {/if}
-    <!-- End of code block for generating recurring contribution installments -->
-
-    {if isset($nextMembershipPayment) and $nextMembershipPayment}
-      <!-- Start of 4th section for custom text.  -->
+    {if isset($recurringContributionData) and $recurringContributionData}
+      <!-- Start of 1st section for custom text.  -->
       <div>
-        <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+        <p style="color: black;">{ts}Thank you for making a recurring contribution. Your payment details are:{/ts}</p>
       </div>
-      <!-- End of 4th section for custom text.  -->
+      <!-- End of 1st section for custom text.  -->
 
-      <!-- Start of code block for generating next contribution information. Edit with caution. -->
-      <div>
-        <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
-      </div>
-      <!-- End of code block for generating next contribution information. -->
-    {/if}
-  {/if}
-
-  {if isset($mandateData) and $mandateData}
-    <!-- Start of Direct Debit Guarantee.  -->
-    <div style="padding-top: 60px">
-      <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
-        <tr >
-          <th style="text-align: left; padding-left: 40px;">
-            <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
-          </th>
-          <th>
-            <div style="margin-right: 10px;">
-              <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
-            </div>
-          </th>
+      <!-- Start of code block for generating payment plan schedule information. Edit with caution. -->
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Order Summary{/ts}<strong></p></th>
+          <th><p></p></th>
         </tr>
-        <tr>
-          <td>
-            <ul>
-              <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
-              <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
-              <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
-              <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
-              <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
-            </ul>
-          </td>
-          <td></td>
+
+          {foreach from=$orderLineItems item=lineItem}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+            </tr>
+          {/foreach}
+
+        <tr style="border: 1px solid black;">
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
+          <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        </tr>
+        <tr style="border: 1px solid black;">
+          <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+          <td style="padding-left: 10px;"><p></p></td>
         </tr>
       </table>
-    </div>
-    <!-- End of Direct Debit Guarantee.  -->
-  {/if}
+      <!-- End of code block for generating payment plan schedule information. -->
+    {/if}
+
+  <!-- if payment method = direct debit. -->
+    {if isset($mandateData) and $mandateData}
+
+      <!-- Start of 2nd section for custom text.  -->
+      <div style="max-width: 600px; width: 100%;" >
+        <p style="color: black;">
+            {ts}Thank you for choosing Direct Debit. Please check that your Direct Debit details below are correct. If they are not, please contact us. If your Direct Debit details are correct, you need do nothing and your Direct Debit will be collected as stated.{/ts}
+        </p>
+      </div>
+      <!-- End of 2nd section for custom text.  -->
+
+      <!-- Start of code block for generating mandate information. Edit with caution. -->
+      <table>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Bank Street Address:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_street_address}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}City:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_city}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}County:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_county}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Postcode:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.bank_postcode}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Account Holder Name:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.account_holder_name}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}A/C Number:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.ac_number}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Sort Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.sort_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Code:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_code}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}DD Ref:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.dd_ref}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+        </tr>
+        <tr>
+          <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+        </tr>
+      </table>
+      <!-- End of code block for generating mandate information. -->
+    {/if}
+
+    {if isset($paymentPlanMemberships) and $paymentPlanMemberships}
+      <!-- Start of 3rd section for custom text.  -->
+      <div>
+        <p style="color: black;">
+            {ts}Your order contains the following membership(s):{/ts}
+        </p>
+      </div>
+      <!-- End of 3rd section for custom text.  -->
+
+      <!-- Start of code block for generating membership information. Edit with caution. -->
+        {foreach from=$paymentPlanMemberships item=membership}
+          <div>
+            <p style="color: black;">
+                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+            </p>
+          </div>
+        {/foreach}
+      <!-- End of code block for generating membership information. -->
+
+      <!-- Start of code block for generating recurring contribution installments -->
+        {if $recurringContributionData.installments gt 0}
+          <p>You can find your installment schedule below:</p>
+            {$recurringContributionData.recurringContributionRows.recurringInstallmentsTable nofilter}
+        {/if}
+      <!-- End of code block for generating recurring contribution installments -->
+
+        {if isset($nextMembershipPayment) and $nextMembershipPayment}
+          <!-- Start of 4th section for custom text.  -->
+          <div>
+            <p style="color: black;">{ts}Please find the details of you next payment below:{/ts}</p>
+          </div>
+          <!-- End of 4th section for custom text.  -->
+
+          <!-- Start of code block for generating next contribution information. Edit with caution. -->
+          <div>
+            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+          </div>
+          <!-- End of code block for generating next contribution information. -->
+        {/if}
+    {/if}
+
+    {if isset($activeMemberships) and $activeMemberships}
+      <div>
+        <p style="color: black;">{ts}You have the following active membership(s):{/ts}</p>
+      </div>
+
+      <table style="border-collapse: collapse;border: 1px solid black; max-width: 600px; width: 100%;">
+        <tr style="border: 1px solid black;background: rgb(162,162,162)">
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Membership Type{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}Start Date{/ts}<strong></p></th>
+          <th style="padding-left: 10px;text-align: left"><p style="color: black;"><strong>{ts}End Date{/ts}<strong></p></th>
+        </tr>
+
+          {foreach from=$activeMemberships item=membership}
+            <tr style="border: 1px solid black;">
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
+              <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            </tr>
+          {/foreach}
+      </table>
+    {/if}
+
+    {if isset($mandateData) and $mandateData}
+      <!-- Start of Direct Debit Guarantee.  -->
+      <div style="padding-top: 60px">
+        <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
+          <tr >
+            <th style="text-align: left; padding-left: 40px;">
+              <h3 style="color: black;">{ts}The Direct Debit Guarantee{/ts}</h3>
+            </th>
+            <th>
+              <div style="margin-right: 10px;">
+                <img src="{$directDebitImageSrc}" style="width:90px;height: auto;" alt="Direct Debit"/>
+              </div>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li style="color: black;">{ts}Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s{/ts}</li>
+                <li style="color: black;">{ts}Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.{/ts}</li>
+                <li style="color: black;">{ts}There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable.{/ts}</li>
+                <li style="color: black;">{ts}The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.{/ts}</li>
+                <li style="color: black;">{ts}Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy.{/ts}</li>
+              </ul>
+            </td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+      <!-- End of Direct Debit Guarantee.  -->
+    {/if}
 </div>
 </body>
 </html>

--- a/xml/DDTemplate_customgroup.xml
+++ b/xml/DDTemplate_customgroup.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+    <CustomGroups>
+        <CustomGroup>
+            <name>direct_debit_message_template</name>
+            <title>Direct Debit</title>
+            <extends>MessageTemplate</extends>
+            <style>Inline</style>
+            <collapse_display>1</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_direct_debit_message_template</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <is_reserved>0</is_reserved>
+            <is_public>1</is_public>
+        </CustomGroup>
+    </CustomGroups>
+    <CustomFields>
+        <CustomField>
+            <name>is_direct_debit_template</name>
+            <label>Is Direct Debit Template?</label>
+            <data_type>Boolean</data_type>
+            <html_type>Radio</html_type>
+            <default>0</default>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>0</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>is_direct_debit_template</column_name>
+            <custom_group_name>direct_debit_message_template</custom_group_name>
+            <in_selector>1</in_selector>
+        </CustomField>
+        <CustomField>
+            <name>template_machine_name</name>
+            <label>Template Machine Name</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>0</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>255</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>template_machine_name</column_name>
+            <custom_group_name>direct_debit_message_template</custom_group_name>
+            <in_selector>1</in_selector>
+        </CustomField>
+    </CustomFields>
+</CustomData>


### PR DESCRIPTION
The following improvements and fixes are done to  the DD message templates : 


- When the payment plan’s number of installment is less than 2 (null, 0, 1), the order summary is now showing only the last installment into calculation.

- When the payment plan’s number of installment is less than 2 (null, 0, 1), the payment schedule  is now showing only the last installment.

- Support for pricefields payments with more than one membership is added.

- New smarty variable is added that show all the current active memberships for the contact.


## Update 1
----------------------------------

A new custom group called **Direct Debit** is added to the **MessageTemplate** entity which contains two fields : 

1- is_direct_debit_template : if 1 then the template will be considered a direct debit template and it will processed by Direct debit smarty tokens processor class **CRM_ManualDirectDebit_Event_Listener_TokenRender**
2- template_machine_name : The machine name for the template which is now used in the code for the 5 default templates instead of the titles. This ensures that the template won't be send broken to the users if the email title get changed.