### PR TITLE
MAE-224: Prevent changing mandate from recur contribution edit form

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -75,6 +75,12 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
     $requiredFields[] = 'mandate_id';
     $this->form->assign('requiredPaymentFields', $requiredFields);
 
+    $extraAttributes = [];
+    $isEditRecurContributionForm = $this->form->_formName == 'UpdateSubscription';
+    if ($isEditRecurContributionForm) {
+      $extraAttributes['disabled'] = true;
+    }
+
     $contactID = CRM_Utils_Request::retrieve('cid', 'Int');
     $this->form->setDefaults(['mandate_id' => $this->getNewlyCreatedMandateID($contactID)]);
     $this->form->add(
@@ -83,7 +89,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
       'Mandate',
       $this->getMandateOptionsForContact($contactID),
       TRUE,
-      []
+      $extraAttributes
     );
   }
 
@@ -181,5 +187,5 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
 
     return FALSE;
   }
-  
+
 }


### PR DESCRIPTION
## Overview

We have multiple places in which users can change mandates, one of them is the one on the recurring contribution edit form, the issue with it in this form is that does not allow users to send a notification email to the contact about the mandate change, so we decided to disable the ability to change the mandate on the mentioned form instead of having to add and maintain the email sending feature. Users still have other places to change the mandate if they want to.

## Before

![2020-04-30 17_18_45-Window](https://user-images.githubusercontent.com/6275540/80721930-b7e44600-8af6-11ea-8f49-293285c4cc1b.png)


## After

![2020-04-30 17_17_30-Window](https://user-images.githubusercontent.com/6275540/80722098-e82be480-8af6-11ea-8afb-de9912bc08be.png)

