### PR TITLE
ASE-299: HOTFIX! Fix Mandate Creation with Start Date Different to Actual Date

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -125,7 +125,20 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
       'name' => "direct_debit_mandate",
     ]);
 
-    CRM_Utils_Hook::custom('update', $directDebitMandateId, $currentContactId, $mandateValues);
+    $mandateFields = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => "direct_debit_mandate",
+    ])['values'];
+
+    foreach ($mandateFields as &$currentField) {
+      if (isset($mandateValues[$currentField['column_name']])) {
+        $currentField['value'] = $mandateValues[$currentField['column_name']];
+      }
+    }
+
+    unset($currentField);
+
+    CRM_Utils_Hook::custom('update', $directDebitMandateId, $currentContactId, $mandateFields);
   }
 
   /**


### PR DESCRIPTION
## Overview
When signing up for membership with direct debit payment method and then if you choose the start date as another day (ie not today) and then save, the mandate is created with today as start date.

## Before
When creating a mandate, insertion into the database was done using a manual INSERT query, and then the civicrm_custom hook was launched so other mandate fields were generated. This hook requires a third parameter, which is a list of the fields and their values in a very specific format with all the fields'
meta data. This format was not being used when calling the hook.

## After
Fixed by replacing the simple [$field => $value] array with another built with the expected format.