### PR TITLE
DD-59: Ensure that the DD refernce field is hidden on add form

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -38,6 +38,10 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
   public function run() {
     if ($this->checkIfDirectDebitMandateInGroupTree()) {
       $this->hideSaveAndNewButton();
+
+      if ($this->isAddOperation()) {
+        $this->hideDdRef();
+      }
     }
 
     $this->checkRecurringContribution();
@@ -65,6 +69,25 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
     foreach ($buttonsGroup->_elements as $key => $button) {
       if ($button->_attributes['value'] == "Save and New") {
         unset($buttonsGroup->_elements[$key]);
+      }
+    }
+  }
+
+  private function isAddOperation() {
+    $mode = CRM_Utils_Request::retrieve('mode', 'String', $this->form);
+    return $mode === 'add';
+  }
+
+  /**
+   *  Hides 'DD ref' custom field
+   */
+  private function hideDdRef() {
+    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("dd_ref");
+    $ddRefElementNameId = $this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]['element_name'];
+    unset($this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]);
+    foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName){
+      if ($requiredFieldsName == $ddRefElementNameId){
+        unset($this->form->_required[$requiredFieldsId]);
       }
     }
   }


### PR DESCRIPTION
On this PR https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/81 , I make it available for users to edit the DD reference field per requirements . But it apparently  now also show the field even for all the mandate forms even the Add form, but this should not be the case since for adding mandate, the reference should be generated automatically. This PR fixes this so the DD reference field is hidden if we are adding a mandate.