### PR TITLE
DD-64: Implement Auto-selection of Created Mandate

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
@@ -67,7 +67,7 @@ class CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator {
       }
     }
 
-    if ($this->fieldsToGenerate['dd_ref'] == FALSE) {
+    if ($this->fieldsToGenerate['dd_ref'] == FALSE || $this->fieldsToGenerate['dd_ref'] == 'DD Ref') {
       $this->fieldsToGenerate['dd_ref'] = $this->generateDirectDebitReference();
     }
 


### PR DESCRIPTION
## Overview
When creating a mandate, its reference should be generated by the system by concatenating a prefix set by the admin with a consecutive number (the mandate's ID).

## Before
The reference was always set to "DD Ref" on the mandate creation form on a hidden field. This cause the mandate reference to not get generated from the prefix and the mandate id.

## After
Fixed so if the mandate corresponds to "DD Ref", it is overwritten by a string generated by the system.
