### PR TITLE
CGP-1472: Implement Validation of Mandate Field on Membership Creation

### DIFF
--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -12,8 +12,24 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
    */
   private $form;
 
-  public function __construct(&$form) {
-    $this->form = $form;
+  /**
+   * Fields POST'ed by the form.
+   *
+   * @var array
+   */
+  private $fields;
+
+  /**
+   * Array of errors found on form'a validation.
+   *
+   * @var array
+   */
+  private $errors;
+
+  public function __construct(&$form, &$fields, &$errors) {
+    $this->form =& $form;
+    $this->fields =& $fields;
+    $this->errors =& $errors;
   }
 
   /**
@@ -26,6 +42,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
       $this->turnOffDirectDebitValidation();
     } else {
       $this->checkSettings();
+      $this->validateMandateIsNotEmpty();
     }
   }
 
@@ -70,6 +87,17 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
       $currentError[] = ['directDebitMandate' => "Please, configure minimum days to first payment"];
       $this->form->setVar('_errors', $currentError);
       CRM_Core_Session::setStatus($error->getMessage(), $title = 'Error', $type = 'error');
+    }
+  }
+
+  /**
+   * Checks that mandate has been created or selected for the membership.
+   */
+  private function validateMandateIsNotEmpty() {
+    $mandateID = intval($this->fields['mandate_id']);
+
+    if ($mandateID === 0) {
+      $this->errors['payment_instrument_id'] = ts('Please create or select a mandate to use Direct Debit payment method.');
     }
   }
 

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -94,9 +94,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
    * Checks that mandate has been created or selected for the membership.
    */
   private function validateMandateIsNotEmpty() {
-    $mandateID = intval($this->fields['mandate_id']);
-
-    if ($mandateID === 0) {
+    if (empty($this->fields['mandate_id'])) {
       $this->errors['payment_instrument_id'] = ts('Please create or select a mandate to use Direct Debit payment method.');
     }
   }

--- a/js/paymentMethodMandateSelection.js
+++ b/js/paymentMethodMandateSelection.js
@@ -1,6 +1,17 @@
 CRM.$(function ($) {
-  CRM.$('#contact_id').change(function () {
-    CRM.vars.coreForm.contact_id = CRM.$(this).val();
-    CRM.$('#payment_instrument_id').trigger('change.paymentBlock');
+  let contactField = $("#contact_id");
+  let paymentInstrumentField = $("#payment_instrument_id");
+
+  if (contactField.val() !== "" && typeof CRM.vars.coreForm !== "undefined") {
+    CRM.vars.coreForm.contact_id = contactField.val();
+  }
+
+  contactField.change(function () {
+    CRM.vars.coreForm.contact_id = $(this).val();
+    CRM.$("#payment_instrument_id").trigger("change.paymentBlock");
   });
+
+  if (paymentInstrumentField.val() !== "") {
+    paymentInstrumentField.trigger("change.paymentBlock");
+  }
 });

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -337,7 +337,7 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
 function manualdirectdebit_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
 
   if ($formName == 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
-    $directDebitValidator = new CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator($form);
+    $directDebitValidator = new CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator($form, $fields, $errors);
     $directDebitValidator->checkValidation();
   }
 }


### PR DESCRIPTION
## Overview
When creating a membership and paying for it using Direct Debit, a field to select/create the mandate is shown. If this field is left empty and the membership saved, the system will start processing the form and end in a screen with a fatal error.

![image](https://user-images.githubusercontent.com/21999940/69247966-5bf5b880-0b79-11ea-8fd1-1102486fcc5e.png)

## Before
Membership creation form was allowing mandate field to be empty when Direct Debit was selected as payment method. This caused a fatal error to be thrown when saving the membership.

## After
Fixed by validating mandate is not empty if direct debit payment method has been chosen. Also added some js logic to leave the membersip creation form in a consistent state after a failed validation, as contact_id and the mandate field were being lost.
