### PR TITLE
BASW-622: Hide and reserve DD activity types

### DIFF
--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -423,6 +423,8 @@
       <weight>100</weight>
       <description>New Direct Debit Recurring Payment</description>
       <option_group_name>activity_type</option_group_name>
+      <filter>1</filter>
+      <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
@@ -432,6 +434,8 @@
       <weight>101</weight>
       <description>Update Direct Debit Recurring Payment</description>
       <option_group_name>activity_type</option_group_name>
+      <filter>1</filter>
+      <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
@@ -441,6 +445,8 @@
       <weight>102</weight>
       <description>Direct Debit Payment Reminder</description>
       <option_group_name>activity_type</option_group_name>
+      <filter>1</filter>
+      <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
@@ -450,6 +456,8 @@
       <weight>103</weight>
       <description>Offline Direct Debit Auto-renewal</description>
       <option_group_name>activity_type</option_group_name>
+      <filter>1</filter>
+      <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
@@ -459,6 +467,8 @@
       <weight>104</weight>
       <description>Direct Debit Mandate Update</description>
       <option_group_name>activity_type</option_group_name>
+      <filter>1</filter>
+      <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionValue>
   </OptionValues>


### PR DESCRIPTION
## Before

The activity types created by this extension are not reserved (by setting is_reserved field value to True) or hidden (by setting filter field value to True), this might allow users to delete these activities types by mistake as it happened with one of our clients.

## After

The existing installation XML that creates these activities is updated to make sure they are both hidden and reserved, also a new upgrader is created to make sure that these activities are created with the mentioned filters if they are not already.
