### PR TITLE
DD-61: Fix creating payment batch pagination count after discarding it

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -401,10 +401,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     //select
     $query->select(implode(' , ', $this->returnValues));
 
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
-    if ($batch->getBatchType() == 'instructions_batch') {
-      $query->distinct(TRUE);
-    }
+    $query->distinct(TRUE);
 
     foreach ($this->searchableFields as $k => $field) {
       if (isset($this->params[$k])) {


### PR DESCRIPTION
In this PR I reapplied the patch that I reverted here : https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/90

since after a call with Guanhuan he said that it might not correct for payment patches where a recurring contribution have more than one contribution in the past. I went through the code again and did some tests and validation and this fix is actually correct and won't cause any issues in such case. 
