### PR TITLE
DD-64: Implement Mandate Selection When Choosing Payment Method

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -107,6 +107,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
       CRM_Core_DAO::executeQuery($sqlInsertInDirectDebitMandate, $values);
 
       $mandateId = $this->getLastInsertedMandateId($currentContactId);
+      $this->launchCustomHook($currentContactId, $mandateValues);
     } catch (Exception $exception) {
       $transaction->rollback();
 
@@ -125,13 +126,13 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    */
   public function launchCustomHook($currentContactId, $mandateValues) {
     $directDebitMandateId = civicrm_api3('CustomGroup', 'getvalue', [
-      'return' => "id",
-      'name' => "direct_debit_mandate",
+      'return' => 'id',
+      'name' => 'direct_debit_mandate',
     ]);
 
     $mandateFields = civicrm_api3('CustomField', 'get', [
       'sequential' => 1,
-      'custom_group_id' => "direct_debit_mandate",
+      'custom_group_id' => 'direct_debit_mandate',
     ])['values'];
 
     foreach ($mandateFields as &$currentField) {
@@ -315,8 +316,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
 
     return $amountOfInstallments == $amountOfContributions ? TRUE : FALSE;
   }
-
-
+  
   /**
    * Changes mandate id for contribution
    *

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -83,6 +83,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
 
     $i = 0;
     foreach ($mandateValues as $key => $value) {
+      if (!isset($value)) {
+        continue;
+      }
+
       $columnName[] = $key;
       $valuesId[] = "%" . $i;
       $values[$i] = [
@@ -202,7 +206,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    *
    * @param $mandateId
    */
-  private function setMandateForCreatingDependency($mandateId) {
+  public function setMandateForCreatingDependency($mandateId) {
     $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
     $mandateContributionConnector->setMandateId($mandateId);
   }

--- a/CRM/ManualDirectDebit/Form/Mandate/Create.php
+++ b/CRM/ManualDirectDebit/Form/Mandate/Create.php
@@ -1,0 +1,244 @@
+<?php
+
+use CRM_ManualDirectDebit_ExtensionUtil as E;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_ManualDirectDebit_Form_Mandate_Create extends CRM_Core_Form {
+
+  /**
+   * List Of mandate custom group fields
+   *
+   * @var array
+   */
+  private $listOfDirectDebitMandateCustomGroupFields;
+
+  public function __construct($state = NULL, $action = CRM_Core_Action::NONE, $method = 'post', $name = NULL) {
+    parent::__construct($state, $action, $method, $name);
+
+    $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
+    $this->listOfDirectDebitMandateCustomGroupFields = $mandateDataProvider->getMandateCustomFieldNames();
+  }
+
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(E::ts('Create Mandate'));
+
+    $mandateDataProvider = new CRM_ManualDirectDebit_Common_DirectDebitDataProvider();
+    $mandateCustomGroupFieldData = $mandateDataProvider->getMandateCustomFieldDataForBuildingForm();
+
+    foreach ($mandateCustomGroupFieldData as $customField) {
+      $this->add(
+        $customField['html_type'],
+        $customField['name'],
+        $customField['label'],
+        $customField['option_group_id'],
+        $customField['is_required'],
+        $customField['params']
+      );
+
+      if ($customField['data_type'] == 'Int') {
+        $this->addRule($customField['name'], ts($customField['label'] . ' must be a number.'), 'numeric');
+      }
+    }
+
+    $minimumDaysToFirstPayment = $this->getMinimumDayForFirstPayment();
+    $this->assign('minimumDaysToFirstPayment', $minimumDaysToFirstPayment);
+
+    $directDebitPaymentInstrumentId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getDirectDebitPaymentInstrumentId();
+    $this->assign('directDebitPaymentInstrumentId', $directDebitPaymentInstrumentId);
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Save'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        'isDefault' => FALSE,
+      ],
+    ]);
+
+    // export form elements
+    $this->assign('elementNames', $this->getRenderableElementNames());
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    $contactID = CRM_Utils_Request::retrieve('contact_id', 'Int', $this);
+    $mandateValues = $this->extractMandateValues($contactID);
+
+    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandate = $storageManager->saveDirectDebitMandate($contactID, $mandateValues);
+
+    CRM_Core_Session::setStatus(
+      E::ts('Mandate created with reference number %1', [
+        1 => $mandate->dd_ref,
+      ]),
+      'Mandate Created',
+      'success'
+    );
+  }
+
+  /**
+   * Extracts mandates data from the provided values.
+   *
+   * @param int $contactID
+   *
+   * @return array
+   */
+  private function extractMandateValues($contactID) {
+    $mandateValues = [];
+    $submitFiles = $this->getVar('_submitFiles');
+    $authorisationFileName = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX . 'authorisation_file';
+    $authorisationFile = $submitFiles[$authorisationFileName];
+
+    if ($this->isFileAttached($authorisationFile)) {
+      $mandateValues['authorisation_file'] = $this->storeMandateFile($contactID, $authorisationFile);
+    }
+
+    $mandateValues['entity_id'] = $contactID;
+
+    $values = $this->exportValues();
+    foreach ($values as $field => $value) {
+      if ($this->isFieldIsPartOfDirectDebitCustomGroup($field) && $this->isValueNotEmpty($value)) {
+        $mandateValues[$this->getColumnName($field)] = $value;
+      }
+    }
+
+    return $mandateValues;
+  }
+
+  /**
+   * Checks if the `field` is a part of Direct Debit Mandate Custom Group
+   *
+   * @param string $fieldName
+   *
+   * @return bool
+   */
+  private function isFieldIsPartOfDirectDebitCustomGroup($fieldName) {
+    return in_array($fieldName, $this->listOfDirectDebitMandateCustomGroupFields);
+  }
+
+  /**
+   * Checks if `value` is not empty
+   *
+   * @param $value
+   *
+   * @return bool
+   */
+  private function isValueNotEmpty($value) {
+    return isset($value) && !empty($value);
+  }
+
+  /**
+   * Cleans 'fieldName' from prefix
+   *
+   * @param $fieldName
+   *
+   * @return string
+   */
+  private function getColumnName($fieldName) {
+    $columnName = '';
+
+    $fieldNamePrefix = substr($fieldName, 0, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
+    if ($fieldNamePrefix == CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX) {
+      $columnName = substr($fieldName, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
+    }
+
+    return $columnName;
+  }
+
+  /**
+   * Checks if 'directDebitMandate_authorisation_file' was added in mandate
+   *
+   * @param $submitFiles
+   *
+   * @return bool
+   */
+  private function isFileAttached($submitFiles) {
+    return !empty($submitFiles['tmp_name']);
+  }
+
+  /**
+   * Save file and assign its Id to mandate
+   *
+   * @param int $contactID
+   * @param array $file
+   *
+   * @return int
+   *
+   * @throws \Exception
+   */
+  private function storeMandateFile($contactID, $file) {
+    $transaction = new CRM_Core_Transaction();
+
+    try {
+      CRM_Core_BAO_File::filePostProcess(
+        $file['tmp_name'],
+        NULL,
+        CRM_ManualDirectDebit_Common_MandateStorageManager::DIRECT_DEBIT_TABLE_NAME,
+        $contactID,
+        NULL,
+        TRUE,
+        NULL,
+        'uploadedMandateFile',
+        $file['type']
+      );
+
+      $sqlSelectDebitMandateID = "SELECT MAX(id) as id FROM `civicrm_file`";
+      $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID);
+      $queryResult->fetch();
+    } catch (Exception $exception) {
+      $transaction->rollback();
+
+      throw $exception;
+    }
+
+    $transaction->commit();
+    if (isset($queryResult->id) && !empty($queryResult->id)) {
+      return $queryResult->id;
+    }
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames() {
+    $elementNames = array();
+
+    foreach ($this->_elements as $element) {
+      $label = $element->getLabel();
+
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+
+    return $elementNames;
+  }
+
+  /**
+   * Gets setting information about minimum days to first payment
+   *
+   * @return int
+   */
+  private function getMinimumDayForFirstPayment() {
+    try {
+      $minimumDaysToFirstPayment = CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
+    } catch (CiviCRM_API3_Exception $error) {
+      $minimumDaysToFirstPayment = 0;
+    }
+
+    return $minimumDaysToFirstPayment;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -64,6 +64,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
    * Adds select field to choose mandates.
    */
   private function addMandateSelectionField() {
+    $this->form->assign('paymentTypeLabel', ts('Direct Debit Mandate'));
     $templateVars = $this->form->get_template_vars();
 
     $paymentFields = $templateVars['paymentFields'];

--- a/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
@@ -53,7 +53,6 @@ class CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator {
 
   /**
    * Finds which of necessary fields have to be generated
-   *
    */
   public function generateMandateFieldsValues() {
     foreach ($this->savedFields as $field) {

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -56,6 +56,13 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     }
   }
 
+  public function saveMandateData() {
+    $mandateID = $this->form->getSubmitValue('mandate_id');
+
+    $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+    $mandateContributionConnector->setMandateId($mandateID);
+  }
+
   /**
    * Checks if payment option appropriate for creating mandate
    */

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Membership/DirectDebitMandate.php
@@ -9,7 +9,7 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
   /**
    * Form object that is being altered.
    *
-   * @var object
+   * @var \CRM_Member_Form
    */
   private $form;
 
@@ -34,7 +34,7 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
    */
   private $currentContactId;
 
-  public function __construct($form) {
+  public function __construct(CRM_Member_Form $form) {
     $this->form = $form;
     $this->currentContactId = $this->form->getVar('_contactID');
 
@@ -46,125 +46,14 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate {
    * Saves Direct Debit Mandate Data
    */
   public function saveMandateData() {
-    $this->setMandateValues();
+    $mandateID = $this->form->getSubmitValue('mandate_id');
 
     $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $storageManager->saveDirectDebitMandate($this->currentContactId, $this->mandateValues);
-  }
 
-  /**
-   * Sets direct debit mandate values
-   */
-  private function setMandateValues() {
-    $submitFiles = $this->form->getVar('_submitFiles');
-    $authorisationFileName = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX . 'authorisation_file';
-    $authorisationFile = $submitFiles[$authorisationFileName];
-    if ($this->isFileAttached($authorisationFile)) {
-      $this->setMandateFile($authorisationFile);
-    }
-
-    $this->setMandateContacId();
-
-    $submitValues = $this->form->getVar('_submitValues');
-
-    foreach ($submitValues as $field => $value) {
-      if ($this->isFieldIsPartOfDirectDebitCustomGroup($field) && $this->isValueNotEmpty($value)) {
-        $this->mandateValues[$this->getColumnName($field)] = $value;
-      }
-    }
-
-    unset($this->mandateValues['dd_ref']);
-  }
-
-  /**
-   * Checks if 'directDebitMandate_authorisation_file' was added in mandate
-   *
-   * @param $submitFiles
-   *
-   * @return bool
-   */
-  private function isFileAttached($submitFiles) {
-    return !empty($submitFiles['tmp_name']);
-  }
-
-  /**
-   * Save file and assign it Id to mandate
-   *
-   * @param $file
-   */
-  private function setMandateFile($file) {
-    $transaction = new CRM_Core_Transaction();
-
-    try {
-      CRM_Core_BAO_File::filePostProcess(
-        $file['tmp_name'],
-        NULL,
-        CRM_ManualDirectDebit_Common_MandateStorageManager::DIRECT_DEBIT_TABLE_NAME,
-        $this->currentContactId,
-        NULL,
-        TRUE,
-        NULL,
-        'uploadedMandateFile',
-        $file['type']
-      );
-
-      $sqlSelectDebitMandateID = "SELECT MAX(id) as id FROM `civicrm_file`";
-      $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID);
-      $queryResult->fetch();
-
-      if (isset($queryResult->id) && !empty($queryResult->id)) {
-        $this->mandateValues['authorisation_file'] = $queryResult->id;
-      }
-    } catch (Exception $exception) {
-      $transaction->rollback();
-      throw $exception;
-    }
-    $transaction->commit();
-  }
-
-  /**
-   * Sets contact id
-   */
-  private function setMandateContacId() {
-    $this->mandateValues['entity_id'] = $this->currentContactId;
-  }
-
-  /**
-   * Checks if the `field` is a part of Direct Debit Mandate Custom Group
-   *
-   * @param string $fieldName
-   *
-   * @return bool
-   */
-  private function isFieldIsPartOfDirectDebitCustomGroup($fieldName) {
-    return in_array($fieldName, $this->listOfDirectDebitMandateCustomGroupFields);
-  }
-
-  /**
-   * Checks if `value` is not empty
-   *
-   * @param $value
-   *
-   * @return bool
-   */
-  private function isValueNotEmpty($value) {
-    return isset($value) && !empty($value);
-  }
-
-  /**
-   * Cleans 'fieldName' from prefix
-   *
-   * @param $fieldName
-   *
-   * @return string
-   */
-  private function getColumnName($fieldName) {
-    $fieldNamePrefix = substr($fieldName, 0, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
-    if ($fieldNamePrefix == CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX) {
-      $columnName = substr($fieldName, strlen(CRM_ManualDirectDebit_Common_DirectDebitDataProvider::PREFIX));
-    }
-
-    return $columnName;
+    $mandate = $storageManager->getMandate($mandateID);
+    $mandateValues = $mandate->toArray();
+    $storageManager->assignMandate($mandateID, $this->currentContactId);
+    $storageManager->launchCustomHook($this->currentContactId, $mandateValues);
   }
 
 }

--- a/js/paymentMethodMandateSelection.js
+++ b/js/paymentMethodMandateSelection.js
@@ -1,0 +1,6 @@
+CRM.$(function ($) {
+  CRM.$('#contact_id').change(function () {
+    CRM.vars.coreForm.contact_id = CRM.$(this).val();
+    CRM.$('#payment_instrument_id').trigger('change.paymentBlock');
+  });
+});

--- a/manualdirectdebit.civix.php
+++ b/manualdirectdebit.civix.php
@@ -352,8 +352,10 @@ function _manualdirectdebit_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _manualdirectdebit_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -442,4 +444,17 @@ function _manualdirectdebit_civix_civicrm_alterSettingsFolders(&$metaDataFolders
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _manualdirectdebit_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+  ));
 }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -212,7 +212,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 
     case "CRM_Member_Form_Membership":
       if ($action == CRM_Core_Action::ADD) {
-        $paymentInstrumentId = $form->getVar('_submitValues') ['payment_instrument_id'];
+        $paymentInstrumentId = $form->getVar('_submitValues')['payment_instrument_id'];
         if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId)) {
           $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Membership_DirectDebitMandate($form);
           $manualDirectDebit->saveMandateData();
@@ -255,6 +255,11 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
   if (get_class($page) == 'CRM_Contact_Page_View_CustomData') {
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
+  }
+
+  if (get_class($page) == 'CRM_Member_Page_Tab') {
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/paymentMethodMandateSelection.js');
   }
 }
 
@@ -307,10 +312,12 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName === 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
-    $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup($form);
-    $formBuilder->buildForm();
-
     $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_Membership($form);
+    $formBuilder->buildForm();
+  }
+
+  if ($formName === 'CRM_Financial_Form_Payment') {
+    $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_Payment($form);
     $formBuilder->buildForm();
   }
 }

--- a/templates/CRM/ManualDirectDebit/Form/Mandate/Create.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Mandate/Create.tpl
@@ -1,0 +1,15 @@
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="top"}
+</div>
+
+{foreach from=$elementNames item=elementName}
+  <div class="crm-section">
+    <div class="label">{$form.$elementName.label}</div>
+    <div class="content">{$form.$elementName.html}</div>
+    <div class="clear"></div>
+  </div>
+{/foreach}
+
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/templates/CRM/ManualDirectDebit/Form/Payment.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Payment.tpl
@@ -1,0 +1,20 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function ($) {
+    CRM.$('#mandate_id').change(function () {
+      if ($(this).val() == 0) {
+        var formURL = CRM.url('civicrm/direct_debit/mandate/create', {
+          reset: 1,
+          contact_id: CRM.$('#contact_id').val(),
+        });
+        CRM.loadForm(formURL, {
+          dialog: {width: 600, height: 0}
+        }).on('crmFormSuccess', function () {
+          CRM.vars.coreForm.contact_id = CRM.$('#contact_id').val();
+          CRM.refreshParent('#mandate_id');
+        });
+      }
+    });
+  });
+  {/literal}
+</script>

--- a/templates/CRM/ManualDirectDebit/Form/Payment.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Payment.tpl
@@ -2,15 +2,18 @@
   {literal}
   CRM.$(function ($) {
     CRM.$('#mandate_id').change(function () {
+      if (typeof CRM.vars.coreForm.contact_id == 'undefined') {
+        CRM.vars.coreForm.contact_id = CRM.$('#contact_id').val();
+      }
+
       if ($(this).val() == 0) {
         var formURL = CRM.url('civicrm/direct_debit/mandate/create', {
           reset: 1,
-          contact_id: CRM.$('#contact_id').val(),
+          contact_id: CRM.vars.coreForm.contact_id,
         });
         CRM.loadForm(formURL, {
           dialog: {width: 600, height: 0}
         }).on('crmFormSuccess', function () {
-          CRM.vars.coreForm.contact_id = CRM.$('#contact_id').val();
           CRM.refreshParent('#mandate_id');
         });
       }

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -29,4 +29,10 @@
     <page_callback>CRM_ManualDirectDebit_Page_AJAX::export</page_callback>
     <weight>610</weight>
   </item>
+  <item>
+    <path>civicrm/direct_debit/mandate/create</path>
+    <page_callback>CRM_ManualDirectDebit_Form_Mandate_Create</page_callback>
+    <title>Mandate_Create</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
Currently on "New Membership" and "Renew Membership" forms, when Direct Debit is selected as the payment method, a mandate fieldset that allows admin to creating a new mandate, appears on the form. This does not happen on any other back-office payment recording pages.

Whenever Direct Debit is selected as the payment method, a dropdown list with the existing mandates of the contact should appear so admin can select one of the existing mandates or create a new mandate for the payment.

The mandate dropdown should list all existing mandates of a contact plus a "Create New..." option. All existing mandates options should be listed in the format of "MANDATE_REF - DD_CODE - A/C_NO - START_DATE".

## Before
Creation of a membership showed fields to create a mandate, when DD payment method was chosen. Other forms where payment method is chosen did not show the form.

![dd-64-before](https://user-images.githubusercontent.com/21999940/48210990-87c74700-e346-11e8-93ea-ba382b9cb2fa.gif)

## After
Added a hook on CRM_Financial_Form_Payment form, which is used by core CiviCRM payment methods to load fields particular to each method. This hook adds a select field with existing mandates for the contact. 

Also added option to create a new mandate from the select combo, which opens a modal form with
mandate creation fields and refreshes mandate select combo on submission, so the new mandate can be selected.

Refactored some of the original code that handled mandate creation into the new mandate creation form and out of membership creation post-processing.

The treatment for when a membership/contribution/event/etc is created differs if it is done from the contact or if it is done with a clean form and the contact is selected/created afterwards. This required some JS manipulation of the form so when the payment method is chosen to be DD, the contacct ID is known and can be used to obtain the mandates.

![dd-64-after](https://user-images.githubusercontent.com/21999940/48211007-91e94580-e346-11e8-978e-368794f68b30.gif)
