### PR TITLE
CGP-1474: Allow users to update Direct Debit batches

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -338,7 +338,10 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     ];
 
     if($this->getBatchType() == 'dd_payments') {
+      $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
+    } else {
+      $returnValues['mandate_id'] = 'civicrm_value_dd_mandate.id as mandate_id';
     }
 
     return $this->getMandateCurrentState($returnValues);
@@ -374,11 +377,15 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
         case 'instructions_batch':
-          $dataForExport[$mandateItem['mandate_id']] = $mandateItem;
+          $entityId = $mandateItem['mandate_id'];
+          unset($mandateItem['mandate_id']);
+          $dataForExport[$entityId] = $mandateItem;
           break;
 
         case 'dd_payments':
-          $dataForExport[$mandateItem['contribute_id']] = $mandateItem;
+          $entityId = $mandateItem['contribute_id'];
+          unset($mandateItem['contribute_id']);
+          $dataForExport[$entityId] = $mandateItem;
           break;
       }
     }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -379,11 +379,18 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           break;
 
         case "dd_payments":
-          if (!empty($mandateItem['contact_id'])) {
-            $row['action'] = $this->getLinkToContribution($mandateItem['id'], $mandateItem['contact_id']);
+          if (isset($mandateItem['contribute_id'])) {
+            $contributionId = $mandateItem['contribute_id'];
+          }
+          else {
+            $contributionId = $mandateItem['id'];
           }
 
-          $rows[$mandateItem['id']] = $row;
+          if (!empty($mandateItem['contact_id'])) {
+            $row['action'] = $this->getLinkToContribution($contributionId, $mandateItem['contact_id']);
+          }
+
+          $rows[$contributionId] = $row;
           break;
       }
 

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -296,16 +296,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    */
   public function getRows() {
     $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
-    $mandateData = $batch->getBatchValues();
-
-    if (isset($mandateData['values']['mandates']) && !empty($mandateData['values']['mandates']) && $this->notPresent != 1) {
-      $rows = $this->getSavedRows($mandateData, $batch);
-    }
-    else {
-      $rows = $this->getBatchRows($batch);
-    }
-
-    return $rows;
+    return $this->getBatchRows($batch);
   }
 
 

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -119,9 +119,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $params['data'] = json_encode(
-      ['values' => [
-        'originator_number' => $params['originator_number'],
-      ]]
+      ['originator_number' => $params['originator_number']]
     );
 
     $params['modified_date'] = date('YmdHis');

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -119,7 +119,9 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $params['data'] = json_encode(
-      ['originator_number' => $params['originator_number']]
+      ['values' => [
+        'originator_number' => $params['originator_number'],
+      ]]
     );
 
     $params['modified_date'] = date('YmdHis');

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -108,7 +108,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
     return [
       [
         'name' => 'originator_number',
-        'value' => $batchData['originator_number'],
+        'value' => $batchData['values']['originator_number'],
       ],
       [
         'name' => 'dd_code',
@@ -143,7 +143,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
     return [
       [
         'name' => 'originator_number',
-        'value' => $batchData['originator_number'],
+        'value' => $batchData['values']['originator_number'],
       ],
       [
         'name' => 'dd_code',

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -54,6 +54,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
           'title' => ts('Submit Transaction'),
           'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'submit' . '\' );"',
         ],
+        CRM_Core_Action::UPDATE => [
+          'name' => ts('Update'),
+          'url' => 'civicrm/direct_debit/batch-transaction',
+          'qs' => 'reset=1&bid=%%id%%&action=update',
+          'title' => ts('Update Transaction'),
+        ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Discard'),
           'title' => ts('Discard Transaction'),
@@ -101,6 +107,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         'Reopened',
       ])) {
         $action -= CRM_Core_Action::ENABLE;
+        $action -= CRM_Core_Action::UPDATE;
         $action -= CRM_Core_Action::DISABLE;
       }
 


### PR DESCRIPTION
## Before
There is no way for the user to update Direct Debit batches (instructions and payments batches). Also even after saving the batch, if the user tried to open the batch update page by going directly to the batch update URL from the browser or by trying to click the back button, the newly added stuff won't appear on the batch view page.


## After
There is now a link to update the batch under the "Submit" button as can  be seen below, also the ability to assign new mandates or contributions to the batch is fixed.

![aaaaa](https://user-images.githubusercontent.com/6275540/79918928-0ed28700-8436-11ea-92f6-485858dae422.gif)

## Technical notes

The issue here with the mandate edit page originate from the way the extension stores mandates (or contributions in case of payment batch) assigned to the batch, when you create the batch for the first time and start assisting mandates to the batch, it will use ajax to store these mandates inside a table called civicrm_entity_batch. And when the user hit the "Save" or "Save and export" button, it will call the form controller postProcess method and store the mandates again in a table called civicrm_batch inside a field called data but in serialized form.
Now if the user used the back button to get back to the batch edit page (or if tried to access it from the browser URL bar) and started to add new mandates to the batch, these batches will be added as above to the civicrm_entity_batch table, but when the user hit the save button and the form postProcess method is called again, it will not update the other civicrm_batch table data field since the postProcess method here only update this field if it empty, and this field is only empty when you save the form for the first time.

Now the thing is that the extension in general tries to get the assigned mandates inside the civicrm_batch data table first, if it fails then it will run some complex query to get the assigned mandates (it is not as easy as just fetching the records inside civicrm_entity_batch table since other information related to the contact and the contribution need to be fetched too), and since not all assigned mandates are stored inside the civicrm_batch data field, the issue above happen.

I fixed the issue here by removing the code that store the mandates in serialized form inside the data field of civicrm_batch table, given that it is how civicrm core functionality work too and that for high number of records storing the record that way might become a problem. This means that civicrm_entity_batch table now is the only table that stored the related mandates (or contributions) for the batch. This also means that the functionality of the "Save" button is no longer needed, and now it more of a facade that its purpose just to redirect you to the batch view page after finishing assigning mandates to it.

The above means that I also get rid of any part of code that use the serialized information inside the data field, and currently the only information that is stored in it is the batch originator number, which is still used since there is no other place or data structure to store this information currently (which is needed to filter the batch related mandates or contributions).
