### PR TITLE
DD-64: Preload Selected Mandate on Recurring Contribution Edit Form

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -41,7 +41,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
    * Alters the form if direct debit was chosen as payment method.
    */
   public function buildForm() {
-    if (!$this->isDirectDebitPaymentInstrument($this->form->paymentInstrumentID)) {
+    if (!$this->form->paymentInstrumentID || !$this->isDirectDebitPaymentInstrument($this->form->paymentInstrumentID)) {
       return;
     }
 

--- a/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Implements hook on buildForm event of the UpdateSubscription form.
+ */
+class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
+
+  /**
+   * Form that is being built.
+   *
+   * @var CRM_Contribute_Form_UpdateSubscription
+   */
+  private $form;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription constructor.
+   *
+   * @param \CRM_Contribute_Form_UpdateSubscription $form
+   */
+  public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Implements buildForm hook.
+   */
+  public function buildForm() {
+    $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this->form);
+    CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $contactID));
+
+    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Positive', $this->form);
+    $selectedMandateID = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionID);
+
+    if ($selectedMandateID) {
+      CRM_Core_Resources::singleton()->addVars('coreForm', array('selected_mandate_id' => (int) $selectedMandateID));
+    }
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
@@ -25,9 +25,32 @@ class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
    * Implements buildForm hook.
    */
   public function buildForm() {
+    $this->addContactIDToCoreFormJSVariable();
+    $this->addMandateIDToCoreFormJSVariable();
+  }
+
+  /**
+   * On UpdateSubscription form, payment details are loaded in by an ajax call
+   * and sends the contact_id, if it is defined in CRM.coreForm.contact_id. If
+   * it's not defined, contact_id is determined by CiviCRM, defaulting to the
+   * current user. This contact ID is needed to obtain the list of mandates the
+   * contact has, and thus allow them to be selected in the form.
+   *
+   * This method sets the contact ID on the CRM.coreForm global variable, used
+   * by CiviCRM to make the call that loads the fields associated to the payment
+   * method.
+   */
+  private function addContactIDToCoreFormJSVariable() {
     $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this->form);
     CRM_Core_Resources::singleton()->addVars('coreForm', array('contact_id' => (int) $contactID));
+  }
 
+  /**
+   * Sets the mandate ID asociated to the recurring contribution as a global JS
+   * variable added to CRM.coreForm.selected_mandate_id, so it can be used to
+   * select the appropriate option on the selection box combo.
+   */
+  private function addMandateIDToCoreFormJSVariable() {
     $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Positive', $this->form);
     $selectedMandateID = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionID);
 

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -224,7 +224,6 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 
 /**
  * Implements hook_civicrm_pageRun().
- *
  */
 function manualdirectdebit_civicrm_pageRun(&$page) {
   switch(get_class($page)) {
@@ -313,6 +312,11 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
 
   if ($formName === 'CRM_Financial_Form_Payment') {
     $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_Payment($form);
+    $formBuilder->buildForm();
+  }
+
+  if ($formName === 'CRM_Contribute_Form_UpdateSubscription') {
+    $formBuilder = new CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription($form);
     $formBuilder->buildForm();
   }
 }

--- a/templates/CRM/ManualDirectDebit/Form/Payment.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Payment.tpl
@@ -18,6 +18,13 @@
         });
       }
     });
+
+    if (typeof CRM.vars.coreForm != 'undefined') {
+      if (typeof CRM.vars.coreForm.selected_mandate_id != 'undefined') {
+        var optionSelector = '#mandate_id option[value=' + CRM.vars.coreForm.selected_mandate_id + ']';
+        CRM.$(optionSelector).attr('selected', 'selected');
+      }
+    }
   });
   {/literal}
 </script>


### PR DESCRIPTION
## Overview
When editing a recurring contribution, you can see the selected payment method and change it. When the payment method used by a recurring contribution is Direct Debit, the mandate selection box is also loaded. However, the mandates box does not show the mandate that had been already associated to the recurring contribution.

## Before
Editing a recurring contribution with Direct Debit as a payment method loaded the mandate selection box, but was loading the box for the currently logged in user, instead of the contact that was being worked on.

![dd-64-mandate-preload-before](https://user-images.githubusercontent.com/21999940/50591874-b7cf2a00-0e5f-11e9-92a3-8843a16a3a20.gif)

## After
When the recurring contribution edit form is loaded, an ajax call is made to load the fields associated to the payment method that was chosen. This call sends the contact_id if it is set in CRM.vars.coreForm.contact_id. If it is not set, CiviCRM attempts to calculate the most reasonable contact id and set if for the form, which ended up being the currently logged contact, instead of the contact being edited.

This problem was fixed by setting CRM.vars.coreForm.contact_id with the current contact before the ajax call to bring in the payment method fields is made.

Added JS logic to determine the selected mandate's ID and use it to preselect the mandate in the selection box.

![dd-64-mandate-preload-after](https://user-images.githubusercontent.com/21999940/50591878-bf8ece80-0e5f-11e9-8874-684e07af7cfd.gif)
