### PR TITLE
BASW-623: Fix attachment bewteen Contribution and mandate after recording a payment without selecting mandate

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -45,6 +45,11 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
       return;
     }
 
+    // Selecting mandate is not needed when recording payments
+    if ($this->form->_formName == 'AdditionalPayment') {
+      return;
+    }
+
     $contactID = CRM_Utils_Request::retrieve('cid', 'Int');
     if (empty($contactID)) {
       CRM_Core_Session::setStatus(


### PR DESCRIPTION
## Overview

1- Go to "Administer >> Payment Plan Settings" page and change the "Offline payment processor for back office" select field to "Live - Direct Debit" (you can also pick Test - Direct Debit).

2- Create a contact and add a membership to the contact with Payment Plan and Direct Debit payment method.

3- Complete any contribution (using record payment option), and choose "Direct Debit" as the payment method but leave the mandate field empty (pointing to the empty select option " - select -").

![2020-05-20 14_13_05-Window](https://user-images.githubusercontent.com/6275540/82450504-b201d500-9aa4-11ea-9bfb-062d4fafa9a0.png)


4- now try to delete any mandate or assigning new one to the recur contribution and it will fail showing a database error.

5- also if you "view" the completed contribution, the assigned mandate will be a hyphen instead of pointing to the actual mandate.

![2020-05-20 16_19_40-Window](https://user-images.githubusercontent.com/6275540/82450742-fd1be800-9aa4-11ea-89b2-c105c7e1ab00.png)

In general, it does not make sense to select a mandate when recording a payment since it is not a place where the mandate is allowed to change, and thus the option should be hidden.


## Before

Selecting "Direct Debit" as payment method when recording a payment will ask users to select a mandate : 

![2020-05-20 16_25_24-Window](https://user-images.githubusercontent.com/6275540/82451405-dc07c700-9aa5-11ea-81d1-fded290a6fc5.png)

which will cause other issues if the user did not select any.

## After

Users cannot select a mandate any more if they are recording a payment with "Direct Debit" payment method.

![2020-05-20 16_25_03-Window](https://user-images.githubusercontent.com/6275540/82451440-e7f38900-9aa5-11ea-8b6f-d94125578db6.png)



## Technical notes

So if you go to replication steps again, you will find that the issue happen after you at least completed one Direct Debit contribution and kept the mandate field empty and only if the "Offline payment processor for back office" is pointing to Direct Debit payment processor, and this happen because The Manual Direct Debit extension runs the following code when you try to record a contribution using Direct Debit :

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/4debd550569d9038a53d4fdc020bc6e7b35942af/manualdirectdebit.php#L210-L212

which will end up calling this code :

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/4debd550569d9038a53d4fdc020bc6e7b35942af/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php#L124-L136

part of this code checks if the recur contribution related to the completed contribution is paid using "Direct Debit" payment processor (and it will be the case if we creating the membership using CiviCRM instead of let's say webforms and in case we have "Offline payment processor for back office" pointing to Direct Debit payment processor), and if so then it will try to assign the new mandate value to the related contributions, but hence that we did not select any mandate when we completed the contribution and instead it was pointing to the " - select " option which has the value of "" (hyphen) and this will end up changing the mandate value of the contribution to "-" (hyphen). Most of Compubox sites have "Live - Offline Recuring contribution" as payment processor this means that part of the code won't be called and thus the contribution mandate value will remain the same after recording the payment.

And while having the contribution mandate to get changed to hyphen when recording a payment without selecting a mandate is an issue that need to be solved probably by hiding the mandate field and make it point by default to the original mandate, why removing or assigning new mandate will result in DB error ?

And what I found is that (after enabling "show backtrace" and "enable debugging" options on civi) is the following if you try to assign new mandate :

```
    [code] => -1
    [message] => DB Error: unknown error
    [mode] => 16
    [debug_info] => UPDATE `civicrm_value_dd_information` AS dd_information 
              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id 
              SET dd_information.mandate_id = 22 
              WHERE dd_information.mandate_id = 21 
              AND contribution.contribution_status_id != 1 [nativecode=1292 ** Truncated incorrect DOUBLE value: '-']
    [type] => DB_Error
```

or this if you are trying to delete a mandate :

```
[db_error: message="DB Error: unknown error" code=-1 mode=callback callback=CRM_Core_Error::exceptionHandler prefix="" info=" DELETE FROM `civicrm_value_dd_information` 
WHERE civicrm_value_dd_information.mandate_id = 22 [nativecode=1292 ** Truncated incorrect DOUBLE value: '-']"] )
```

So the main error is :

```
nativecode=1292 ** Truncated incorrect DOUBLE value: '-'
```

And it seems that this issue happen when :

1-MySQL strict mode enabled
2- The mandate_id field is varchar but we are normally store integers in it, so as long as it contains integers then updating or deleting records from it will work fine.
3- Change the mandate_id in at least one record to a charterer instead of integer, now if you now try to update or delete any other record it will show the above error.

And while I couldn't find a straight answer on the web or MySQL docs, it seems that MySQL do some optimization on the varchar field if it only contains integers, so that's why it work fine initially, but once at least one record break this rule (in our case a hyphen will be stored inside the mandate_id field and the hyphen is a character) it seems as if MySQL disable this optimization, and since strict mode is enabled, trying to delete any record with the mandate_id in the WHERE clause without respecting the mandate_id field type (not surrounding the value in quotes) will result in the above error.

I decided to solve this just by prevent users from selecting a mandate if they are recording a payment, since it is not something that need to be changed if users are recording a payment, and thus no hyphen will be stored inside the database anymore.