### PR TITLE
ASE-271: Ensure that all recur contributions get submitted  correctly for payment instruction batch

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -405,7 +405,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
           break;
 
         case 'dd_payments':
-          $dataForExport[$mandateItems['contribute_id']] = $mandateItem;
+          $dataForExport[$mandateItem['contribute_id']] = $mandateItem;
           break;
       }
     }


### PR DESCRIPTION
## Problem

When submitting a payment instruction patch for more than one recurring contribution, only one recurring contribution will be submitted.

## Solution
This was caused by a typo in a variable name inside getMandateCurrentState() method which is fixed and now the submission work correctly.