### PR TITLE
MAE-290: Improve DD batch submission performance by using task queue

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -338,7 +338,10 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     ];
 
     if($this->getBatchType() == 'dd_payments') {
+      $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
+    } else {
+      $returnValues['mandate_id'] = 'civicrm_value_dd_mandate.id as mandate_id';
     }
 
     return $this->getMandateCurrentState($returnValues);
@@ -374,11 +377,15 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
         case 'instructions_batch':
-          $dataForExport[$mandateItem['mandate_id']] = $mandateItem;
+          $entityId = $mandateItem['mandate_id'];
+          unset($mandateItem['mandate_id']);
+          $dataForExport[$entityId] = $mandateItem;
           break;
 
         case 'dd_payments':
-          $dataForExport[$mandateItem['contribute_id']] = $mandateItem;
+          $entityId = $mandateItem['contribute_id'];
+          unset($mandateItem['contribute_id']);
+          $dataForExport[$entityId] = $mandateItem;
           break;
       }
     }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -379,11 +379,18 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           break;
 
         case "dd_payments":
-          if (!empty($mandateItem['contact_id'])) {
-            $row['action'] = $this->getLinkToContribution($mandateItem['id'], $mandateItem['contact_id']);
+          if (isset($mandateItem['contribute_id'])) {
+            $contributionId = $mandateItem['contribute_id'];
+          }
+          else {
+            $contributionId = $mandateItem['id'];
           }
 
-          $rows[$mandateItem['id']] = $row;
+          if (!empty($mandateItem['contact_id'])) {
+            $row['action'] = $this->getLinkToContribution($contributionId, $mandateItem['contact_id']);
+          }
+
+          $rows[$contributionId] = $row;
           break;
       }
 

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -296,16 +296,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    */
   public function getRows() {
     $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
-    $mandateData = $batch->getBatchValues();
-
-    if (isset($mandateData['values']['mandates']) && !empty($mandateData['values']['mandates']) && $this->notPresent != 1) {
-      $rows = $this->getSavedRows($mandateData, $batch);
-    }
-    else {
-      $rows = $this->getBatchRows($batch);
-    }
-
-    return $rows;
+    return $this->getBatchRows($batch);
   }
 
 

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -119,9 +119,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $params['data'] = json_encode(
-      ['values' => [
-        'originator_number' => $params['originator_number'],
-      ]]
+      ['originator_number' => $params['originator_number']]
     );
 
     $params['modified_date'] = date('YmdHis');

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -119,7 +119,9 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $params['data'] = json_encode(
-      ['originator_number' => $params['originator_number']]
+      ['values' => [
+        'originator_number' => $params['originator_number'],
+      ]]
     );
 
     $params['modified_date'] = date('YmdHis');

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -108,7 +108,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
     return [
       [
         'name' => 'originator_number',
-        'value' => $batchData['originator_number'],
+        'value' => $batchData['values']['originator_number'],
       ],
       [
         'name' => 'dd_code',
@@ -143,7 +143,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
     return [
       [
         'name' => 'originator_number',
-        'value' => $batchData['originator_number'],
+        'value' => $batchData['values']['originator_number'],
       ],
       [
         'name' => 'dd_code',

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -197,7 +197,6 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'assign' => 'create',
       'remove' => 'del',
       'discard' => 'create',
-      'submit' => 'create',
     ];
 
     $response = ['status' => 'record-updated-fail'];
@@ -225,18 +224,6 @@ class CRM_ManualDirectDebit_Page_AJAX {
             $params['modified_date'] = date('YmdHis');
             $params['modified_id'] = $session->get('userID');
             $params['id'] = $recordID;
-            break;
-          case 'submit':
-            $dd = new CRM_ManualDirectDebit_Batch_BatchHandler($recordID);
-
-            if ($dd->submitBatch()) {
-              $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
-              $params['status_id'] = CRM_Utils_Array::key('Submitted', $batchStatus);
-              $session = CRM_Core_Session::singleton();
-              $params['modified_date'] = date('YmdHis');
-              $params['modified_id'] = $session->get('userID');
-              $params['id'] = $recordID;
-            }
             break;
         }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -52,7 +52,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         CRM_Core_Action::ENABLE => [
           'name' => ts('Submit'),
           'title' => ts('Submit Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'submit' . '\' );"',
+          'extra' => 'onclick = "submitBatch(%%id%%);"',
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Update'),

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -54,6 +54,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
           'title' => ts('Submit Transaction'),
           'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'submit' . '\' );"',
         ],
+        CRM_Core_Action::UPDATE => [
+          'name' => ts('Update'),
+          'url' => 'civicrm/direct_debit/batch-transaction',
+          'qs' => 'reset=1&bid=%%id%%&action=update',
+          'title' => ts('Update Transaction'),
+        ],
         CRM_Core_Action::DISABLE => [
           'name' => ts('Discard'),
           'title' => ts('Discard Transaction'),
@@ -101,6 +107,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         'Reopened',
       ])) {
         $action -= CRM_Core_Action::ENABLE;
+        $action -= CRM_Core_Action::UPDATE;
         $action -= CRM_Core_Action::DISABLE;
       }
 

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -1,0 +1,45 @@
+<?php
+
+class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
+
+  private $queue;
+
+  private $batchId;
+
+  public function __construct($title = NULL, $mode = NULL) {
+    parent::__construct($title, $mode);
+
+    $this->queue = CRM_ManualDirectDebit_Queue_BatchSubmission::getQueue();
+    $this->batchId =  CRM_Utils_Request::retrieveValue('batchId', 'Int');
+  }
+
+  public function run() {
+    $this->enqueueBatchSubmissionTask();
+    $this->runQueue();
+  }
+
+  private function enqueueBatchSubmissionTask() {
+    $task = new CRM_Queue_Task(
+      ['CRM_ManualDirectDebit_Queue_Task_BatchSubmission', 'run'],
+      [$this->batchId]
+    );
+    $this->queue->createItem($task);
+  }
+
+  private function runQueue() {
+    $runner = new CRM_Queue_Runner([
+      'title' => ts('Submitting the batch, this may take a while depending on how many records are processed ..'),
+      'queue' => $this->queue,
+      'errorMode'=> CRM_Queue_Runner::ERROR_ABORT,
+      'onEnd' => array('CRM_ManualDirectDebit_Page_BatchSubmissionQueue', 'onEnd'),
+      'onEndUrl' => CRM_Utils_System::url('civicrm/direct_debit/batch-transaction', ['reset' => 1, 'action' => 'view', 'bid' => $this->batchId]),
+    ]);
+
+    $runner->runAllViaWeb();
+  }
+
+  public static function onEnd(CRM_Queue_TaskContext $ctx) {
+    $message = ts('Batch Submission Completed');
+    CRM_Core_Session::setStatus($message, '', 'success');
+  }
+}

--- a/CRM/ManualDirectDebit/Queue/BatchSubmission.php
+++ b/CRM/ManualDirectDebit/Queue/BatchSubmission.php
@@ -1,0 +1,21 @@
+<?php
+
+class CRM_ManualDirectDebit_Queue_BatchSubmission {
+
+  const QUEUE_NAME = 'uk.co.compucorp.manualdirectdebit.queue.batchsubmission';
+
+  private static $queue;
+
+  public static function getQueue() {
+    if(!self::$queue) {
+      self::$queue = CRM_Queue_Service::singleton()->create([
+        'type' => 'Sql',
+        'name' => self::QUEUE_NAME,
+        'reset' => false,
+      ]);
+    }
+
+    return self::$queue;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_ManualDirectDebit_Queue_Task_BatchSubmission {
+
+  public static function run(CRM_Queue_TaskContext $ctx, $batchId) {
+    $batchHandler = new CRM_ManualDirectDebit_Batch_BatchHandler($batchId);
+    if ($batchHandler->submitBatch()) {
+      $session = CRM_Core_Session::singleton();
+      $loggedInUserId = $session->get('userID');
+
+      civicrm_api3('Batch', 'create', [
+        'id' => $batchId,
+        'status_id' => 'Submitted',
+        'modified_date' => date('YmdHis'),
+        'modified_id' => $loggedInUserId
+      ]);
+    }
+
+    return TRUE;
+  }
+
+}

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -56,27 +56,29 @@
     order: []
   });
 
-  function assignRemove(recordID, op) {
-    if (op == 'submit') {
-      CRM.$("#enableDisableStatusMsg").dialog({
-        title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
-        modal: true,
-        open: function () {
-          var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
+  function submitBatch(batchId) {
+    CRM.$("#enableDisableStatusMsg").dialog({
+      title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
+      modal: true,
+      open: function () {
+        var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
 
-          CRM.$('#enableDisableStatusMsg').show().html(msg);
+        CRM.$('#enableDisableStatusMsg').show().html(msg);
+      },
+      buttons: {
+        {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {
+          CRM.$(this).dialog("close");
         },
-        buttons: {
-          {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {
-              CRM.$(this).dialog("close");
-          },
-          {/literal}"{ts escape='js'}Submit{/ts}"{literal}: function () {
-              CRM.$(this).dialog("close");
-              saveRecord(recordID, op);
-          }
+        {/literal}"{ts escape='js'}Submit{/ts}"{literal}: function () {
+          CRM.$(this).dialog("close");
+          window.location.href = CRM.url('civicrm/direct_debit/batch/submit', {batchId: batchId});
         }
-      });
-    } else if (op == 'discard') {
+    }
+    });
+  }
+
+  function assignRemove(recordID, op) {
+    if (op == 'discard') {
       CRM.$("#enableDisableStatusMsg").dialog({
         title: {/literal}'{ts escape="js"}Discard Batch{/ts}'{literal},
         modal: true,

--- a/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
@@ -67,33 +67,33 @@ CRM.$(function($) {
     return false;
   });
   CRM.$('#submitted').click( function() {
-    assignRemove(entityID, 'submit');
+      submitBatch(entityID);
     return false;
   });
 });
 
-function assignRemove(recordID, op) {
-  if (op == 'submit') {
-    CRM.$("#enableDisableStatusMsg").dialog({
-      title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
-      modal: true,
-      open: function () {
-        var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
-
-        CRM.$('#enableDisableStatusMsg').show().html(msg);
+function submitBatch(batchId) {
+  CRM.$("#enableDisableStatusMsg").dialog({
+    title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
+    modal: true,
+    open: function () {
+      var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
+      CRM.$('#enableDisableStatusMsg').show().html(msg);
+    },
+    buttons: {
+      {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {
+        CRM.$(this).dialog("close");
       },
-      buttons: {
-        {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {
-          CRM.$(this).dialog("close");
-        },
-        {/literal}"{ts escape='js'}Submit{/ts}"{literal}: function () {
-          CRM.$(this).dialog("close");
-          var recordBAO = 'CRM_Batch_BAO_Batch';
-          saveRecord(recordID, op, recordBAO, null);
-        }
+      {/literal}"{ts escape='js'}Submit{/ts}"{literal}: function () {
+        CRM.$(this).dialog("close");
+        window.location.href = CRM.url('civicrm/direct_debit/batch/submit', {batchId: batchId});
       }
-    });
-  } else if (op == 'discard') {
+    }
+  });
+}
+
+function assignRemove(recordID, op) {
+  if (op == 'discard') {
     CRM.$("#enableDisableStatusMsg").dialog({
       title: {/literal}'{ts escape="js"}Discard Batch{/ts}'{literal},
       modal: true,
@@ -141,7 +141,7 @@ function saveRecord(recordID, op, recordBAO, entityID) {
   CRM.$.post( postUrl, { records: [recordID], recordBAO: recordBAO, op:op, entityID:entityID, key: {/literal}"{crmKey name='civicrm/ajax/ar'}"{literal},  originator_number: {/literal}"{$originator_number}"{literal} }, function( html ){
     //this is custom status set when record update success.
     if (html.status == 'record-updated-success') {
-      if (op == 'discard' || op == 'submit') {
+      if (op == 'discard') {
         window.location.href = CRM.url('civicrm/direct_debit/batch-list', 'reset=1&type_id=' + {/literal}"{$batchType_id}"{literal});
       }
       else {

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -30,6 +30,11 @@
     <weight>610</weight>
   </item>
   <item>
+    <path>civicrm/direct_debit/batch/submit</path>
+    <page_callback>CRM_ManualDirectDebit_Page_BatchSubmissionQueue</page_callback>
+    <title>Batch Submission Queue</title>
+  </item>
+  <item>
     <path>civicrm/direct_debit/mandate/create</path>
     <page_callback>CRM_ManualDirectDebit_Form_Mandate_Create</page_callback>
     <title>Mandate_Create</title>


### PR DESCRIPTION
## Before
Submitting a batch with high number of records will result in timeout error.

## After
Submitting batches works now with high number of records without any timeout by 
changing the way the batches are submitted by using CiviCRM task queue runner, which allows for running the batch submission process in the background.

## UI Changes

Since we are now using the task queue runner, the UI for submitting DD batches now look like the following : 

![beee](https://user-images.githubusercontent.com/6275540/80045256-7f99a200-850f-11ea-8796-599483f2f724.gif)

![affff222](https://user-images.githubusercontent.com/6275540/80045262-83c5bf80-850f-11ea-9ca3-0258d3490ab7.gif)


## Technical notes

