### PR TITLE
MAE-95: Fix duplicate pagination issue in DD batch list pages

### DIFF
--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -51,8 +51,7 @@
     bAutoWidth: false,
     bProcessing: false,
     bLengthChange: true,
-    sPaginationType: "full_numbers",
-    sDom: '<"crm-datatable-pager-top"lfp>rt<"crm-datatable-pager-bottom"ip>',
+    paging: false,
     bJQueryUI: true,
     order: []
   });


### PR DESCRIPTION
## Before

When there are more than 50 batch (either a payment or an instruction batch), then the list view (table) page will show a duplicate pagination control as following : 

![2019-11-22 00_06_58-](https://user-images.githubusercontent.com/6275540/69381087-a3389200-0cbc-11ea-8782-8ff284ead9eb.png)

## After

Only one pagination control appears in the page : 

![after](https://user-images.githubusercontent.com/6275540/69381156-c4997e00-0cbc-11ea-9ea3-7cef8b036579.png)


## Technical notes

The DD batch list pages are doing both CiviCRM backed pagination and also Datatables JS plugin pagination,.

The issue happen for > 50 records because CiviCRM backend pagination have a default value of 50 row per page, so when there are more than 50 records (let's say 55 records) CiviCRM backed pagination will split the records into two pages, and because we also have Datatables pagination with default records per page set to 10 (which is the default Datatables records per page number) then Datatables will split the first CiviCRM page with 50 records into 10 pages and the 2 CiviCRM page with the rest of the 5 records into a single page which will result in this annoying behavior.

There are many solutions to this problem, I found that the simplest one is just to disable Datatables pagination by setting **paging** property to False

