### PR TITLE
CGP-1507: Fix missing mandate Id on contribution and recur contribution after webform submission

### DIFF
--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -86,7 +86,15 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
    */
   public function setContributionProperties($dao) {
     $this->contributionId = $dao->id;
+
+    if ($dao->id == $this->contributionId && empty($dao->contribution_recur_id)) {
+      return;
+    }
     $this->contributionRecurId = $dao->contribution_recur_id;
+
+    if ($dao->id == $this->contributionId && empty($dao->payment_instrument_id)) {
+      return;
+    }
     $this->currentPaymentInstrumentId = $dao->payment_instrument_id;
   }
 


### PR DESCRIPTION
## Before

When creating a membership signup webform with Direct debit enabled on it, the created contribution(s) and recur contribution will not have the created mandate linked to them.

![befff](https://user-images.githubusercontent.com/6275540/70075170-1e227680-15f4-11ea-98da-c643beb8b1e2.gif)


It seems that the issue started after this PR : 

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/112/files

When this line is called : 

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/36886717a2709d308d38fd70c63c939144edb36d/CRM/ManualDirectDebit/Hook/Post/Contribution.php#L18

it will call CiviCRM contribution API to update a certain custom field on the contribution, which will trigger this hook : manualdirectdebit_civicrm_postSave_civicrm_contribution()  with only the contribution ID and that custom field value, 
the hook above will call this method CRM_ManualDirectDebit_Hook_MandateContributionConnector::setContributionProperties() which will overwrite the values of both $contributionRecurId and $currentPaymentInstrumentId properties to NULL, and when the extension later assign the mandate to the related contribution and recur contribution it will not find them and hence the link between the mandate and these entities will not happen.


## After


![aft](https://user-images.githubusercontent.com/6275540/70073719-51afd180-15f1-11ea-9a41-c55aed54a317.gif)


I added a check to ensure that these two properties ($contributionRecurId and $currentPaymentInstrumentId ) will not be overwritten if there values are null.