### PR TITLE
ASE-272: Implement Deletion of Mandates and Hide Account Number on Notifications

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -320,8 +320,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    *
    * @param $mandateID
    *
-   * @return boolean
-   *   True on success, false otw
+   * @throws \Exception
    */
   public function deleteMandate($mandateID) {
     $transaction = new CRM_Core_Transaction();

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -315,4 +315,41 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
     CRM_Core_DAO::executeQuery($query);
   }
 
+  /**
+   * Deletes mandate and all references to it.
+   *
+   * @param $mandateID
+   *
+   * @return boolean
+   *   True on success, false otw
+   */
+  public function deleteMandate($mandateID) {
+    $transaction = new CRM_Core_Transaction();
+
+    try {
+      $recurrMandateRef = new CRM_ManualDirectDebit_BAO_RecurrMandateRef();
+      $recurrMandateRef->mandate_id = $mandateID;
+      $recurrMandateRef->delete();
+
+      $query = '
+        DELETE FROM `civicrm_value_dd_information`
+        WHERE civicrm_value_dd_information.mandate_id = %1
+      ';
+      CRM_Core_DAO::executeQuery($query, [
+        1 => [$mandateID, 'Integer']
+      ]);
+
+      $dao = CRM_Core_BAO_CustomGroup::class;
+      $groupID = CRM_Core_DAO::getFieldValue($dao, 'direct_debit_mandate', 'id', 'name');
+      CRM_Core_BAO_CustomValue::deleteCustomValue($mandateID, $groupID);
+    } catch (Exception $e) {
+      $transaction->rollback();
+      $message = "An error occurred deleting mandate with id ({$mandateID}): " . $e->getMessage();
+
+      throw new Exception($message);
+    }
+
+    $transaction->commit();
+  }
+
 }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -146,12 +146,6 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     ]);
 
     while ($dao->fetch()) {
-      if (strlen($dao->ac_number) > 4) {
-        $accountNumber = str_repeat('*', strlen($dao->ac_number) - 4) . substr($dao->ac_number, -4);
-      } else {
-        $accountNumber = '****';
-      }
-
       $this->tplParams['mandateData'] = [
         'bank_name' => $dao->bank_name,
         'bank_street_address' => $dao->bank_street_address,
@@ -159,7 +153,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'bank_county' => $dao->bank_county,
         'bank_postcode' => $dao->bank_postcode,
         'account_holder_name' => $dao->account_holder_name,
-        'ac_number' => $accountNumber,
+        'ac_number' => $this->obfuscateAccountNumber($dao->ac_number),
         'sort_code' => $dao->sort_code,
         'dd_ref' => $dao->dd_ref,
         'dd_code' => $this->getDdCode($dao->dd_code),
@@ -167,6 +161,24 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'authorisation_date' => CRM_Utils_Date::customFormat($dao->authorisation_date, '%d/%m/%Y'),
       ];
     }
+  }
+
+  /**
+   * Replaces all but the last four charcters of the given number for '*'
+   * characters.
+   *
+   * @param string $accountNumber
+   *
+   * @return string
+   */
+  private function obfuscateAccountNumber($accountNumber) {
+    if (strlen($accountNumber) > 4) {
+      $accountNumber = str_repeat('*', strlen($accountNumber) - 4) . substr($accountNumber, -4);
+    } else {
+      $accountNumber = '****';
+    }
+
+    return $accountNumber;
   }
 
   /**

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -146,6 +146,12 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     ]);
 
     while ($dao->fetch()) {
+      if (strlen($dao->ac_number) > 4) {
+        $accountNumber = str_repeat('*', strlen($dao->ac_number) - 4) . substr($dao->ac_number, -4);
+      } else {
+        $accountNumber = '****';
+      }
+
       $this->tplParams['mandateData'] = [
         'bank_name' => $dao->bank_name,
         'bank_street_address' => $dao->bank_street_address,
@@ -153,7 +159,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'bank_county' => $dao->bank_county,
         'bank_postcode' => $dao->bank_postcode,
         'account_holder_name' => $dao->account_holder_name,
-        'ac_number' => $dao->ac_number,
+        'ac_number' => $accountNumber,
         'sort_code' => $dao->sort_code,
         'dd_ref' => $dao->dd_ref,
         'dd_code' => $this->getDdCode($dao->dd_code),

--- a/api/v3/ManualDirectDebit.php
+++ b/api/v3/ManualDirectDebit.php
@@ -11,3 +11,17 @@
 function civicrm_api3_manual_direct_debit_run($params) {
   return (new CRM_ManualDirectDebit_ScheduleJob_ReminderHandler())->init();
 }
+
+function civicrm_api3_manual_direct_debit_deletemandate($params) {
+  try {
+    $mandateManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandateManager->deleteMandate($params['mandate_id']);
+  } catch (Exception $e) {
+    return civicrm_api3_create_error($e->getMessage(), $params);
+  }
+
+  return civicrm_api3_create_success(
+    TRUE,
+    $params
+  );
+}


### PR DESCRIPTION
## Overview
We need to implement the option to delete mandates. Also, when sending notifications relate to direct debit mandates, the account number should be obfuscated, replacing all but the last 4 characters with asterisks.

## Before
The button to delete mandates was hidden. Account number sent on e-mail notifications was sent complete, posing obvious security risks.

## Solution
The button to delete is now shown and re-styled to match the edit button. Clicking it calls  new API action that deletes the mandate and all related records.

When data is collected from mandates to be used on DD notifications, account number is obfuscated by replacing all but the last 4 numbers to the '*' character.