### PR TITLE
CGP-1492: Fix Programatic Installation of DD with Compuclient

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -142,6 +142,9 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->createDirectDebitPaymentInstrument();
     $this->createDirectDebitPaymentProcessorType();
     $this->createDirectDebitPaymentProcessor();
+    
+    // Reset columnSpecs cache to avoid re-creating fields on log tables.
+    unset(\Civi::$statics[CRM_Logging_Schema::class]['columnSpecs']);
   }
 
   public function upgrade_0010() {

--- a/info.xml
+++ b/info.xml
@@ -22,7 +22,7 @@
   <version>2.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.19</ver>
   </compatibility>
   <comments></comments>
   <civix>


### PR DESCRIPTION
## Overview
When deploying sites with compuclient, installation of Direct Debit Extension caused an error.

```
Deploying CGP-1450-t3 on compuclient-cgp-1450-k1p
Something went wrong with the deployment
Task [Upgrade Drupal DB] failed on [camden.servers.compucorp.co.uk] with message: [non-zero return code stderr: Performed update: compuclient_update_7101                                   [ok]
Performed update: compuclient_update_7102                                   [ok]
DB Error: unknown error                                                  [error]
Performed update: compuclient_update_7103                                   [ok]
'all' cache was cleared.                                               [success]
Finished performing updates.                                                [ok]]
```

## Before
Upgrade upgrade_5_19_alpha1 of CiviCRM was adding `is_active` field to `civicrm_status_pref` table. This caused table column specs cache to be initialized without the field added to it, although the field was also added to logging table. By the end of installing direct debit, schema differences were processed, to add missing fields to logging tables. Since column spec cache was missing is_active field, system was trying to add it again to `log_civicrm_status_pref` on final sync, causing the error.

## After
Reset column spec cache before ending DD installation. Also bumped minimum version of DD to CiviCRM v5.19.
