### PR TITLE
MAE-76: Fixing issues with creating mandates and printing mandate letters

### DIFF
--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -94,7 +94,7 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
    * Checks that mandate has been created or selected for the membership.
    */
   private function validateMandateIsNotEmpty() {
-    if (empty($this->fields['mandate_id'])) {
+    if (empty($this->fields['mandate_id']) || $this->fields['mandate_id'] == '-') {
       $this->errors['payment_instrument_id'] = ts('Please create or select a mandate to use Direct Debit payment method.');
     }
   }

--- a/CRM/ManualDirectDebit/Mail/Task/PDFLetterCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/PDFLetterCommon.php
@@ -49,7 +49,7 @@ class CRM_ManualDirectDebit_Mail_Task_PDFLetterCommon extends CRM_Member_Form_Ta
       Civi::log()->warning('No Letters were generated for the membership(s) with the following Id(s):' . $membershipIdsMessagePart);
     }
 
-    CRM_Utils_System::civiExit(1);
+    CRM_Utils_System::civiExit();
   }
 
   /**

--- a/js/paymentMethodMandateSelection.js
+++ b/js/paymentMethodMandateSelection.js
@@ -2,7 +2,7 @@ CRM.$(function ($) {
   let contactField = $("#contact_id");
   let paymentInstrumentField = $("#payment_instrument_id");
 
-  if (contactField.val() !== "" && typeof CRM.vars.coreForm !== "undefined") {
+  if (contactField.val() !== "" && contactField.val() != null  && typeof CRM.vars.coreForm !== "undefined") {
     CRM.vars.coreForm.contact_id = contactField.val();
   }
 


### PR DESCRIPTION
## Problems

1- If the '- Select -' option was not changed  when paying using direct debit then a validation message should appear asking the user to select a mandate 

![2019-11-27 18_18_17-das addsaads _ m7civi519](https://user-images.githubusercontent.com/6275540/69740608-8f17e900-1131-11ea-847d-5522e5834bcc.png)

but currently the page will just hang.

2- When creating a mandate, it will be added to the current logged in user instead of the contact that we are creating the mandate for.

3- Printing direct debit letters will throw "Invalid Response" http error.

## Solution

1- the `- Select- ` option value is `-` , but the validation code checks for empty value, so I just fixed the code to also check for `-` and show the validation message if the  `- Select- ` option is selected.

2- 

When creating a membership from the membership tab , the `contact_id` element does not exist but still it was calling the following lines 
```
  if (contactField.val() !== ""  && typeof CRM.vars.coreForm !== "undefined") {
    CRM.vars.coreForm.contact_id = contactField.val();
  }
```

which results in assinging the current logged in contact ID to `CRM.vars.coreForm.contact_id ` instead of the id of the contact we are adding the membership to, I fixed the issue by adding this check to the if statement `contactField.val() != null` to make sure it does not get called during creating the membership from the memberships tab.

3- After this change in CiviCRM core : https://github.com/civicrm/civicrm-core/pull/12902 , calling CRM_Utils_System::civiExit(); with `1` as a parameter will result in throwing a 500 HTTP error, I fixed the issue by removing the `1` from the call to civiExit method so a proper exist take place after generating the pdf file instead.