### PR TITLE
DD-77: Ensuring that collection reminders get send before the configured day and not after

### DIFF
--- a/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
@@ -37,7 +37,7 @@ class CRM_ManualDirectDebit_ScheduleJob_TargetContribution {
         contribution.receipt_date IS NULL
         AND contribution.payment_instrument_id = %2
         AND (contribution.contribution_status_id = %3 OR contribution.contribution_status_id = %4)
-        AND contribution.receive_date <= (now() - INTERVAL %1 DAY) 
+        AND (DATE(contribution.receive_date) - INTERVAL %1 DAY) <= CURDATE() 
         AND sendflag_customgroup.is_notification_sent = 0 
     ";
 


### PR DESCRIPTION
## Problem

Suppose we have the following scenario : 

```
today date is : 24/5/2019

There are 4 contribution with the following 
receive dates : 

1- 24/6/2019
2- 24/7/2019
3- 24/8/2019
4- 24/9/2019

If "Days in advance for Collection Reminder " is configured to be 10 days, then the contact must receive an email for every contribution above at the following dates  respectively : 

1- 14/6/2019-10
2- 14/7/2019-10
3- 14/8/2019-10
4- 14/9/2019-10
```

but that was not the case, the current code was sending them in the eample above 10 days after the received date and not before.

## Solution

I altered the query that fetch the list of collection reminder contirbution to match the correct condition which is : 

```
Contribution "receive date" Minus  "Days in advance for Collection Reminder" is less or Equal today date.
```