### PR TITLE
CGP-1472: Handle Mandate ID Validation Errors on Membership Forms and Dialogs

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
@@ -22,7 +22,15 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Membership {
    *  Builds form
    */
   public function buildForm() {
+    $this->addMandateRelatedJSGlobalVariables();
     $this->changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected();
+  }
+
+  /**
+   * Adds global variables required to maintain status of mandate field.
+   */
+  private function addMandateRelatedJSGlobalVariables() {
+    CRM_Core_Resources::singleton()->addVars('coreForm', array('empty_mandate_id' => FALSE));
   }
 
   private function changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected() {

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -94,8 +94,11 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
    * Checks that mandate has been created or selected for the membership.
    */
   private function validateMandateIsNotEmpty() {
+    CRM_Core_Resources::singleton()->addVars('coreForm', array('empty_mandate_id' => FALSE));
+
     if (empty($this->fields['mandate_id']) || $this->fields['mandate_id'] == '-') {
       $this->errors['payment_instrument_id'] = ts('Please create or select a mandate to use Direct Debit payment method.');
+      CRM_Core_Resources::singleton()->addVars('coreForm', array('empty_mandate_id' => TRUE));
     }
   }
 

--- a/js/paymentMethodMandateSelection.js
+++ b/js/paymentMethodMandateSelection.js
@@ -1,26 +1,69 @@
+var CRM = CRM || {};
+CRM.coreForm = CRM.coreForm || {};
+
 CRM.$(function ($) {
-  let contactField = $("#contact_id");
-  let paymentInstrumentField = $("#payment_instrument_id");
+  /**
+   * Loads contact ID into CiviCRM form globals.
+   *
+   * CRM.vars.coreForm.contact_id is a global variable CiviCRM uses to send the
+   * contact_id into the ajax call that obtains fields required for each
+   * particular payment instrument. However, we lose this value after a failed
+   * validation, and on modal dialogs. Thus, we need to load it if it isn't set,
+   * as we need the contact ID to be able to load its existing mandates.
+   */
+  function loadContactIDIntoGlobalFormVariables() {
+    let contactField = $("#contact_id");
 
-  if (typeof contactField.val() !== "undefined" && contactField.val() !== "" && typeof CRM.vars.coreForm !== "undefined") {
-    CRM.vars.coreForm.contact_id = contactField.val();
+    if (typeof contactField.val() !== "undefined" && contactField.val() !== "") {
+      CRM.vars.coreForm.contact_id = contactField.val();
+    }
   }
 
-  if (paymentInstrumentField.val() !== "") {
-    paymentInstrumentField.trigger("change.paymentBlock");
+  /**
+   * Sets up trigger to reload payment instrument fields on contact change.
+   *
+   * A change in contact needs to trigger the payment instrument block fields to
+   * be refreshed, so it loads the mandates specific for that contact. Also, if
+   * the user chooses direct debit the payment instrument, leaving the contact
+   * empty, we show an error message to the user asking him to select the
+   * contact. Doing so, should also trigger the payment instrument fields to be
+   * refreshed.
+   */
+  function setupContactChangeEventTriggeringPaymentBlockRefresh() {
+    let contactField = $("#contact_id");
+
+    contactField.change(function () {
+      CRM.vars.coreForm.contact_id = $(this).val();
+      $("#payment_instrument_id").trigger("change.paymentBlock");
+    });
   }
 
-  contactField.change(function () {
-    CRM.vars.coreForm.contact_id = $(this).val();
-    $("#payment_instrument_id").trigger("change.paymentBlock");
-  });
+  /**
+   * Triggers loading of fields related to payment instrument.
+   *
+   * Checks if a payment instrument has been selected and if so, triggers the
+   * event to load fields specific to that instrument.
+   */
+  function triggerPaymentBlockRefreshingIfPaymentInstrumentIsNotNull() {
+    let paymentInstrumentField = $("#payment_instrument_id");
 
-  paymentInstrumentField.closest('.ui-dialog').on('crmFormLoad.crmForm', function () {
-    $("#payment_instrument_id").trigger("change.paymentBlock");
-  });
+    if (paymentInstrumentField.val() !== "") {
+      paymentInstrumentField.trigger("change.paymentBlock");
+    }
+  }
 
-  paymentInstrumentField.closest('.ui-dialog').on('crmFormError.crmForm', function () {
-    $("#billing-payment-block").on('crmLoad', function() {
+  /**
+   * Checks if there has been a validation error for the mandate field.
+   *
+   * If the mandate field has is found empty after validation, it is marked as
+   * an error by adding the appropriate CSS classes.
+   */
+  function handleEmptyMandateFieldValidationError() {
+    $("#billing-payment-block").on("crmLoad", function() {
+      if (typeof CRM.vars.coreForm.empty_mandate_id === "undefined" || !CRM.vars.coreForm.empty_mandate_id) {
+        return;
+      }
+
       let mandateField = $("#mandate_id");
       let mandateFieldLabel = $("label[for='mandate_id']");
       if (typeof mandateField.val() !== "undefined" && mandateField.val() === "-") {
@@ -28,5 +71,27 @@ CRM.$(function ($) {
         mandateFieldLabel.addClass("error crm-error");
       }
     });
-  });
+  }
+
+  /**
+   * Handle validation errors on forms opened as modal dialogs.
+   *
+   * Forms opened on modal dialogs don't actually refresh the page, so we need
+   * to capture CiviCRM load events to refresh payment instrument fields and
+   * handle errors of mandate field.
+   */
+  function handleEmptyMandateFieldOnFailedValidationForMembershipDialogs() {
+    let paymentInstrumentField = $("#payment_instrument_id");
+
+    paymentInstrumentField.closest('.ui-dialog').on('crmFormLoad.crmForm', function () {
+      $("#payment_instrument_id").trigger("change.paymentBlock");
+      handleEmptyMandateFieldValidationError();
+    });
+  }
+
+  loadContactIDIntoGlobalFormVariables();
+  setupContactChangeEventTriggeringPaymentBlockRefresh();
+  triggerPaymentBlockRefreshingIfPaymentInstrumentIsNotNull();
+  handleEmptyMandateFieldValidationError();
+  handleEmptyMandateFieldOnFailedValidationForMembershipDialogs();
 });

--- a/js/paymentMethodMandateSelection.js
+++ b/js/paymentMethodMandateSelection.js
@@ -2,16 +2,31 @@ CRM.$(function ($) {
   let contactField = $("#contact_id");
   let paymentInstrumentField = $("#payment_instrument_id");
 
-  if (contactField.val() !== "" && contactField.val() != null  && typeof CRM.vars.coreForm !== "undefined") {
+  if (typeof contactField.val() !== "undefined" && contactField.val() !== "" && typeof CRM.vars.coreForm !== "undefined") {
     CRM.vars.coreForm.contact_id = contactField.val();
   }
-
-  contactField.change(function () {
-    CRM.vars.coreForm.contact_id = $(this).val();
-    CRM.$("#payment_instrument_id").trigger("change.paymentBlock");
-  });
 
   if (paymentInstrumentField.val() !== "") {
     paymentInstrumentField.trigger("change.paymentBlock");
   }
+
+  contactField.change(function () {
+    CRM.vars.coreForm.contact_id = $(this).val();
+    $("#payment_instrument_id").trigger("change.paymentBlock");
+  });
+
+  paymentInstrumentField.closest('.ui-dialog').on('crmFormLoad.crmForm', function () {
+    $("#payment_instrument_id").trigger("change.paymentBlock");
+  });
+
+  paymentInstrumentField.closest('.ui-dialog').on('crmFormError.crmForm', function () {
+    $("#billing-payment-block").on('crmLoad', function() {
+      let mandateField = $("#mandate_id");
+      let mandateFieldLabel = $("label[for='mandate_id']");
+      if (typeof mandateField.val() !== "undefined" && mandateField.val() === "-") {
+        mandateField.addClass("error crm-error");
+        mandateFieldLabel.addClass("error crm-error");
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Overview
'Mandate' field is not highlighted, when Warning message is shown. After form validation.

Furthermore, on Contact's new membership and renew membership modal dialogs, after failed validation the mandat field is not shown, and you need to select another payment instrument and reselect Direct Debit in order to load the mandate id field.

## Before
Since mandate field is loaded after the membership forms are, CiviCRM wasn't able to mark the field as an error.

Also, on modal dialogs, since the page is not refreshed, events to re-load mandate ID field are not triggered.

![CGP-1472 - Before](https://user-images.githubusercontent.com/21999940/71625811-dd4c5c00-2bb7-11ea-8a8f-45144da00e8a.gif)

## After
Added a global JS variable set by back.end validation in order to be able to check if mandate field has been sent empty. So now the mandate dield is marked with appropriat CSS classes to be shown as an error.

Also captured CiviCRM dialog load events to be able to refresh payment instrument fields on load, and handle any validation errors produced by payment instrument fields.

![CGP-1472 - After](https://user-images.githubusercontent.com/21999940/71625822-e806f100-2bb7-11ea-9892-de7de8167ff2.gif)

## Notes
Refactored most of the JS code used to handle membership forms and added documentation so it is easier in the future to understand why these changes were implemented.
