### PR TITLE
MAE-226: Fix sending DD emails on Compuclient sites

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -144,6 +144,17 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->createDirectDebitPaymentProcessor();
   }
 
+  /**
+   * Current Compuclient database does not have
+   * the message templates custom fields set for
+   * some reason, this upgrader fixes that.
+   * @return bool
+   */
+  public function upgrade_0011() {
+    $this->setDDTemplatesCustomFields();
+    return TRUE;
+  }
+
   public function upgrade_0010() {
     $this->addCollectionReminderFlagCustomGroup();
     $this->createCollectionReminderFlagRecords();


### PR DESCRIPTION
## Problem

Users are unable to send DD emails on sites created using Compuclient.

For some reason,  the database that is used for creating Compuclient sites does not have the direct debit message templates related custom fields set which are needed in order for such emails to be sent.

## Solution

I added a new upgrader that will set these fields for existing sites if there are not already set.