### PR TITLE
RSE-1143: Add phpunit, phpcs linter and GitHub action workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install phpcs
-        run: ./bin/install-php-linter
+        run: cd bin && ./install-php-linter
 
       - name: Fetch target branch
         run: git fetch -n origin ${GITHUB_BASE_REF}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: ./bin/install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs linter
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+
+      - name: Build Drupal site
+        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit
+
+      - name: Installing Manual Direct Debit and its dependencies
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
+
+      - name: Run phpunit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit
+        run: phpunit5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Build Drupal site
         run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
 
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.24.6
+          path: site/web/sites/all/modules/civicrm
+
       - uses: actions/checkout@v2
         with:
           path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Download PHPCS if it already does not exist
+if [ ! -f phpcs.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+fi
+# Give executable permission to PHPCS
+chmod +x phpcs.phar
+
+# Clone Drupal Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+fi

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -16,7 +16,7 @@ fi
 # Give executable permission to PHPCBF
 chmod +x phpcbf.phar
 
-# Clone Drupal Coder repo
+# Clone CiviCRM Coder repo
 if [ ! -d drupal/coder ]; then
-  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
 fi

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -8,6 +8,14 @@ fi
 # Give executable permission to PHPCS
 chmod +x phpcs.phar
 
+# Download PHPCBF if it already does not exist
+if [ ! -f phpcbf.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+fi
+
+# Give executable permission to PHPCBF
+chmod +x phpcbf.phar
+
 # Clone Drupal Coder repo
 if [ ! -d drupal/coder ]; then
   git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="PHP Custom Ruleset">
-  <description>Drupal Coder Ruleset with some exclusions</description>
-  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
-    <!-- CiviCRM expects to have file names with underscores -->
-    <!-- Example: The Class `CRM_ManualDirectDebit_Upgrader` has a file name of `Upgrader.php` -->
-    <!-- Hence the following rules are excluded -->
-    <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
-    <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
-    <!--Drupal expects function names like manualdirectdebit_civicrm_pre_process but civi can have-->
-    <!--manualdirectdebit_civicrm_preProcess which is valid for civi.-->
-    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
-
-    <!-- this was was added in drupal, but in civicrm we ignore this rule -->
-    <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
-  </rule>
+  <description>CiviCRM Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal"></rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="PHP Custom Ruleset">
+  <description>Drupal Coder Ruleset with some exclusions</description>
+  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
+    <!-- CiviCRM expects to have file names with underscores -->
+    <!-- Example: The Class `CRM_ManualDirectDebit_Upgrader` has a file name of `Upgrader.php` -->
+    <!-- Hence the following rules are excluded -->
+    <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
+    <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
+    <!--Drupal expects function names like manualdirectdebit_civicrm_pre_process but civi can have-->
+    <!--manualdirectdebit_civicrm_preProcess which is valid for civi.-->
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+
+    <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+    <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
+  </rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="Manual Direct Debit Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+}

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,13 +1,21 @@
 <?php
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
+/**
+ * An abstract BaseHeadlessTest class.
+ */
 abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
 
+  /**
+   * Sets up Headless, use stock schema,, install extensions.
+   */
   public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
+    return Test::headless()
+      ->installMe([__DIR__, 'uk.co.compucorp.membershipextras'])
       ->apply();
   }
+
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * This file is a wrapper to bootstrap cv command.
+ */
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=classloader', 'phpcode'));
@@ -11,14 +16,16 @@ eval(cv('php:boot --level=classloader', 'phpcode'));
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
+ *
  * @throws \RuntimeException
  *   If the command terminates abnormally.
  */
 function cv($cmd, $decode = 'json') {
   $cmd = 'cv ' . $cmd;
-  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
   $oldOutput = getenv('CV_OUTPUT');
   putenv("CV_OUTPUT=json");
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
@@ -34,7 +41,8 @@ function cv($cmd, $decode = 'json') {
       return $result;
 
     case 'phpcode':
-      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      // If the last output is /*PHPCODE*/
+      // then we managed to complete execution.
       if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
         throw new \RuntimeException("Command failed ($cmd):\n$result");
       }


### PR DESCRIPTION
## Overview
This PR is to add phpcs linter, PHP Unit Test suite and Github action workflows. 

Github Action workflows contain: 

- Linters workflow that run phpcs that check *.php when are added or/and updated.
- Unit Tests' workflow that run all php unit tests in the extension.

## Before

- The manual direct debit did not have functionality to run unit tests.
- unit tests were not run automatically. 
- phpcs linter was not run automatically. 
- GitHub actions was not implemented. 

## After
- Linters action will be triggered when Pull Request is created and/or updated
- phpcs will only run if *.php is updated or added.
- Unit tests will to triggered and run every time PR is created and/or updated. 
- Linter and unit tests can be executed locally. 

## Technical Details

PHP CS Linter is implemented based on Drupal code sniffer with some exclusion for CiviCRM. 

```
<ruleset name="PHP Custom Ruleset">
  <description>Drupal Coder Ruleset with some exclusions</description>
  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
    <!-- CiviCRM expects to have file names with underscores -->
    <!-- Example: The Class `CRM_ManualDirectDebit_Upgrader` has a file name of `Upgrader.php` -->
    <!-- Hence the following rules are excluded -->
    <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
    <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
    <!--Drupal expects function names like manualdirectdebit_civicrm_pre_process but civi can have-->
    <!--manualdirectdebit_civicrm_preProcess which is valid for civi.-->
    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>

    <!-- this was was added in drupal, but in civicrm we ignore this rule -->
    <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
  </rule>
</ruleset>
```

The linter is currently fails (see warning below) when checking against bootstrap.php inside tests/phpunit as we need eval() function is used to evaluate cv command for bootstrapping CiviCRM in order to run the unit tests. 

```
 10 | WARNING | The use of function eval() is discouraged
```
Since the eval() is discouraged and should not be used and using this for bootstrapping CiviCRM can be an exception as this will not affect the functionality. 
