### PR TITLE
MAE-84: Fixing an error that prevented users from creating DD batches

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -583,8 +583,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'view' => [
           'name' => ts('View'),
           'title' => ts('View Mandate'),
-          'url' => "civicrm/contact/view",
-          'qs' => "reset=1&cid=%%contact_id%%&selectedChild=custom_%%mandate_custom_group_id%%",
+          'url' => "civicrm/contact/view/cd",
+          'qs' => "reset=1&cid=%%contact_id%%&selectedChild=custom_%%mandate_custom_group_id%%&gid=%%mandate_custom_group_id%%",
         ],
       ],
       NULL,
@@ -612,8 +612,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'view' => [
           'name' => ts('View'),
           'title' => ts('View Contribution'),
-          'url' => "civicrm/contact/view",
-          'qs' => "reset=1&cid=%%contact_id%%&selectedChild=contribute&openContribution=%%contribution_id%%",
+          'url' => "civicrm/contact/view/contribution",
+          'qs' => "reset=1&id=%%contribution_id%%&cid=%%contact_id%%&action=view&context=contribution&selectedChild=contribute",
         ],
       ],
       NULL,

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -4,7 +4,7 @@
 /**
  * This class generates form components for Batch Transaction
  */
-class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form {
+class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Search {
 
   /**
    * The action links that we need to display for the browse screen.


### PR DESCRIPTION
## Before
When trying to create a DD batch (either an instruction batch or a payment collection batch) then a fatal error will appear that prevents the user to do so.

![after](https://user-images.githubusercontent.com/6275540/68586270-34696680-047c-11ea-88bd-1a8b68bdd449.gif)


## After

Creating DD batches work fine : 

![after22](https://user-images.githubusercontent.com/6275540/68586293-43e8af80-047c-11ea-9dad-5b123a868201.gif)


## Technical Notes

Whan trying to create an Instruction batch or a Payment collection
batch, the following fatal error will appear after the user select the
batch name and originator number and clicking Next :

Error: Call to undefined method CRM_ManualDirectDebit_Form_BatchTransaction::addSearchFieldMetadata() in CRM_Contribute_BAO_Query::buildSearchForm

which prevent the user from creating the batch and exporting it.

The error caused by the following line inside
CRM_ManualDirectDebit_Form_BatchTransaction class :

CRM_Contribute_BAO_Query::buildSearchForm($this);

The line above pass an instant of the current form object to
the buildSearchForm, but the CRM_ManualDirectDebit_Form_BatchTransaction
class is of type CRM_Contribute_Form where the buildSearchForm method
expect a class of type CRM_Contribute_Form_Search and call some method
that are only defined inside it such as addSearchFieldMetadata().

The batch creation, submition and exporting in general inside DD extension is copied
from CiviCRM core with some modificaions (at the navigation menu see
Contribution >> Accounting Batches), that's why CRM_ManualDirectDebit_Form_BatchTransaction
extends CRM_Contribute_Form since this how the core class CRM_Financial_Form_BatchTransaction
was defined before, but since CiviCRM > 5.X many changes happen around
that area that resulted in changing the class that
CRM_Financial_Form_BatchTransaction extends to be
CRM_Contribute_Form_Search instead of CRM_Contribute_Form, and since we
are now targeting CiviCRM 5.19 for membershipextras product V2, this
issue appeared also on DD extension which still extends
CRM_Contribute_Form.

In this commit I changed the class to follow the class that it was
copied from which is to extend CRM_Contribute_Form_Search instead of
CRM_Contribute_Form, which fixes the issue.

Also I did some checking on the class to ensure that no other function
is broken by this change and it seems to be safe.

## Other fixes

I noticed that also the "View Mandate" and "View Contribution" pages inside the batch browse page are also broken : 

Before : 

![111](https://user-images.githubusercontent.com/6275540/68586707-2831d900-047d-11ea-967e-a4d8441870f4.gif)

![3333](https://user-images.githubusercontent.com/6275540/68586720-2c5df680-047d-11ea-8d82-ac4ca06fe62f.gif)


After : 

![2222](https://user-images.githubusercontent.com/6275540/68586728-31bb4100-047d-11ea-881f-1f3664e87f0b.gif)

![44444](https://user-images.githubusercontent.com/6275540/68586737-37188b80-047d-11ea-9024-3e12a59b2883.gif)

