### PR TITLE
MAE-68: Pick the correct sender email when sending direct debit emails

### DIFF
--- a/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
@@ -30,7 +30,9 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
   public static function submit(&$form, $formValues) {
     self::saveMessageTemplate($formValues);
 
-    $from = CRM_Utils_Array::value($formValues['fromEmailAddress'], $form->_emails);
+    $from = CRM_Utils_Array::value('from_email_address', $formValues);
+    $from = CRM_Utils_Mail::formatFromAddress($from);
+
     $subject = $formValues['subject'];
 
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields

--- a/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
@@ -30,7 +30,9 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
   public static function submit(&$form, $formValues) {
     self::saveMessageTemplate($formValues);
 
-    $from = CRM_Utils_Array::value($formValues['fromEmailAddress'], $form->_emails);
+    $from = CRM_Utils_Array::value('from_email_address', $formValues);
+    $from = CRM_Utils_Mail::formatFromAddress($from);
+
     $subject = $formValues['subject'];
 
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields


### PR DESCRIPTION
## Before

1. Login as admin
2. Use 'Find memberships' or 'Find Contribution' search 
3. Select a few memberships/or contributions and then select Actions / Send Direct Debit Notifications
4. On next screen select the from email address to be something else than the logged in user's email address
5. Select one of the DD templates
6. Send the email
7. Check the email and see which email address the email was sent FROM - its the logged in user's email address instead of the one that you selected.



## After

The selected user in step 4 above will be the one used in the "From" when sending the email instead of the logged in user.

The issue happen because some changes in core forms that you can see below, and since the DD send notifications search actions where written on top of civicrm core functionally, the changes in the form needed to be reflected on the classes below.