### PR TITLE
MAE-162: Fix the sub-header of batch edit screen on Shoreditch

### DIFF
--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -1,7 +1,7 @@
 
-<h3>{ts}Added to batch{/ts}:</h3>
+<h3 style="margin-top: 30px;">{ts}Added to batch{/ts}:</h3>
 {if in_array($batchStatus, array('Open', 'Reopened')) && $action eq 2} {* Add / remove transactions only allowed for Open/Reopened batches *}
-  <br /><div class="form-layout-compressed">{$form.trans_remove.html}&nbsp;{$form.rSubmit.html}</div><br/>
+  <div class="form-layout-compressed">{$form.trans_remove.html}&nbsp;{$form.rSubmit.html}</div>
 {/if}
 <div id="ltype">
   <div class="form-item">


### PR DESCRIPTION
## Before

When Shoreditch extension is enabled, the "Added to batch" sub-header on batch edit pages will appear as the following and block the save and export buttons :

![2019-11-22 14_18_25-Calendar](https://user-images.githubusercontent.com/6275540/69425647-3f957f80-0d23-11ea-8c0d-e7564f93e1d6.png)

While without  Shoreditch extension it looks fine: 

![2019-11-22 14_19_50-New Direct Debit Instructions _ m7civi519](https://user-images.githubusercontent.com/6275540/69425703-59cf5d80-0d23-11ea-979c-7c41be6e1e1f.png)


## After

![2019-11-22 14_18_47-Calendar](https://user-images.githubusercontent.com/6275540/69425754-6f448780-0d23-11ea-86d3-7cf2f3d5a941.png)


And here it is without Shoreditch : 

![2019-11-22 14_20_05-New Direct Debit Instructions _ m7civi519](https://user-images.githubusercontent.com/6275540/69425776-7b304980-0d23-11ea-97bf-e533af6f8f1b.png)
