### PR TITLE
MAE-269: Hide the time picker from the date range selector in payment batch search

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -632,20 +632,20 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @param $query
    */
   private function addContributionReceiveDateCondition(&$query) {
-    if (!empty($this->params['contribution_date_relative'])) {
-      $relativeDate = explode('.', $this->params['contribution_date_relative']);
+    if (!empty($this->params['receive_date_relative'])) {
+      $relativeDate = explode('.', $this->params['receive_date_relative']);
       $date = CRM_Utils_Date::relativeToAbsolute($relativeDate[0], $relativeDate[1]);
       $query->where('civicrm_contribution.receive_date >= @receive_date_start', ['receive_date_start' => $date['from']]);
       $query->where('civicrm_contribution.receive_date <= @receive_date_end', ['receive_date_end' => $date['to']]);
     }
-    if (!empty($this->params['contribution_date_low'])) {
+    if (!empty($this->params['receive_date_low'])) {
       $query->where('civicrm_contribution.receive_date >= @receive_date_start',
-                     ['receive_date_start' => date('Ymd', strtotime($this->params['contribution_date_low']))]
+                     ['receive_date_start' => date('Ymd', strtotime($this->params['receive_date_low']))]
                    );
     }
-    if(!empty($this->params['contribution_date_high'])) {
+    if(!empty($this->params['receive_date_high'])) {
       $query->where('civicrm_contribution.receive_date <= @receive_date_end',
-                     ['receive_date_end' => date('Ymd', strtotime($this->params['contribution_date_high']))]
+                     ['receive_date_end' => date('Ymd', strtotime($this->params['receive_date_high']))]
                    );
     }
   }

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -106,6 +106,7 @@ CRM.$(function($) {
     CRM.$('.crm-batch_transaction_search-accordion:not(.collapsed)').crmAccordionToggle();
   });
 
+  hideTimeFieldFromDatePicker();
   setDefaultFilterValues();
 
   var batchStatus = {/literal}{$statusID}{literal};
@@ -163,6 +164,10 @@ CRM.$(function($) {
 
   hideSearchFields();
 });
+
+function hideTimeFieldFromDatePicker() {
+  CRM.$('input.crm-form-time').hide();
+}
 
 function hideSearchFields() {
   var fieldsToHide  = [

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -105,20 +105,16 @@ CRM.$(function($) {
   CRM.$('#_qf_BatchTransaction_submit-top, #_qf_BatchTransaction_submit-bottom').click(function() {
     CRM.$('.crm-batch_transaction_search-accordion:not(.collapsed)').crmAccordionToggle();
   });
+
+  setDefaultFilterValues();
+
   var batchStatus = {/literal}{$statusID}{literal};
   {/literal}{if $validStatus}{literal}
-    // build transaction listing only for open/reopened batches
-    var paymentInstrumentID = {/literal}{if $paymentInstrumentID neq null}{$paymentInstrumentID}{else}'null'{/if}{literal};
-    if (paymentInstrumentID != 'null') {
-      buildTransactionSelectorAssign( true );
-    }
-    else {
-      buildTransactionSelectorAssign( false );
-    }
+    buildTransactionSelectorAssign();
     buildTransactionSelectorRemove();
 
     CRM.$('#_qf_BatchTransaction_submit-bottom, #_qf_BatchTransaction_submit-top').click( function() {
-      buildTransactionSelectorAssign( true );
+      buildTransactionSelectorAssign();
       return false;
     });
 
@@ -166,8 +162,6 @@ CRM.$(function($) {
   {/literal}{/if}{literal}
 
   hideSearchFields();
-  setDefaultFilterValues();
-
 });
 
 function hideSearchFields() {
@@ -203,13 +197,10 @@ function toggleFinancialSelections(toggleID, toggleClass) {
   }
 }
 
-function buildTransactionSelectorAssign(filterSearch) {
-  var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=getInstructionTransactionsList&snippet=4&context=instructionBatch&entityID=$entityID&entityTable=$entityTable&notPresent=1&statusID=$statusID"}'{literal};
+function buildTransactionSelectorAssign() {
+  var sourceUrl = {/literal}'{crmURL p="civicrm/ajax/rest" h=0 q="className=CRM_ManualDirectDebit_Page_AJAX&fnName=getInstructionTransactionsList&snippet=4&context=instructionBatch&entityID=$entityID&entityTable=$entityTable&notPresent=1&statusID=$statusID&search=1"}'{literal};
 
-  if ( filterSearch ) {
-    sourceUrl = sourceUrl+"&search=1";
-    var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}None found.{/ts}{literal}</li></ul></div>';
-  }
+  var ZeroRecordText = '<div class="status messages">{/literal}{ts escape="js"}None found.{/ts}{literal}</li></ul></div>';
 
   var columns = [
     {sClass:'crm-transaction-checkbox', bSortable:false, mData: "check"},
@@ -259,7 +250,7 @@ function buildTransactionSelectorAssign(filterSearch) {
       var searchData = {/literal}{$searchData}{literal};
       aoData = aoData.concat(searchData);
 
-      if ( filterSearch ) {
+
       CRM.$('#searchForm :input').each(function() {
         if (CRM.$(this).val()) {
           aoData.push(
@@ -272,7 +263,6 @@ function buildTransactionSelectorAssign(filterSearch) {
           });
         }
       });
-    }
 
       CRM.$.ajax({
       "dataType": 'json',
@@ -379,7 +369,7 @@ function bulkAssignRemove( action ) {
   CRM.$.post(postUrl, { ID: fids, actions:action }, function(data) {
     //this is custom status set when record update success.
     if (data.status == 'record-updated-success') {
-      buildTransactionSelectorAssign( true );
+      buildTransactionSelectorAssign();
       buildTransactionSelectorRemove();
       batchSummary({/literal}{$entityID}{literal});
     }
@@ -423,10 +413,12 @@ function setDefaultFilterValues() {
   cj('#contribution_status_id').select2().enable(false);
 
   // Date received
-  // set default end date to today's date if user chooses "Choose date range" option.
-  cj('#contribution_date_relative').on('change.select2', function(e){
-    if(e.val == 0) {
-      cj('#contribution_date_high').next().datepicker('setDate', new Date());
+  cj('#receive_date_relative').select2('val', 0).trigger('change');
+  cj('#receive_date_high').next().datepicker('setDate', new Date()).trigger('change');
+
+  cj('#receive_date_relative').on('change.select2', function(e){
+    if(e.val == "0") {
+      cj('#receive_date_high').next().datepicker('setDate', new Date()).trigger('change');
     }
   });
 


### PR DESCRIPTION
## Before

Users when search for contrbibutions in payment batch form need only to use the date filter, the time part is unimportant and we need to hide it : 


![2020-04-12 15_38_48-Direct Debit Payments _ s1mev2](https://user-images.githubusercontent.com/6275540/79069045-eb8c3700-7cd3-11ea-9f7d-f5f2e63924f1.png)


## After

![2020-04-12 15_38_04-Direct Debit Payments _ s1mev2](https://user-images.githubusercontent.com/6275540/79069044-e8914680-7cd3-11ea-8747-2511bd44d6e5.png)

