### PR TITLE
RSE-1145: Create a direct debit sign up form

### DIFF
--- a/CRM/ManualDirectDebit/Form/SignUp.php
+++ b/CRM/ManualDirectDebit/Form/SignUp.php
@@ -1,0 +1,48 @@
+<?php
+
+use CRM_ManualDirectDebit_ExtensionUtil as E;
+
+/**
+ * Form Manual Direct Debit Sign up Form
+ *
+ */
+class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
+
+  private $contributionId;
+
+  public function preProcess() {
+    parent::preProcess();
+    $this->contributionId = CRM_Utils_Request::retrieveValue('contribution_id', 'String', NULL);
+    if ($this->contributionId == NULL) {
+      CRM_Utils_System::redirect('/');
+    }
+    CRM_Utils_System::setTitle(E::ts('Direct Debit Sign up'));
+  }
+
+  public function buildQuickForm() {
+    $errorMessage = NULL;
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $this->contributionId,
+      'contribution_status_id' => "Pending",
+    ]);
+
+    if ($contribution['count'] == 0) {
+      $errorMessage = E::ts('This invoice is already paid. Please contact the administrator for the correct link to setup direct debit.');
+    } else if (is_null($contribution['value']['contribution_recur_id'])) {
+      $errorMessage = E::ts('This invoice is not part of a payment plan. Please contact the administrator for the correct link to set up a direct debit.');
+    }
+
+    if ($errorMessage != NULL) {
+      $this->assign('errorMessage', $errorMessage);
+      return;
+    }
+
+    parent::buildQuickForm();
+  }
+
+  public function postProcess() {
+    parent::postProcess();
+  }
+
+}

--- a/CRM/ManualDirectDebit/Form/SignUp.php
+++ b/CRM/ManualDirectDebit/Form/SignUp.php
@@ -12,7 +12,7 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
 
   public function preProcess() {
     parent::preProcess();
-    $this->contributionId = CRM_Utils_Request::retrieveValue('contribution_id', 'String', NULL);
+    $this->contributionId = CRM_Utils_Request::retrieveValue('contribution_id', 'Positive', NULL);
     if ($this->contributionId == NULL) {
       CRM_Utils_System::redirect('/');
     }

--- a/manualdirectdebit.civix.php
+++ b/manualdirectdebit.civix.php
@@ -263,16 +263,17 @@ function _manualdirectdebit_civix_find_files($dir, $pattern) {
  */
 function _manualdirectdebit_civix_civicrm_managed(&$entities) {
   $mgdFiles = _manualdirectdebit_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }

--- a/templates/CRM/ManualDirectDebit/Form/SignUp.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SignUp.tpl
@@ -1,0 +1,3 @@
+{if $errorMessage}
+  {$errorMessage} <a href="/civicrm">{ts}Return to dashboard{/ts}</a>
+{/if}

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -40,4 +40,11 @@
     <title>Mandate_Create</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/direct_debit/signup</path>
+    <page_callback>CRM_ManualDirectDebit_Form_SignUp</page_callback>
+    <title>SignUp</title>
+    <access_arguments>profile create</access_arguments>
+    <is_public>true</is_public>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This pull request is to add a direct debit sign up form to work stream branch. 

The form includes the functionality to load contribution details and check if

1. Contribution id parameter is passed to URL, if not redirect user to the home page.
2. Check if contribution is attached to recurring contribution, if not show error message. 
3. Check if contribution is status is pending, if not show error message. 


## Before
Direct debit sign up form did not exist on in Manual Direct Debit extension. 

## After
The form is added to Manual Direct Debit Extensions. 

The form will throw below error message if contribution is not attached to recurring contribution. 
![Screenshot from 2020-06-11 14-19-46](https://user-images.githubusercontent.com/208713/84394680-2daef780-abf5-11ea-9b33-d030cd920111.png)

The form will throw below error message if contribution does not exist or status is not pending. 
![Screenshot from 2020-06-11 14-20-04](https://user-images.githubusercontent.com/208713/84394686-2f78bb00-abf5-11ea-9640-8ea247082b74.png)

## Technical Details
Since the requirement is to make the form public and by adding _<is_public>_ tag to the menu item is not enough, the access permission needs to be defined so _profile create_ permission is used in order to user to access the page publicly. 

The reason that the _profile_create_ was chosen because anonymous user role has this permission by default.

```
<item>
    <path>civicrm/direct_debit/signup</path>
    <page_callback>CRM_ManualDirectDebit_Form_SignUp</page_callback>
    <title>SignUp</title>
    <access_arguments>profile create</access_arguments>
    <is_public>true</is_public>
  </item>
```

