### PR TITLE
ASESPRT-216: fix editing mandate for orgnisation sub-type contacts

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -20,18 +20,28 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
    * @param $recurringContributionId
    */
   public function alterRecurContributionLinks(&$values, $recurringContributionId) {
+    $contactId =  CRM_Utils_Request::retrieve('cid', 'Integer');
+    $contactType = $this->getContactType($contactId);
+
     $this->links[] = [
       'name' => ts('Use a new mandate'),
       'url' => 'civicrm/contact/view/cd/edit',
       'title' => 'Use a new mandate',
-      'qs' => 'reset=1&type=Individual&groupID=%%groupID%%&entityID=%%cid%%&cgcount=%%cgcount%%&multiRecordDisplay=single&mode=add&updatedRecId=%%updatedRecId%%',
+      'qs' => 'reset=1&type=' . $contactType . '&groupID=%%groupID%%&entityID=%%cid%%&cgcount=%%cgcount%%&multiRecordDisplay=single&mode=add&updatedRecId=%%updatedRecId%%',
       'class' => 'no-popup',
     ];
 
     $values['groupID'] = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_mandate");
-    $values['cid'] = CRM_Utils_Request::retrieve('cid', 'Integer');
+    $values['cid'] = $contactId;
     $values['cgcount'] = $this->getCgCount();
     $values['updatedRecId'] = $recurringContributionId;
+  }
+
+  private function getContactType($contactId) {
+    return civicrm_api3('Contact', 'getvalue', [
+      'return' => 'contact_type',
+      'id' => $contactId,
+    ]);
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
@@ -61,6 +61,16 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
     }
 
     if ($mandateId) {
+      $contactId = CRM_Utils_Request::retrieve('cid', 'Integer', $this->page);
+      $contactType = civicrm_api3('Contact', 'getvalue', [
+        'return' => 'contact_type',
+        'id' => $contactId,
+      ]);
+
+      CRM_Core_Resources::singleton()->addVars('uk.co.compucorp.manualdirectdebit', [
+        'contactType' => $contactType,
+      ]);
+
       CRM_Core_Region::instance('page-body')->add([
         'template' => "{$this->templatePath}/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl",
       ]);
@@ -70,7 +80,7 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
         ->addSetting([
           'urlData' => [
             'gid' => CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_mandate"),
-            'cid' => CRM_Utils_Request::retrieve('cid', 'Integer', $this->page, FALSE),
+            'cid' => $contactId,
             'recId' => $mandateId,
             'mandateId' => $mandateId,
             'cgcount' => $this->getCgCount(),

--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -60,7 +60,7 @@ CRM.$('document').ready(function () {
       'civicrm/contact/view/cd/edit',
       {
         reset: '1',
-        type: 'Individual',
+        type: CRM.vars['uk.co.compucorp.manualdirectdebit'].contactType,
         groupID: groupId,
         entityID: contactId,
         cgcount: cgCount,

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -234,6 +234,10 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
       break;
 
     case 'CRM_Contact_Page_View_CustomData':
+      $contactId = $page->getVar('_contactId');
+      CRM_Core_Resources::singleton()->addVars('uk.co.compucorp.manualdirectdebit', [
+        'contactType' => _manualdirectdebit_getContactType($contactId),
+      ]);
       CRM_Core_Resources::singleton()
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
       break;
@@ -255,6 +259,13 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/paymentMethodMandateSelection.js');
       break;
   }
+}
+
+function _manualdirectdebit_getContactType($contactId) {
+  return civicrm_api3('Contact', 'getvalue', [
+    'return' => 'contact_type',
+    'id' => $contactId,
+  ]);
 }
 
 /**

--- a/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
@@ -50,7 +50,7 @@
       'civicrm/contact/view/cd/edit',
       {
         reset: '1',
-        type: 'Individual',
+        type: CRM.vars['uk.co.compucorp.manualdirectdebit'].contactType,
         groupID: urlData.gid,
         entityID: urlData.cid,
         cgcount: urlData.cgcount,


### PR DESCRIPTION
## Before

Trying to edit a mandate for a contact that belongs to an organisation sub-type (such as Team subtype)  will result in the following error : 

```

CRM_Core_Exception: Invalid Entity Filter civicrm/CRM/Core/BAO/CustomGroup.php on line 489
CRM_Core_BAO_CustomGroup::validateSubTypeByEntity('Individual', 'Team')
```

## After

Editing a mandate for a contact that belongs to any subtype is working normally whether it from the recur contribution view page or "use new mandate" button.

## Technical notes

The error occurs because the mandate edit link that is generated by the extension always have `Individual` as the contact type in the URL GET parameters, e.g : 

```
/civicrm/contact/view/cd/edit?reset=1&type=Individual&groupID=23&entityID=226&cgcount=1&multiRecordDisplay=single&mode=edit&mandateId=96&snippet=json
```

and since the mandate entity is basically a custom group/fields and the link above take advantage of CiviCRM core way to handle custom groups/fields and Civi core except the right contact type to be passed but it is not, the error is triggered.

I fixed the issue by getting the contact type first using its ID and then using he actually contact type instead of being hard-coded to `Individual`