### PR TITLE
DD-61: Fix payment batches pagination count

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -401,10 +401,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     //select
     $query->select(implode(' , ', $this->returnValues));
 
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
-    if ($batch->getBatchType() == 'instructions_batch') {
-      $query->distinct(TRUE);
-    }
+    $query->distinct(TRUE);
 
     foreach ($this->searchableFields as $k => $field) {
       if (isset($this->params[$k])) {


### PR DESCRIPTION
## Problem

1- Create a new payment batch with say 3 items
2-  Create new payment batch page
3- Then discard the payments batch
4- Creating a new payment batch with the 3 items above and check the no. of available payments now, it will 6 instead of 3.

![2018-10-17 11_45_10-](https://user-images.githubusercontent.com/6275540/47074146-b6dc1400-d1f1-11e8-979e-d420f047e295.png)


## Solution

I changed the query that used for both fetching the batch items as well as counting the items to return distinct items. It was only enforced on instruction batches before so I changed it to be applied for both instruction and payment batches.

![2018-10-17 11_45_31-](https://user-images.githubusercontent.com/6275540/47074157-b8a5d780-d1f1-11e8-9b86-7bbc547ee4dc.png)
