### PR TITLE
MAE-228: Prevent changing recur contribution payment method from/to Direct Debit

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
@@ -13,12 +13,20 @@ class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
   private $form;
 
   /**
+   * Path to where extension templates are physically stored.
+   *
+   * @var string
+   */
+  private $templatePath;
+
+  /**
    * CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription constructor.
    *
    * @param \CRM_Contribute_Form_UpdateSubscription $form
    */
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
+    $this->templatePath = CRM_ManualDirectDebit_ExtensionUtil::path() . '/templates';
   }
 
   /**
@@ -27,6 +35,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
   public function buildForm() {
     $this->addContactIDToCoreFormJSVariable();
     $this->addMandateIDToCoreFormJSVariable();
+    $this->preventChangingDirectDebitPaymentMethod();
   }
 
   /**
@@ -57,6 +66,12 @@ class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
     if ($selectedMandateID) {
       CRM_Core_Resources::singleton()->addVars('coreForm', array('selected_mandate_id' => (int) $selectedMandateID));
     }
+  }
+
+  private function preventChangingDirectDebitPaymentMethod() {
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
+    ]);
   }
 
 }

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -1,0 +1,12 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    var selectedPaymentMethod = $('#payment_instrument_id option:selected').text();
+    if (selectedPaymentMethod == 'Direct Debit') {
+      $('#payment_instrument_id_field').hide();
+    } else {
+      $('#payment_instrument_id_field option:contains(Direct Debit)').hide();
+    }
+  });
+  {/literal}
+</script>


### PR DESCRIPTION
## Before

There are some issues when users are changing the payment plan (recur contribution) payment method from Direct debit to something else or vice versa, such as the created mandate when changing the payment method to DD is not getting linked to the related contributions , And since fixing these issues might take sometime we decided to hide the ability to change the payment method of the recur contribution if the it is already Direct Debit, and to hide the Direct Debit payment method if the payment method is already something else (such as  Cash).

![2020-04-08 16_58_04-fsdfdsfsd fdssdf _ s1mev2](https://user-images.githubusercontent.com/6275540/78806113-2af81200-79ba-11ea-84cd-1e64454ae5d2.png)

![2020-04-08 16_58_17-dasdas dasads _ s1mev2](https://user-images.githubusercontent.com/6275540/78806122-2df30280-79ba-11ea-9c5b-24ce09114304.png)


## After

EFT Payment method is selected, the Direct debit payment method is not appearing as a payment method : 
![1](https://user-images.githubusercontent.com/6275540/78806137-32b7b680-79ba-11ea-82f1-fbf19daee892.png)

Direct debit is the payment method for this Recur contribution, so we are hiding the whole payment method selection field : 
![2](https://user-images.githubusercontent.com/6275540/78806142-35b2a700-79ba-11ea-8239-2b99b3a83ef4.png)
