### PR TITLE
IOSPRT-35: Prevent changing payment plan cycle day when using new mandate

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -45,8 +45,40 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
    * Generates and saves the required fields values if they are not supplied by the user.
    */
   public function runDataGeneration() {
+    $isThereExistingMandateReference = $this->isThereExistingMandateReference();
     $this->generateMandateData();
-    $this->generateContributionData();
+
+    if (!$isThereExistingMandateReference) {
+      $this->generateContributionData();
+    }
+  }
+
+  /**
+   * Checks if the recur contribution
+   * already has a mandate assigned to it
+   * or not.
+   *
+   * @return bool
+   */
+  private function isThereExistingMandateReference() {
+    $contactLastRecurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'contact_id' => $this->entityID,
+      'options' => ['limit' => 1, 'sort' => 'contribution_recur_id DESC'],
+    ]);
+
+    $mandateReference = NULL;
+    if (!empty($contactLastRecurContribution['values'][0]['id'])) {
+      $contributionRecurId = $contactLastRecurContribution['values'][0]['id'];
+      $mandateReference =  CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
+    }
+
+    if (!empty($mandateReference)) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
## Before

Changing a recur contribution (payment plan) to use new mandate will result in changing the recur contribution start date and cycle day, it will also result in changing the last contribution receive date.

And while we may need to think on how to handle this in the future, for now we need only to change the recur contribution to point to the new mandate without touching the dates.

## After
Changing the recur contribution mandate is only affecting the mandate that the recur contribution is linked to and does not the dates.


## Technical notes

When using "using new mandate" button to change the payment plan mandate, a new form will be opened that after get submitted will both create and assign the mandate to the payment plan, where in places such as the membership form the mandate is created first in a separate form (modal) and then select from the select list (so the creation and the assigning of the mandate happen sepeartly).

And because with "using new mandate" both the creation and the assignment happen at the same time, it will trigger manualdirectdebit_civicrm_custom hook on `create` mode for the mandate and in `create` mode the hook will save the mandate then calculate the cycle day and the new start date for the payment plan based on the logic described here : https://github.com/compucorp/uk.co.compucorp.manualdirectdebit#2-batch-settings

I fixed the issue by adding a check inside manualdirectdebit_civicrm_custom hook `create` mode, so it checks if the payment plan is already have a mandate  assigned to it, if it does then it means we are replacing the mandate here and thus we prevent the hook from running the code that calculate  the cycle day and the start date.

 
