### PR TITLE
ASESPRT-119: Prevent contribution date from updating when editing dd mandate

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -263,12 +263,12 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
  */
 function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
   if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
-    if ($op == 'create' || $op == 'edit') {
+    if ($op == 'create') {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->runDataGeneration();
     }
 
-    if ($op == 'update') {
+    if ($op == 'edit' || $op == 'update') {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->generateMandateData();
     }


### PR DESCRIPTION
**Overview**
When dd mandate was edited and saved, it updated receive date from the last contribution installment. As a result, the installment was collected at a wrong date.
This PR makes sure that contribution don’t get updated when dd mandate is edited.

**Before**
Contribution date was updated when dd mandate was edited.

**After**
Contribution date doesnt update when dd mandate is edited.

**Technical Details**
Below is the code that caused this issue. The runDataGeneration was run on both create and edit of mandate. This function generates date was contributions too. It should run on generateMandateData() method when dd mandate is edited.
```php
function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
  if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
    if ($op == 'create' || $op == 'edit') {
      $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
      $mandateDataGenerator->runDataGeneration();
    }
    if ($op == 'update') {
      $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
      mandateDataGenerator->generateMandateData();
    }
  }
}
```

Below is the fix for this:
```php
function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
  if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
    // Run only on create.
    if ($op == 'create') {
      $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
      $mandateDataGenerator->runDataGeneration();
    }
    // Run only when mandate in being edit
    if ($op == 'edit' || $op == 'update') {
      $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
      $mandateDataGenerator->generateMandateData();
    }
  }
}
```
