### PR TITLE
DD-77: Ensure that the collection reminder get sent only once for each contribution

### DIFF
--- a/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
+++ b/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
@@ -1,0 +1,36 @@
+<?php
+
+class CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager {
+
+  public static function setIsNotificationSentToUnsent($contributionId) {
+    self::setIsNotificationSentValue($contributionId, 0);
+  }
+
+  public static function setIsNotificationSentToSent($contributionId) {
+    self::setIsNotificationSentValue($contributionId, 1);
+  }
+
+  private static function setIsNotificationSentValue($contributionId, $value) {
+    $isNotificationSentCustomFieldId = self::getIsNotificationSentCustomFieldId();
+    if ($isNotificationSentCustomFieldId) {
+      civicrm_api3('Contribution', 'create', [
+        'id' => $contributionId,
+        'custom_' . $isNotificationSentCustomFieldId => $value,
+      ]);
+    }
+  }
+
+
+  private static function getIsNotificationSentCustomFieldId() {
+    try {
+      return civicrm_api3('CustomField', 'getvalue', [
+        'return' => 'id',
+        'name' => 'is_notification_sent',
+      ]);
+    }
+    catch (CRM_Core_Exception $e) {
+      return NULL;
+    }
+  }
+
+}

--- a/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
+++ b/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
@@ -20,7 +20,6 @@ class CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager {
     }
   }
 
-
   private static function getIsNotificationSentCustomFieldId() {
     try {
       return civicrm_api3('CustomField', 'getvalue', [

--- a/CRM/ManualDirectDebit/Hook/Post/Contribution.php
+++ b/CRM/ManualDirectDebit/Hook/Post/Contribution.php
@@ -1,0 +1,21 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager as CollectionReminderSendFlagManager;
+
+class CRM_ManualDirectDebit_Hook_Post_Contribution {
+
+  private $contributionId;
+
+  public function __construct($contributionId) {
+    $this->contributionId = $contributionId;
+  }
+
+  public function process() {
+    $this->createCollectionReminderSendFlag();
+  }
+
+  private function createCollectionReminderSendFlag() {
+    CollectionReminderSendFlagManager::setIsNotificationSentToUnsent($this->contributionId);
+  }
+
+}

--- a/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager as CollectionReminderSendFlagManager;
+
 /**
  * Run reminder
  */
@@ -111,10 +113,15 @@ class CRM_ManualDirectDebit_ScheduleJob_Reminder {
 
     if ($result) {
       $this->setLog(ts("Email was sent."));
+      $this->updateNotificationSentFlag($contributionId);
     }
     else {
       $this->setLog(ts("Email was not sent."));
     }
+  }
+
+  private function updateNotificationSentFlag($contributionId) {
+    CollectionReminderSendFlagManager::setIsNotificationSentToSent($contributionId);
   }
 
 }

--- a/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
@@ -30,12 +30,15 @@ class CRM_ManualDirectDebit_ScheduleJob_TargetContribution {
         ) AS email
       FROM civicrm_contribution AS contribution
       LEFT JOIN civicrm_contact AS contact
-        ON contribution.contact_id = contact.id
+        ON contribution.contact_id = contact.id 
+      LEFT JOIN civicrm_value_direct_debit_collectionreminder_sendflag AS sendflag_customgroup 
+        ON sendflag_customgroup.entity_id = contribution.id 
       WHERE 
         contribution.receipt_date IS NULL
         AND contribution.payment_instrument_id = %2
         AND (contribution.contribution_status_id = %3 OR contribution.contribution_status_id = %4)
-        AND contribution.receive_date <= (now() - INTERVAL %1 DAY)
+        AND contribution.receive_date <= (now() - INTERVAL %1 DAY) 
+        AND sendflag_customgroup.is_notification_sent = 0 
     ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -136,6 +136,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->addMessageTemplateToCustomGroupEntities();
     $this->addDDTemplateCustomGroup();
     $this->addCollectionReminderFlagCustomGroup();
+    $this->createCollectionReminderFlagRecords();
     $this->createMessageTemplates();
     $this->createDirectDebitNavigationMenu();
     $this->createDirectDebitPaymentInstrument();
@@ -145,7 +146,15 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   public function upgrade_0010() {
     $this->addCollectionReminderFlagCustomGroup();
+    $this->createCollectionReminderFlagRecords();
     return TRUE;
+  }
+
+  private function createCollectionReminderFlagRecords() {
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag 
+      (entity_id, is_notification_sent) SELECT id,0 FROM civicrm_contribution
+      ");
   }
 
   public function upgrade_0009() {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -128,17 +128,24 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     "direct_debit_mandate",
     "direct_debit_information",
     "direct_debit_message_template",
+    "direct_debit_collection_reminder_sendflag"
   ];
 
   public function install() {
     $this->createScheduledJob();
     $this->addMessageTemplateToCustomGroupEntities();
     $this->addDDTemplateCustomGroup();
+    $this->addCollectionReminderFlagCustomGroup();
     $this->createMessageTemplates();
     $this->createDirectDebitNavigationMenu();
     $this->createDirectDebitPaymentInstrument();
     $this->createDirectDebitPaymentProcessorType();
     $this->createDirectDebitPaymentProcessor();
+  }
+
+  public function upgrade_0010() {
+    $this->addCollectionReminderFlagCustomGroup();
+    return TRUE;
   }
 
   public function upgrade_0009() {
@@ -176,7 +183,15 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   }
 
   private function addDDTemplateCustomGroup() {
-    $customGroupsXMLFile = E::path('xml/DDTemplate_customgroup.xml');
+    $this->importCustomGroupXML('DDTemplate_customgroup.xml');
+  }
+
+  private function addCollectionReminderFlagCustomGroup() {
+    $this->importCustomGroupXML('collectionReminderSendFlag_customgroup.xml');
+  }
+
+  private function importCustomGroupXML($fileName) {
+    $customGroupsXMLFile = E::path('xml/' . $fileName);
     $import = new CRM_Utils_Migrate_Import();
     $import->run($customGroupsXMLFile);
   }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -284,6 +284,16 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
 }
 
 /**
+ * Implements hook_civicrm_post.
+ */
+function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  if ($op == 'create' && $objectName == 'Contribution') {
+    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
+    $postContributionHook->process();
+  }
+}
+
+/**
  * Implements hook_civicrm_buildForm()
  */
 function manualdirectdebit_civicrm_buildForm($formName, &$form) {

--- a/xml/collectionReminderSendFlag_customgroup.xml
+++ b/xml/collectionReminderSendFlag_customgroup.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+    <CustomGroups>
+        <CustomGroup>
+            <name>direct_debit_collection_reminder_sendflag</name>
+            <title>Collection Reminder Send Flag</title>
+            <extends>Contribution</extends>
+            <style>Inline</style>
+            <collapse_display>1</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_direct_debit_collectionreminder_sendflag</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <is_reserved>0</is_reserved>
+            <is_public>1</is_public>
+        </CustomGroup>
+    </CustomGroups>
+    <CustomFields>
+        <CustomField>
+            <name>is_notification_sent</name>
+            <label>Is Collection Reminder Notification sent ?</label>
+            <data_type>Boolean</data_type>
+            <html_type>Radio</html_type>
+            <default>0</default>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>is_notification_sent</column_name>
+            <custom_group_name>direct_debit_collection_reminder_sendflag</custom_group_name>
+            <in_selector>1</in_selector>
+        </CustomField>
+    </CustomFields>
+</CustomData>


### PR DESCRIPTION
## Problem

Every time the "Send Direct Debit Payment Collection Reminders" job is executed, it will find any contribution that meets all criteria below:

- Payment Method is Direct Debit
- Contribution Status is Pending or Cancelled
- Receipt Date is empty
- "Received Date" minus "Days in advance for Collection Reminder" is equal to or smaller than today.

 And send an email for the contact which matches the criteria above every time the scheduled job runs, Which will result in keep sending the same email over and over to the same contact each time the job runs .

## Solution

I added a new contribution custom group called "Collection Reminder Send Flag" which contains a single Boolean field called "Is Collection Reminder Notification sent ?".

Whenever a contribution is now created, the field will be set to False (0) , and once the email is sent it will be set to True (1), I also altered the query that fetch the contributions for collection reminder so only the ones with  the flag set to False (0) will be fetched. 

Also an upgrader that set "Is Collection Reminder Notification sent ?" default value for existing  contributions  is added.