### PR TITLE
MAE-261: Fix payment transaction payment method when submitting payments batches

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -287,7 +287,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
         $this->updateDDMandate('recurring_contribution', $row['mandate_id']);
       }
       if (!empty($row['contribute_id'])) {
-        $this->updateContribute('Completed', $row['contribute_id']);
+        $this->recordContributionPayment($row['contribute_id']);
       }
     }
 
@@ -295,27 +295,20 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   }
 
   /**
-   * Updates Contributes status and calls transition components to update
+   * Updates Contribution status and calls transition components to update
    * related entities (like memberships).
    *
-   * @param string $status
-   * @param string $mandateId
+   * @param int $contributionId
    */
-  private function updateContribute($status, $mandateId) {
+  private function recordContributionPayment($contributionId) {
     $originalStatusID = civicrm_api3('Contribution', 'getvalue', [
       'return' => 'contribution_status_id',
-      'id' => $mandateId,
+      'id' => $contributionId,
     ])['result'];
 
-    $contributeStatuses = CRM_Core_PseudoConstant::get(
-      'CRM_Contribute_DAO_Contribution',
-      'contribution_status_id',
-      ['labelColumn' => 'name']
-    );
-
     $result = civicrm_api3('Contribution', 'create', [
-      'id' => $mandateId,
-      'contribution_status_id' => array_search($status, $contributeStatuses),
+      'id' => $contributionId,
+      'contribution_status_id' => 'Completed',
     ]);
     $contribution = array_shift($result['values']);
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -309,6 +309,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $result = civicrm_api3('Contribution', 'create', [
       'id' => $contributionId,
       'contribution_status_id' => 'Completed',
+      'payment_instrument_id' => 'direct_debit',
     ]);
     $contribution = array_shift($result['values']);
 


### PR DESCRIPTION
## Before

Submitting Payment batches will result in recorded payments but with the payment method field empty : 

![2020-04-09 19_46_37-ffdsfdsdsf dfdsffds _ s1mev2](https://user-images.githubusercontent.com/6275540/78919721-39adfa00-7a8a-11ea-956d-45871b9e2768.png)


## After

Submitting payment batches is resulting in having the correct payment method on the created payment, which `direct debit` : 

![2020-04-09 19_50_40-ffdsfdsdsf dfdsffds _ s1mev2](https://user-images.githubusercontent.com/6275540/78920038-b8a33280-7a8a-11ea-8623-8f34cdb65594.png)

## Notes

This PR is only part of the fix, the other part is that the Direct Debit payment method finincal account is not configured when Direct Debit extension is installed : 

![2020-04-09 18_11_12-Payment Methods Options _ s1mev2](https://user-images.githubusercontent.com/6275540/78920232-fe5ffb00-7a8a-11ea-9931-a64831ef1784.png)

So it need to be set to something too, For now we are not defaulting it to any specific value and will leave admins to configure it by themselves, but at some point we need  to find a suitable default.

