### PR TITLE
ASE-306: Log failed membership Ids instead of showing them in a notification

### DIFF
--- a/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
@@ -146,7 +146,7 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
 
     if (!empty($failedMembershipIds)) {
       $membershipIdsMessagePart = implode(', ', $failedMembershipIds);
-      CRM_Core_Session::setStatus('No Emails were sent for the membership(s) with the following Id(s):' . $membershipIdsMessagePart);
+      Civi::log()->warning('No Emails were sent for the membership(s) with the following Id(s):' . $membershipIdsMessagePart);
     }
 
   }

--- a/CRM/ManualDirectDebit/Mail/Task/PDFLetterCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/PDFLetterCommon.php
@@ -46,7 +46,7 @@ class CRM_ManualDirectDebit_Mail_Task_PDFLetterCommon extends CRM_Member_Form_Ta
 
     if (!empty($failedMembershipIds)) {
       $membershipIdsMessagePart = implode(', ', $failedMembershipIds);
-      CRM_Core_Session::setStatus('No Letters were generated for the membership(s) with the following Id(s):' . $membershipIdsMessagePart);
+      Civi::log()->warning('No Letters were generated for the membership(s) with the following Id(s):' . $membershipIdsMessagePart);
     }
 
     CRM_Utils_System::civiExit(1);


### PR DESCRIPTION
## Problem

When trying to export a Direct Debit PDF letters from "membership search" action, and if there is at least one membership that cannot be exported then a notification will appear with the following message : 

```
No Letters were generated for the membership(s) with the following Id(s): XXX-1, XXX-2 ..etc
```
But the problem is that since there is a file that will be downloaded, the notification will only appear after moving to different civicrm page or refreshing the same page manualy, and it is really hard to do a refresh for the page after downloading automatically without reworking major parts of how civicrm handles pdf exports.

## Solution

Instead of showing a notification, We now log the message to civicrm logs file,  and if "Enable Drupal Watchdog Logging" option is enabled, it will also show in drupal logs page.
