### PR TITLE
MAE-254: Improving "submit batch" modal text

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -184,27 +184,28 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     if ($batchTypes[$typeId] == 'instructions_batch') {
-      $submittedMessage = '<p>' . ts('You are submitting the batch results:') . '</p>';
-      $submittedMessage .= '<p>' . ts('-All mandates in the batch with code %1 will be transite to code %2', [
+      $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
+      $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
           1 => '0N',
           2 => '01',
         ]) . '</p>';
-      $submittedMessage .= '<p>' . ts('-The batch will be updated with \'Submitted\' status') . '</p>';
-      $submittedMessage .= '<p>' . ts('This process is not revertable.') . '</p>';
+      $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
+      $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     elseif ($batchTypes[$typeId] == 'dd_payments') {
-      $submittedMessage = '<p>' . ts('You are submitting the batch results:') . '</p>';
-      $submittedMessage .= '<p>' . ts('-All mandates in the batch with code %1 will be transite to code %2', [
+      $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
+      $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
           1 => '01',
           2 => '17',
         ]) . '</p>';
-      $submittedMessage .= '<p>' . ts('-All contributions in the batch with status \'Pending\' will be marked as \'Completed\'') . '</p>';
-      $submittedMessage .= '<p>' . ts('-The batch will be updated with \'Submitted\' status') . '</p>';
-      $submittedMessage .= '<p>' . ts('This process is not revertable.') . '</p>';
+
+      $submittedMessage .= '<p>' . ts('- All contributions in the batch with status \'Pending\' will be marked as \'Completed\'') . '</p>';
+      $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
+      $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     else {
       $submittedMessage = '<p>' . ts('Are you sure you want to submit this batch?') . '</p>';
-      $submittedMessage .= '<p>' . ts('This process is not revertable.') . '</p>';
+      $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
 
     return $submittedMessage;


### PR DESCRIPTION
## Before

When you are ready to submit a DD batch and you click the 'submit batch' button, you see the following:


Instructions Batch : 

![ins](https://user-images.githubusercontent.com/6275540/79069415-b03f3780-7cd6-11ea-8b76-d54f464f262c.png)


Payments Batch : 


![pa](https://user-images.githubusercontent.com/6275540/79069420-b2a19180-7cd6-11ea-9e11-bbd1b480681a.png)




## After

Here we updated the text to : 


Instructions Batch : 

![inaa](https://user-images.githubusercontent.com/6275540/79069446-e54b8a00-7cd6-11ea-9108-9ccee29f059b.png)


Payments Batch : 

![2020-04-12 16_01_29-View Payment Batches _ s1mev2](https://user-images.githubusercontent.com/6275540/79069450-ed0b2e80-7cd6-11ea-9749-9a8b176f3a45.png)



