### PR TITLE
MAE-221: Fix Total Amount Calculation on Mailings Membership Summary

### DIFF
--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -323,14 +323,14 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $orderLineItems = [];
     $total = 0;
     foreach ($lineItems['values'] as $lineItem) {
-      $price = $this->formatAmount($lineItem['line_total'] * $installmentsCount);
+      $price = $lineItem['line_total'] * $installmentsCount;
       $orderLineItems[] = [
         'label' => $lineItem['label'],
-        'price' => $price,
+        'price' => $this->formatAmount($price),
         'entityTable' => $lineItem['entity_table'],
         'entityId' => $lineItem['entity_id'],
       ];
-      $total += (float) $price;
+      $total += $price;
     }
 
     $this->tplParams['orderLineItems'] = $orderLineItems;


### PR DESCRIPTION
## Overview
Incorrect total amount is displayed on DD email notification sent for Organisation membership with >1 Installments.

![image](https://user-images.githubusercontent.com/21999940/79781489-28bf7d00-8303-11ea-99b7-150986c496c1.png)

## Before
The price for each line item was being formatted to be human-readable before using it to totalize the amount for the whole plan. On amounts below 1000, this wasn't a problem, but on larger amounts, the addec separators caused the value to be incorrectly parsed as a float. For example, `1,000.00` got parsed as `1.00`, causing the wrong values.

## After
Used unformatted price values for each line to totalize, and formatted the numbers after they were used on calculations.

![image](https://user-images.githubusercontent.com/21999940/79781750-966ba900-8303-11ea-9b3a-90fffb8e580d.png)
