### PR TITLE
MAE-164: Make save button avaliable when editing mandate

### DIFF
--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -14,7 +14,7 @@ CRM.$('document').ready(function () {
         var mandateData = JSON.parse(CRM.$(this).attr('data-post'));
         var editMandateURL = getUrlForUpdatingCurrentMandate(cgCount, mandateData.groupID, mandateData.contactId, mandateData.valueID);
         var editButtonHTML =
-          '<a href="#" class="button edit" id="edit_direct_debit_mandate_' + cgCount + '" title="Edit Direct Debit Mandate" onclick="CRM.loadPage(\'' + editMandateURL + '\')">' +
+          '<a href="'+ editMandateURL +'" class="button edit" id="edit_direct_debit_mandate_' + cgCount + '" title="Edit Direct Debit Mandate">' +
           '  <span><i class="crm-i fa-pencil"></i> Edit </span>' +
           '</a>';
 

--- a/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
@@ -46,24 +46,20 @@
       CRM.loadPage(url);
     });
 
-    CRM.$('#newDirectDebitMandate').click(function () {
-      var newUrl = CRM.url(
-        'civicrm/contact/view/cd/edit',
-        {
-          reset: '1',
-          type: 'Individual',
-          groupID: urlData.gid,
-          entityID: urlData.cid,
-          cgcount: urlData.cgcount,
-          multiRecordDisplay: 'single',
-          mode: 'add',
-          updatedRecId: urlData.recurringContribution,
-        }
-      );
-
-      CRM.loadPage(newUrl);
-    });
-
+    var newUrl = CRM.url(
+      'civicrm/contact/view/cd/edit',
+      {
+        reset: '1',
+        type: 'Individual',
+        groupID: urlData.gid,
+        entityID: urlData.cid,
+        cgcount: urlData.cgcount,
+        multiRecordDisplay: 'single',
+        mode: 'add',
+        updatedRecId: urlData.recurringContribution,
+      }
+    );
+    CRM.$('#newDirectDebitMandate').attr('href', newUrl);
   });
   {/literal}
 </script>


### PR DESCRIPTION
## Problem

When Shoreditch theme is enabled and When Trying to edit a mandate

![11](https://user-images.githubusercontent.com/6275540/70144620-3945c280-1696-11ea-9218-c7fe73d0cf1f.gif)

or create a new mandate for the recur contribution : 

![22](https://user-images.githubusercontent.com/6275540/70144629-3d71e000-1696-11ea-8069-f7b111a83ab5.gif)

then the save and cancel buttons do not appear.

## Solution

Here how things look now for edit mandate page  : 
![33](https://user-images.githubusercontent.com/6275540/70144634-42cf2a80-1696-11ea-8b4c-a12b469bc9f0.gif)

And for "using new mandate" I had to make it open in a new page since it will be time consuming to make it work inside a modal : 
![44](https://user-images.githubusercontent.com/6275540/70144732-77db7d00-1696-11ea-99c0-bd370141fb77.gif)

## Technical notes 

I had to change the links to open the mandate forms so the href attribute  contains the link to edit the mandate instead of using onclick even listener and CRM.loadPage() 

