### PR TITLE
IOSPRT-34: Fixes to manual mandate update

### DIFF
--- a/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
@@ -95,4 +95,23 @@ class CRM_ManualDirectDebit_BAO_RecurrMandateRef extends CRM_ManualDirectDebit_D
     }
   }
 
+  public static function getMandateReferenceId($mandateId, $recurContributionId) {
+    $sqlSelectDebitMandateID = "SELECT `id`  
+      FROM " . self::DIRECT_DEBIT_RECURRING_CONTRIBUTION_NAME . " 
+      WHERE `recurr_id` = %1 AND `mandate_id` = %2 ORDER BY mandate_id DESC LIMIT 1";
+
+    $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
+      1 => [
+        $recurContributionId,
+        'String',
+      ],
+      2 => [
+        $mandateId,
+        'String',
+      ],
+    ]);
+    $queryResult->fetch();
+    return $queryResult->id;
+  }
+
 }

--- a/CRM/ManualDirectDebit/DAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/DAO/RecurrMandateRef.php
@@ -127,48 +127,6 @@ class CRM_ManualDirectDebit_DAO_RecurrMandateRef extends CRM_Core_DAO {
   }
 
   /**
-   * Given an associative array of name/value pairs, extract all the values
-   * that belong to this object and initialize the object with said values
-   *
-   * @param array $params
-   *   (reference ) associative array of name/value pairs.
-   *
-   * @return bool
-   *   Did we copy all null values into the object
-   */
-  public function copyValues(&$params) {
-    $fields = &$this->fields();
-    $allNull = TRUE;
-    foreach ($fields as $name => $value) {
-      $dbName = $value['name'];
-      if (array_key_exists($dbName, $params)) {
-        $pValue = $params[$dbName];
-        $exists = TRUE;
-      }
-      elseif (array_key_exists($name, $params)) {
-        $pValue = $params[$name];
-        $exists = TRUE;
-      }
-      else {
-        $exists = FALSE;
-      }
-
-      // if there is no value then make the variable NULL
-      if ($exists) {
-        if ($pValue === '') {
-          $this->$dbName = 'null';
-        }
-        else {
-          $this->$dbName = $pValue;
-          $allNull = FALSE;
-        }
-      }
-    }
-
-    return $allNull;
-  }
-
-  /**
    * Returns the list of fields that can be exported
    *
    * @param bool $prefix

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -113,11 +113,8 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
     $oldMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionId);
     $this->mandateId = $this->mandateStorage->getLastInsertedMandateId($this->currentContactId);
 
-    $params = [
-      'recurr_id' => $recurringContributionId,
-      'mandate_id' => $this->mandateId,
-    ];
-    CRM_ManualDirectDebit_BAO_RecurrMandateRef::create($params);
+    $mandateManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandateManager->assignRecurringContributionMandate($recurringContributionId, $this->mandateId);
 
     if (!empty($oldMandateId)) {
       $this->mandateStorage->changeMandateForContribution($this->mandateId, $oldMandateId);

--- a/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/Contribution/DirectDebitMandate.php
@@ -64,28 +64,6 @@ class CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate {
   }
 
   /**
-   * Checks if payment option appropriate for creating mandate
-   */
-  public function checkPaymentOptionToCreateMandate() {
-    $isRecurring = isset($this->form->getVar('_params')['is_recur']) && !empty($this->form->getVar('_params')['is_recur']);
-
-    if ($isRecurring) {
-      $selectedPaymentProcessor = $this->form->getVar('_params')['payment_processor_id'];
-
-      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitPaymentProcessor($selectedPaymentProcessor)) {
-        $this->mandateStorage->createEmptyMandate($this->currentContactId);
-      }
-    }
-    else {
-      $selectedPaymentInstrument = $this->form->getVar('_params')['payment_instrument_id'];
-
-      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($selectedPaymentInstrument)) {
-        $this->mandateStorage->createEmptyMandate($this->currentContactId);
-      }
-    }
-  }
-
-  /**
    *  Launches all required processes after saving mandate
    */
   public function run() {

--- a/CRM/ManualDirectDebit/Hook/PostProcess/RecurContribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/RecurContribution/DirectDebitMandate.php
@@ -1,0 +1,46 @@
+<?php
+
+class CRM_ManualDirectDebit_Hook_PostProcess_RecurContribution_DirectDebitMandate {
+
+  private $recurContributionId;
+
+  private $mandateId;
+
+  public function __construct($form) {
+    $this->recurContributionId = $form->getVar('contributionRecurID');
+
+    if (!empty($form->getSubmitValue('mandate_id'))) {
+      $this->mandateId = $form->getSubmitValue('mandate_id');
+    }
+
+  }
+
+  public function saveMandateData() {
+    if (empty($this->mandateId)) {
+      return;
+    }
+
+    $mandateManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandateManager->assignRecurringContributionMandate($this->recurContributionId, $this->mandateId);
+    $relatedContributions = $this->getRelatedPendingContributions();
+    foreach ($relatedContributions as $contribution) {
+      $mandateManager->assignContributionMandate($contribution['id'], $this->mandateId);
+    }
+  }
+
+  private function getRelatedPendingContributions() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'contribution_status_id' => 'Pending',
+      'contribution_recur_id' => $this->recurContributionId,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -190,8 +190,8 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
 
   switch (true) {
     case $formName == 'CRM_Contribute_Form_UpdateSubscription' && $action == CRM_Core_Action::UPDATE:
-      $activity = new CRM_ManualDirectDebit_Hook_Post_RecurContribution_Activity($form->getVar('contributionRecurID'), 'edit');
-      $activity->process();
+      $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_RecurContribution_DirectDebitMandate($form);
+      $manualDirectDebit->saveMandateData();
       break;
 
     case $formName == 'CRM_Member_Form_Membership' && $action == CRM_Core_Action::ADD && $isDirectDebit:


### PR DESCRIPTION
## Before

1- Changing the mandate from the recur contribution edit form  will not actually change the mandate.

2- a new mandate reference record is created inside `dd_contribution_recurr_mandate_ref` table (whichstores the reference between the mandate and the recur contribution) every time the user change the mandate

## After

1- Changing the mandate from the recur contribution edit form is now reflected on the recur contribution.

2- only one mandate reference is now getting created per recur contribution and it will get updated if the user change the recur contribution mandate. 

## Other notes

- Some unused methods are removed
- the copyValues() method inside CRM_ManualDirectDebit_DAO_RecurrMandateRef  class was unnecessarily overridden, so I removed it.