### PR TITLE
DD-72: Refining logics on newly added contribution filters.

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -127,8 +127,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       ts('Amount'),
       ts('Reference Number'),
       ts('Transaction Type'),
-      ts('Receive Date'),
     ];
+
+    if($this->getBatchType() == 'dd_payments') {
+      $headers[] = ts('Receive Date');
+    }
 
     $fileName = 'Batch_' . $this->batchID . '_' . date('YmdHis') . '.csv';
     CRM_Utils_System::setHttpHeader('Content-Type', 'text/plain');
@@ -348,8 +351,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
         'amount' => 'IF(civicrm_contribution.net_amount IS NOT NULL, civicrm_contribution.net_amount , 0.00) as amount',
         'reference_number' => CRM_ManualDirectDebit_Batch_Transaction::DD_MANDATE_TABLE . '.dd_ref as reference_number',
         'transaction_type' => 'CONCAT("\t",civicrm_option_value.label) as transaction_type',
-        'receive_date' => 'civicrm_contribution.receive_date as receive_date',
       ];
+
+      if($this->getBatchType() == 'dd_payments') {
+        $returnValues['receive_date'] = 'civicrm_contribution.receive_date as receive_date';
+      }
 
       $dataForExport = $this->getMandateCurrentState($returnValues);
     }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -235,7 +235,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setColumnHeader($columnHeader = []) {
-
+    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
     if (empty($columnHeader)) {
       $columnHeader = [
         'contact_id' => ts('ID'),
@@ -245,9 +245,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'amount' => ts('Amount'),
         'reference_number' => ts('Reference Number'),
         'transaction_type' => ts('Transaction Type'),
-        'receive_date' => ts('Receive Date'),
       ];
 
+      if($batch->getBatchType() == 'dd_payments') {
+        $columnHeader['receive_date'] = ts('Receive Date');
+      }
     }
 
     $this->columnHeader = $columnHeader;
@@ -263,6 +265,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setReturnValues($returnValues = []) {
+    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
     if (empty($returnValues) || !is_array($returnValues)) {
       $returnValues = [
         'id' => $this->params['entityTable'] . '.id as id',
@@ -274,8 +277,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'amount' => 'IF(civicrm_contribution.net_amount IS NOT NULL, civicrm_contribution.net_amount , 0.00) as amount',
         'reference_number' => self::DD_MANDATE_TABLE . '.dd_ref as reference_number',
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
-        'receive_date' => 'civicrm_contribution.receive_date as receive_date',
       ];
+
+      if($batch->getBatchType() == 'dd_payments') {
+        $returnValues['receive_date'] = 'civicrm_contribution.receive_date as receive_date';
+      }
     }
 
     $this->returnValues = $returnValues;

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -255,10 +255,10 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form {
         'amount' => 'IF(civicrm_contribution.net_amount IS NOT NULL, civicrm_contribution.net_amount , 0.00) as amount',
         'reference_number' => CRM_ManualDirectDebit_Batch_Transaction::DD_MANDATE_TABLE . '.dd_ref as reference_number',
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
-        'receive_date' => 'civicrm_contribution.receive_date as receive_date',
       ];
 
       if ($batchHandles->getBatchType() == 'dd_payments'){
+        $returnValues['receive_date'] = 'civicrm_contribution.receive_date as receive_date';
         $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       };
       $mandateCurrentState['values']['mandates'] = $batchHandles->getMandateCurrentState($returnValues);

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -20,7 +20,6 @@ class CRM_ManualDirectDebit_Page_AJAX {
       5 => 'amount',
       6 => 'reference_number',
       7 => 'transaction_type',
-      8 => 'receive_date',
     ];
 
     $sEcho = CRM_Utils_Request::retrieveValue('sEcho', 'Integer');
@@ -31,6 +30,11 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $entityID = CRM_Utils_Request::retrieveValue('entityID', 'String', NULL);
     $entityTable = CRM_Utils_Request::retrieveValue('entityTable', 'String', NULL);
     $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
+
+    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($entityID));
+    if($batch->getBatchType() == 'dd_payments') {
+      $sortMapper[] = 'receive_date';
+    }
 
     $sort = CRM_Utils_Array::value(CRM_Utils_Request::retrieveValue('iSortCol_0', 'Integer', NULL), $sortMapper);
     $sortOrder = CRM_Utils_Request::retrieveValue('sSortDir_0', 'String', 'asc');
@@ -67,9 +71,12 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'amount',
       'reference_number',
       'transaction_type',
-      'receive_date',
-      'action',
     ];
+
+    if($batch->getBatchType() == 'dd_payments') {
+      $selectorElements[] = 'receive_date';
+    }
+    $selectorElements[] = 'action';
 
     if ($return) {
       return CRM_Utils_JSON::encodeDataTableSelector($mandateItems, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -404,8 +404,15 @@ function contactRecurContribution(recId, cid) {
 function setDefaultFilterValues() {
   // Payment method
   // Allow 'Direct debit' option only.
-  cj('#contribution_payment_instrument_id').select2('val', [6]);
-  cj('#contribution_payment_instrument_id').select2().enable(false);
+  CRM.api3('OptionValue', 'getsingle', {
+    "return": ["value"],
+    "name": "direct_debit",
+    "option_group_id": "payment_instrument"
+  }).done(function(result) {
+    cj('#contribution_payment_instrument_id').select2('val', [result.value]);
+    cj('#contribution_payment_instrument_id').select2().enable(false);
+  });
+
 
   // Contribution Status
   // Allow 'Pending' and 'Cancelled' options only.

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -211,24 +211,26 @@ function buildTransactionSelectorAssign(filterSearch) {
     var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}None found.{/ts}{literal}</li></ul></div>';
   }
 
+  var columns = [
+    {sClass:'crm-transaction-checkbox', bSortable:false, mData: "check"},
+    {sClass:'crm-contact-id', bSortable:false, mData: "contact_id"},
+    {sClass:'crm-name', mData: "name"},
+    {sClass:'crm-sort-code', mData: "sort_code"},
+    {sClass:'crm-account-number', mData: "account_number"},
+    {sClass:'crm-amount', mData: "amount"},
+    {sClass:'crm-reference-number', mData: "reference_number"},
+    {sClass:'crm-transaction-type', mData: "transaction_type"},
+    ('{/literal}{$showReceiveDateColumn}{literal}' ? {sClass:'crm-receive-date', mData: "receive_date"} : undefined),
+    {sClass:'crm-action', mData: "action"},
+  ].filter(Boolean);
+
   var crmBatchSelector = CRM.$('#crm-transaction-selector-assign-{/literal}{$entityID}{literal}').dataTable({
     "bDestroy"   : true,
     "bFilter"    : false,
     "bAutoWidth" : false,
     "lengthMenu": [ 10, 25, 50, 100, 250, 500, 1000, 2000 ],
     "aaSorting"  : [],
-    "aoColumns"  : [
-      {sClass:'crm-transaction-checkbox', bSortable:false, mData: "check"},
-      {sClass:'crm-contact-id', bSortable:false, mData: "contact_id"},
-      {sClass:'crm-name', mData: "name"},
-      {sClass:'crm-sort-code', mData: "sort_code"},
-      {sClass:'crm-account-number', mData: "account_number"},
-      {sClass:'crm-amount', mData: "amount"},
-      {sClass:'crm-reference-number', mData: "reference_number"},
-      {sClass:'crm-transaction-type', mData: "transaction_type"},
-      {sClass:'crm-receive-date', mData: "receive_date"},
-      {sClass:'crm-action', mData: "action"}
-    ],
+    "aoColumns"  : columns,
     "bProcessing": true,
     "asStripClasses" : [ "odd-row", "even-row" ],
     "sPaginationType": "full_numbers",
@@ -289,23 +291,25 @@ function buildTransactionSelectorAssign(filterSearch) {
 function buildTransactionSelectorRemove( ) {
   var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=getInstructionTransactionsList&snippet=4&context=financialBatch&entityID=$entityID&entityTable=$entityTable&statusID=$statusID"}'{literal};
 
+  var columns = [
+    {/literal} {if in_array($batchStatus, array('Open', 'Reopened')) && $action eq 2}{literal} {sClass:'crm-transaction-checkbox', bSortable:false, mData: "check"}, {/literal}{/if}{literal}
+    {sClass:'crm-contact-id', bSortable:false, mData: "contact_id"},
+    {sClass:'crm-name', mData: "name"},
+    {sClass:'crm-sort-code', mData: "sort_code"},
+    {sClass:'crm-account-number', mData: "account_number"},
+    {sClass:'crm-amount', mData: "amount"},
+    {sClass:'crm-reference-number', mData: "reference_number"},
+    {sClass:'crm-transaction-type', mData: "transaction_type"},
+    ('{/literal}{$showReceiveDateColumn}{literal}' ? {sClass:'crm-receive-date', mData: "receive_date"} : undefined),
+    {sClass:'action', mData: "action"}
+  ].filter(Boolean);
+
   var crmBatchSelector = CRM.$('#crm-transaction-selector-remove-{/literal}{$entityID}{literal}').dataTable({
     "bDestroy"   : true,
     "bFilter"    : false,
     "bAutoWidth" : false,
     "aaSorting"  : [],
-    "aoColumns"  : [
-      {/literal} {if in_array($batchStatus, array('Open', 'Reopened')) && $action eq 2}{literal} {sClass:'crm-transaction-checkbox', bSortable:false, mData: "check"}, {/literal}{/if}{literal}
-      {sClass:'crm-contact-id', bSortable:false, mData: "contact_id"},
-      {sClass:'crm-name', mData: "name"},
-      {sClass:'crm-sort-code', mData: "sort_code"},
-      {sClass:'crm-account-number', mData: "account_number"},
-      {sClass:'crm-amount', mData: "amount"},
-      {sClass:'crm-reference-number', mData: "reference_number"},
-      {sClass:'crm-transaction-type', mData: "transaction_type"},
-      {sClass:'crm-receive-date', mData: "receive_date"},
-      {sClass:'action', mData: "action"}
-    ],
+    "aoColumns"  : columns,
     "bProcessing": true,
     "asStripClasses" : [ "odd-row", "even-row" ],
     "sPaginationType": "full_numbers",

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -413,20 +413,18 @@ function setDefaultFilterValues() {
     cj('#contribution_payment_instrument_id').select2().enable(false);
   });
 
-
   // Contribution Status
   // Allow 'Pending' and 'Cancelled' options only.
   cj('#contribution_status_id').select2('val', [2, 3]);
   cj('#contribution_status_id').select2().enable(false);
 
   // Date received
-  // Set 'choose date range' and default option and disable the field.
-  cj('#contribution_date_relative').select2('val', [0]);
-  cj('#contribution_date_relative').trigger('change');
-  cj('#contribution_date_relative').select2().enable(false);
-  // Donot allow user to choose future dates.
-  cj('.hasDatepicker').datepicker('option', 'maxDate', '0');
-  cj('#contribution_date_high').next().datepicker('setDate', new Date());
+  // set default end date to today's date if user chooses "Choose date range" option.
+  cj('#contribution_date_relative').on('change.select2', function(e){
+    if(e.val == 0) {
+      cj('#contribution_date_high').next().datepicker('setDate', new Date());
+    }
+  });
 
   // Contribution Recur Status
   // Set all options except 'Cancelled'.


### PR DESCRIPTION
**Overview**
This PR solves a few issues regarding contribution filters and receive date column on direct debit batch pages.

**DD-72: Fetch direct_debit option value dynamically** 
Earlier, it was a bad idea to use static option value for the option generate by an extension. It selected a different payment method on the dev site because the option values where different. This commit sorts that out.

**DD-72: Set end date to today's date only when user chooses 'Choose Date Range' option**
We are now allowing all date options for the filters.

**DD-72: Only Add receive column for dd payments batch page 
DD-72: Only add receive_date for dd_payments batch types**
"Received date" columns is now visible only on dd payment create page and not on instructions page.