### PR TITLE
MAE-220: Fix Issues with DD E-mail Templates

### DIFF
--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -220,7 +220,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     }
     $recurringContributionRows['recurringInstallmentsTable'] = $this->buildRecuringContributionTable($recurringContributionPlan, $totalTax);
     $total = $this->formatAmount($total);
-    $totalTax = $totalTax ? $this->formatAmount($totalTax) : null;
+    $totalTax = $totalTax ? $this->formatAmount($totalTax) : NULL;
 
     $this->tplParams['recurringContributionData'] = [
       'recurringContributionRows' => $recurringContributionRows,
@@ -351,7 +351,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'price' => $this->formatAmount($price),
         'entityTable' => $lineItem['entity_table'],
         'entityId' => $lineItem['entity_id'],
-        'tax' => $tax ? $this->formatAmount($tax) : null,
+        'tax' => $tax ? $this->formatAmount($tax) : NULL,
       ];
       $total += $price;
     }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -147,7 +147,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         mandate.dd_ref AS dd_ref,
         mandate.start_date AS start_date,
         mandate.authorisation_date AS authorisation_date
-      FROM civicrm_value_dd_information AS dd_information 
+      FROM civicrm_value_dd_information AS dd_information
       LEFT JOIN civicrm_value_dd_mandate AS mandate
         ON dd_information.mandate_id = mandate.id
       WHERE dd_information.entity_id = %1
@@ -220,7 +220,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     }
     $recurringContributionRows['recurringInstallmentsTable'] = $this->buildRecuringContributionTable($recurringContributionPlan, $totalTax);
     $total = $this->formatAmount($total);
-    $totalTax = $this->formatAmount($totalTax);
+    $totalTax = $totalTax ? $this->formatAmount($totalTax) : null;
 
     $this->tplParams['recurringContributionData'] = [
       'recurringContributionRows' => $recurringContributionRows,
@@ -283,7 +283,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
    */
   private function collectRecurringContributionRows($installmentsCount) {
     $query = "
-      SELECT 
+      SELECT
         contribution.total_amount AS amount,
         contribution.tax_amount AS tax_amount,
         contribution.receive_date AS receive_date,
@@ -298,7 +298,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       LEFT JOIN civicrm_financial_type AS financial_type
         ON contribution.financial_type_id = financial_type.id
       LEFT JOIN civicrm_contribution_recur AS contribution_recur
-        ON contribution.contribution_recur_id = contribution_recur.id  
+        ON contribution.contribution_recur_id = contribution_recur.id
       WHERE contribution.contribution_recur_id = %1
     ";
 
@@ -351,7 +351,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'price' => $this->formatAmount($price),
         'entityTable' => $lineItem['entity_table'],
         'entityId' => $lineItem['entity_id'],
-        'tax' => $this->formatAmount($tax),
+        'tax' => $tax ? $this->formatAmount($tax) : null,
       ];
       $total += $price;
     }
@@ -429,8 +429,8 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $completedStatus = CRM_ManualDirectDebit_Common_OptionValue::getValueForOptionValue('contribution_status', 'Completed');
 
     $query = "
-      SELECT 
-        contribution.receive_date AS next_payment_date, 
+      SELECT
+        contribution.receive_date AS next_payment_date,
         contribution.total_amount AS next_payment_amount
       FROM civicrm_membership_payment AS membership_payment
       LEFT JOIN civicrm_contribution AS contribution

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -57,6 +57,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
    * @return array
    */
   public function retrieve() {
+    $this->setShortDateFormat();
     $this->setContributionId();
     $this->loadContributionData();
     $this->setContactEmailData();
@@ -75,6 +76,13 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $this->generateActiveMembershipsTable();
 
     return $this->tplParams;
+  }
+
+  /**
+   * Loads short date format as configured in CiviCRM.
+   */
+  private function setShortDateFormat() {
+    $this->tplParams['shortDateFormat'] = Civi::Settings()->get('dateformatshortdate');
   }
 
   /**
@@ -162,8 +170,8 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'sort_code' => $dao->sort_code,
         'dd_ref' => $dao->dd_ref,
         'dd_code' => $this->getDdCode($dao->dd_code),
-        'start_date' => CRM_Utils_Date::customFormat($dao->start_date, '%d/%m/%Y'),
-        'authorisation_date' => CRM_Utils_Date::customFormat($dao->authorisation_date, '%d/%m/%Y'),
+        'start_date' => $dao->start_date,
+        'authorisation_date' => $dao->authorisation_date,
       ];
     }
   }
@@ -238,6 +246,8 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('totalTax', $totalTax);
     $smarty->assign('installments', $recurringContributionPlan);
+    $smarty->assign('shortDateFormat', $this->tplParams['shortDateFormat']);
+
     return $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/InstallmentList.tpl');
   }
 
@@ -443,7 +453,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
     while ($dao->fetch()) {
       $this->tplParams['nextMembershipPayment'] = [
-        'date' => CRM_Utils_Date::customFormat($dao->next_payment_date, '%d/%m/%Y'),
+        'date' => $dao->next_payment_date,
         'amount' => round($dao->next_payment_amount, 2)
       ];
     }
@@ -471,7 +481,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
   private function generateOrderSummaryTable() {
     $smarty = CRM_Core_Smarty::singleton();
-    $paramsToAssign = ['orderLineItems', 'recurringContributionData', 'currency'];
+    $paramsToAssign = ['orderLineItems', 'recurringContributionData', 'currency', 'shortDateFormat'];
     foreach ($paramsToAssign as $param) {
       $smarty->assign($param, $this->tplParams[$param]);
     }
@@ -482,6 +492,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
   private function generateActiveMembershipsTable() {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('activeMemberships', $this->tplParams['activeMemberships']);
+    $smarty->assign('shortDateFormat', $this->tplParams['shortDateFormat']);
 
     $this->tplParams['activeMembershipsTable']  =  $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl');
   }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -344,16 +344,16 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $orderLineItems = [];
     $total = 0;
     foreach ($lineItems['values'] as $lineItem) {
-      $price = $this->formatAmount($lineItem['line_total'] * $installmentsCount);
-      $tax = $this->formatAmount($lineItem['tax_amount'] * $installmentsCount);
+      $price = $lineItem['line_total'] * $installmentsCount;
+      $tax = $lineItem['tax_amount'] * $installmentsCount;
       $orderLineItems[] = [
         'label' => $lineItem['label'],
-        'price' => $price,
+        'price' => $this->formatAmount($price),
         'entityTable' => $lineItem['entity_table'],
         'entityId' => $lineItem['entity_id'],
-        'tax' => $tax,
+        'tax' => $this->formatAmount($tax),
       ];
-      $total += (float) $price;
+      $total += $price;
     }
 
     $this->tplParams['orderLineItems'] = $orderLineItems;

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
@@ -64,11 +64,11 @@
         </tr>
         <tr>
           <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date|crmDate:$shortDateFormat}</span></td>
         </tr>
         <tr>
           <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+          <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date|crmDate:$shortDateFormat}</span></td>
         </tr>
       </table>
     {/if}
@@ -103,7 +103,10 @@
           </div>
 
           <div>
-            <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+            <p style="color: black;">
+              {ts 1=$nextMembershipPayment.amount 2=$currency}Your next payment of %2%1 will be collected on{/ts}
+              {$nextMembershipPayment.date|crmDate:$shortDateFormat}
+            </p>
           </div>
         {/if}
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/AutoRenewNotification.tpl
@@ -83,7 +83,11 @@
         {foreach from=$paymentPlanMemberships item=membership}
           <div>
             <p style="color: black;">
-                {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                {if !empty($membership.tax)}
+                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency 4=$membership.tax}{$membership.label} at %3%1 (+%3%4 tax) per %2{/ts}.
+                {else}
+                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2{/ts}.
+                {/if}
             </p>
           </div>
         {/foreach}
@@ -113,7 +117,7 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-      <div style="padding-top: 60px">
+      <div style="padding-top: 30px">
         <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
           <tr >
             <th style="text-align: left; padding-left: 40px;">

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
@@ -83,7 +83,11 @@
         {foreach from=$paymentPlanMemberships item=membership}
             <div>
                 <p style="color: black;">
-                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                    {if !empty($membership.tax)}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency 4=$membership.tax}{$membership.label} at %3%1 (+%3%4 tax) per %2{/ts}.
+                    {else}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2{/ts}.
+                    {/if}
                 </p>
             </div>
         {/foreach}
@@ -113,7 +117,7 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-        <div style="padding-top: 60px">
+        <div style="padding-top: 30px">
             <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
                 <tr >
                     <th style="text-align: left; padding-left: 40px;">

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/MandateUpdateNotification.tpl
@@ -64,11 +64,11 @@
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date|crmDate:$shortDateFormat}</span></td>
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date|crmDate:$shortDateFormat}</span></td>
             </tr>
         </table>
     {/if}
@@ -103,7 +103,10 @@
             </div>
 
             <div>
-                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+                <p style="color: black;">
+                  {ts 1=$nextMembershipPayment.amount 2=$currency }Your next payment of %2%1 will be collected on{/ts}
+                  {$nextMembershipPayment.date|crmDate:$shortDateFormat}
+                </p>
             </div>
         {/if}
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
@@ -83,7 +83,11 @@
         {foreach from=$paymentPlanMemberships item=membership}
             <div>
                 <p style="color: black;">
-                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                    {if !empty($membership.tax)}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency 4=$membership.tax}{$membership.label} at %3%1 (+%3%4 tax) per %2{/ts}.
+                    {else}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2{/ts}.
+                    {/if}
                 </p>
             </div>
         {/foreach}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
@@ -113,7 +113,7 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-        <div style="padding-top: 60px">
+        <div style="padding-top: 30px">
             <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
                 <tr >
                     <th style="text-align: left; padding-left: 40px;">

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentCollectionReminder.tpl
@@ -64,11 +64,11 @@
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date|crmDate:$shortDateFormat}</span></td>
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date|crmDate:$shortDateFormat}</span></td>
             </tr>
         </table>
     {/if}
@@ -103,7 +103,10 @@
             </div>
 
             <div>
-                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+                <p style="color: black;">
+                  {ts 1=$nextMembershipPayment.amount 2=$currency }Your next payment of %2%1 will be collected on{/ts}
+                  {$nextMembershipPayment.date|crmDate:$shortDateFormat}
+                </p>
             </div>
         {/if}
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -83,7 +83,11 @@
         {foreach from=$paymentPlanMemberships item=membership}
             <div>
                 <p style="color: black;">
-                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                    {if !empty($membership.tax)}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency 4=$membership.tax}{$membership.label} at %3%1 (+%3%4 tax) per %2{/ts}.
+                    {else}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2{/ts}.
+                    {/if}
                 </p>
             </div>
         {/foreach}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -113,7 +113,7 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-        <div style="padding-top: 60px">
+        <div style="padding-top: 30px">
             <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
                 <tr >
                     <th style="text-align: left; padding-left: 40px;">

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -64,11 +64,11 @@
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date|crmDate:$shortDateFormat}</span></td>
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date|crmDate:$shortDateFormat}</span></td>
             </tr>
         </table>
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentSignUpNotification.tpl
@@ -103,7 +103,10 @@
             </div>
 
             <div>
-                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+                <p style="color: black;">
+                  {ts 1=$nextMembershipPayment.amount 2=$currency}Your next payment of %2%1 will be collected on{/ts}
+                  {$nextMembershipPayment.date|crmDate:$shortDateFormat}
+                </p>
             </div>
         {/if}
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
@@ -65,11 +65,11 @@
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Start Date{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.start_date|crmDate:$shortDateFormat}</span></td>
             </tr>
             <tr>
                 <td style="padding-left: 10px;"><span style="color: black;">{ts}Authorisation Date:{/ts}</span></td>
-                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date}</span></td>
+                <td style="padding-left: 10px;"><span style="color: black;">{$mandateData.authorisation_date|crmDate:$shortDateFormat}</span></td>
             </tr>
         </table>
     {/if}
@@ -104,7 +104,10 @@
             </div>
 
             <div>
-                <p style="color: black;">{ts 1=$nextMembershipPayment.amount 2=$nextMembershipPayment.date 3=$currency }Your next payment of %3%1 will be collected on %2{/ts}</p>
+                <p style="color: black;">
+                  {ts 1=$nextMembershipPayment.amount 2=$currency}Your next payment of %2%1 will be collected on{/ts}
+                  {$nextMembershipPayment.date|crmDate:$shortDateFormat}
+                </p>
             </div>
         {/if}
     {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
@@ -114,7 +114,7 @@
     {/if}
 
     {if isset($mandateData) and $mandateData}
-        <div style="padding-top: 60px">
+        <div style="padding-top: 30px">
             <table style="border-collapse: collapse;border: 1px solid black;max-width: 600px;width: 100%;">
                 <tr >
                     <th style="text-align: left; padding-left: 40px;">

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/PaymentUpdateNotification.tpl
@@ -84,7 +84,11 @@
         {foreach from=$paymentPlanMemberships item=membership}
             <div>
                 <p style="color: black;">
-                    {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2.{/ts}
+                    {if !empty($membership.tax)}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency 4=$membership.tax}{$membership.label} at %3%1 (+%3%4 tax) per %2{/ts}.
+                    {else}
+                        {ts 1=$membership.price 2=$membership.durationUnit 3=$currency }{$membership.label} at %3%1 per %2{/ts}.
+                    {/if}
                 </p>
             </div>
         {/foreach}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl
@@ -8,8 +8,8 @@
     {foreach from=$activeMemberships item=membership}
         <tr style="border: 1px solid black;">
             <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
-            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate|crmDate:'%d/%m/%Y'}</strong></p></td>
-            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate|crmDate:'%d/%m/%Y'}</strong></p></td>
+            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate|crmDate:$shortDateFormat}</strong></p></td>
+            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate|crmDate:$shortDateFormat}</strong></p></td>
         </tr>
     {/foreach}
 </table>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl
@@ -8,8 +8,8 @@
     {foreach from=$activeMemberships item=membership}
         <tr style="border: 1px solid black;">
             <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.name}</strong></p></td>
-            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate}</strong></p></td>
-            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate}</strong></p></td>
+            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.startDate|crmDate:'%d/%m/%Y'}</strong></p></td>
+            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$membership.endDate|crmDate:'%d/%m/%Y'}</strong></p></td>
         </tr>
     {/foreach}
 </table>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/InstallmentList.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/InstallmentList.tpl
@@ -1,7 +1,11 @@
 <table>
     <tr>
         <th style="padding-left: 10px;"><strong>Installment No.</strong></th>
-        <th style="padding-left: 10px;"><strong>Amount</strong></th>
+        {if !empty($totalTax)}
+          <th style="padding-left: 10px;"><strong>Value</strong></th>
+          <th style="padding-left: 10px;"><strong>Tax</strong></th>
+        {/if}
+        <th style="padding-left: 10px;"><strong>Total Amount</strong></th>
         <th style="padding-left: 10px;"><strong>Due Date</strong></th>
     </tr>
     {foreach from=$installments item=recurringPlanRow}
@@ -9,11 +13,19 @@
             <td style="padding-left: 10px;">
                 {$recurringPlanRow.index}
             </td>
+            {if !empty($totalTax)}
+              <td style="padding-left: 10px;">
+                £{$recurringPlanRow.sub_total}
+              </td>
+              <td style="padding-left: 10px;">
+                £{$recurringPlanRow.tax}
+              </td>
+            {/if}
             <td style="padding-left: 10px;">
                 £{$recurringPlanRow.amount}
             </td>
             <td style="padding-left: 10px;">
-                {$recurringPlanRow.due_date}
+                {$recurringPlanRow.due_date|crmDate:'%d/%m/%Y'}
             </td>
         </tr>
     {/foreach}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/InstallmentList.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/InstallmentList.tpl
@@ -25,7 +25,7 @@
                 £{$recurringPlanRow.amount}
             </td>
             <td style="padding-left: 10px;">
-                {$recurringPlanRow.due_date|crmDate:'%d/%m/%Y'}
+                {$recurringPlanRow.due_date|crmDate:$shortDateFormat}
             </td>
         </tr>
     {/foreach}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
@@ -18,7 +18,7 @@
     <tr style="border: 1px solid black;">
         <td style="padding-left: 10px;">
           <p style="color: black">
-            {ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}
+            {ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid in %1 installments of %3%2 each{/ts}
             {if !empty($recurringContributionData.tax_total)}
               (includes {$currency}{$recurringContributionData.tax_total/$recurringContributionData.installments} tax)
             {/if}

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
@@ -7,16 +7,23 @@
     {foreach from=$orderLineItems item=lineItem}
         <tr style="border: 1px solid black;">
             <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$lineItem.label}</strong></p></td>
-            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}</strong></p></td>
+            <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$lineItem.price}{if !empty($lineItem.tax)} (+{$currency}{$lineItem.tax} tax){/if}</strong></p></td>
         </tr>
     {/foreach}
 
     <tr style="border: 1px solid black;">
         <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{ts}Total{/ts}</strong></p></td>
-        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}</strong></p></td>
+        <td style="border: 1px solid black;padding-left: 10px;"><p style="color: black;"><strong>{$currency}{$recurringContributionData.total}{if !empty($recurringContributionData.tax_total)} (+{$currency}{$recurringContributionData.tax_total} tax){/if}</strong></p></td>
     </tr>
     <tr style="border: 1px solid black;">
-        <td style="padding-left: 10px;"><p style="color: black">{ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}</p></td>
+        <td style="padding-left: 10px;">
+          <p style="color: black">
+              {ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}
+            {if !empty($recurringContributionData.tax_total)}
+                (includes {$currency}{$recurringContributionData.tax_total/$recurringContributionData.installments} tax)
+            {/if}
+          </p>
+        </td>
         <td style="padding-left: 10px;"><p></p></td>
     </tr>
 </table>

--- a/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
+++ b/templates/CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl
@@ -18,9 +18,9 @@
     <tr style="border: 1px solid black;">
         <td style="padding-left: 10px;">
           <p style="color: black">
-              {ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}
+            {ts 1=$recurringContributionData.installments 2=$recurringContributionData.installments_paid 3=$currency }To be paid on %1 installments of %3%2 each{/ts}
             {if !empty($recurringContributionData.tax_total)}
-                (includes {$currency}{$recurringContributionData.tax_total/$recurringContributionData.installments} tax)
+              (includes {$currency}{$recurringContributionData.tax_total/$recurringContributionData.installments} tax)
             {/if}
           </p>
         </td>


### PR DESCRIPTION
## Overview
Several fixes needed to be done on the DD e-mail templates:

1. Membership Amount shown on DD email notification is not included with VAT value. If you check the contribution amount & total amount, VAT is not included, while in some places of the email, VAT is included in the contribution amount.
2. Direct Debit Logo is missing on the email.
3. Spacing of the Direct Debit Guarantee block was too large.
4. Dates should be in CiviCRM short date format, as per configured settings on all the instances.

## Before
1. Tax was not taken into account when building the templates.
2. The URL for the logo was being built as a relative URL, but on the e-mail we need the absolute URL to be able to locate the image.
3. 60px were hard-coded as spacing before the guarantee block.
4. Dates were being shown in yyyy-mm-dd format.

![image](https://user-images.githubusercontent.com/21999940/79336300-18fdfe00-7ee9-11ea-9e81-17983cc804fe.png)

## After
1. Added taxes to records and totals, to be used in templates, and showed tax values where applicable, if contributions actually have tax.
2. Built the absolute URL so the image gets resolved when opening the e-mail.
2. Reduced spacing to 30px.
4. Obtained CiviCRM shortdate setting and passed format to all the templates, so it can be used to print dates in this format.

![image](https://user-images.githubusercontent.com/21999940/79336123-cae8fa80-7ee8-11ea-977e-f92ace9f54ec.png)
