### PR TITLE
RSE-1146: Custom form fields

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -3,10 +3,10 @@
 use CRM_ManualDirectDebit_ExtensionUtil as E;
 
 /**
- * Form Manual Direct Debit Sign up Form
+ * Form Manual Direct Debit Setup up Form
  *
  */
-class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
+class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
 
   /**
    * @var $contributionId
@@ -19,10 +19,11 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
     if ($this->contributionId == NULL) {
       CRM_Utils_System::redirect('/');
     }
-    CRM_Utils_System::setTitle(E::ts('Direct Debit Sign up'));
+    CRM_Utils_System::setTitle(E::ts('Set up a Direct Debit'));
   }
 
   public function buildQuickForm() {
+    parent::buildQuickForm();
     $errorMessage = NULL;
     $contribution = $this->getContribution();
     if (empty($contribution)) {
@@ -49,7 +50,7 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
       $this->assign('payment_date_value', reset($paymentDates));
       $this->add('hidden', 'payment_dates', key($paymentDates));
     }else {
-      $this->add('select', 'payment_dates', E::ts('Payment Date'), $paymentDates,TRUE);
+      $this->add('select', 'payment_dates', E::ts('Payment Date'), $paymentDates);
     }
 
     $this->add('text', 'bank_name', E::ts('Bank name:'), ['size' => 40], TRUE);
@@ -65,7 +66,6 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
       ],
     ]);
 
-    parent::buildQuickForm();
   }
 
   public function postProcess() {

--- a/CRM/ManualDirectDebit/Form/SignUp.php
+++ b/CRM/ManualDirectDebit/Form/SignUp.php
@@ -8,6 +8,9 @@ use CRM_ManualDirectDebit_ExtensionUtil as E;
  */
 class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
 
+  /**
+   * @var $contributionId
+   */
   private $contributionId;
 
   public function preProcess() {
@@ -21,15 +24,10 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
 
   public function buildQuickForm() {
     $errorMessage = NULL;
-    $contribution = civicrm_api3('Contribution', 'get', [
-      'sequential' => 1,
-      'id' => $this->contributionId,
-      'contribution_status_id' => "Pending",
-    ]);
-
-    if ($contribution['count'] == 0) {
+    $contribution = $this->getContribution();
+    if (empty($contribution)) {
       $errorMessage = E::ts('This invoice is already paid. Please contact the administrator for the correct link to setup direct debit.');
-    } else if (is_null($contribution['value']['contribution_recur_id'])) {
+    } else if (empty($contribution['contribution_recur_id'])) {
       $errorMessage = E::ts('This invoice is not part of a payment plan. Please contact the administrator for the correct link to set up a direct debit.');
     }
 
@@ -38,11 +36,95 @@ class CRM_ManualDirectDebit_Form_SignUp extends CRM_Core_Form {
       return;
     }
 
+    $this->assign('invoiceNumber', $contribution['invoice_number']);
+    $this->assign('amount', $this->calculateAmount($contribution['total_amount'], $contribution['tax_amount']));
+
+    if (!empty($contribution['tax_amount'])) {
+      $this->assign('taxAmount', $contribution['tax_amount']);
+    }
+    $this->assign('totalAmount', $contribution['total_amount']);
+
+    $paymentDates = $this->getPaymentDates();
+    if (count($paymentDates) == 1) {
+      $this->assign('payment_date_value', reset($paymentDates));
+      $this->add('hidden', 'payment_dates', key($paymentDates));
+    }else {
+      $this->add('select', 'payment_dates', E::ts('Payment Date'), $paymentDates,TRUE);
+    }
+
+    $this->add('text', 'bank_name', E::ts('Bank name:'), ['size' => 40], TRUE);
+    $this->add('text', 'bank_account_holder', E::ts('Name of Account holder:'), ['size' => 40], TRUE);
+    $this->add('text', 'bank_account_number', E::ts('Account number:'), ['size' => 40], TRUE);
+    $this->add('text', 'bank_sort_code', E::ts('Sort code:'), ['size' => 40], TRUE);
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Submit'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+
     parent::buildQuickForm();
   }
 
   public function postProcess() {
     parent::postProcess();
+  }
+
+  /**
+   * @param $totalAmount
+   * @param $taxAmount
+   * @return mixed
+   */
+  private function calculateAmount($totalAmount, $taxAmount) {
+    return $totalAmount - $taxAmount;
+  }
+
+  /**
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  private function getPaymentDates() {
+    $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+    $settings = $settingsManager->getManualDirectDebitSettings();
+
+    $locale = civicrm_api3('Setting', 'get', [
+      'sequential' => 1,
+      'return' => ["lcMessages"],
+    ])['values']['lcMessages'];
+    $ordinalSuffixFormatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
+
+    $paymentDates = [];
+    foreach ($settings['payment_collection_run_dates'] as $day){
+      $paymentDates[$day] =  $ordinalSuffixFormatter->format($day);
+    }
+
+    return $paymentDates;
+  }
+
+  /**
+   * @return array|mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function getContribution() {
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $this->contributionId,
+      'contribution_status_id' => 'Pending',
+      'return' => [
+        'contribution_recur_id',
+        'invoice_number',
+        'tax_amount',
+        'total_amount'
+      ],
+    ]);
+
+    if (empty($contribution['values'])) {
+      return [];
+    }
+
+    return $contribution['values'][0];
   }
 
 }

--- a/css/setUp.css
+++ b/css/setUp.css
@@ -8,7 +8,7 @@
   height: 50px;
 }
 
-.crm-direct-debit-sign-up-guarantee .dd-logo{
+.crm-direct-debit-set-up-guarantee .dd-logo{
   width: 90px;
   height: auto;
   float: right;

--- a/css/signUp.css
+++ b/css/signUp.css
@@ -1,0 +1,17 @@
+.crm-manual-direct-debit-form-block .label{
+  color: black;
+}
+
+.crm-manual-direct-debit-form-block .crm-submit-buttons{
+  float: right;
+  width: 53%;
+  height: 50px;
+}
+
+.crm-direct-debit-sign-up-guarantee .dd-logo{
+  width: 90px;
+  height: auto;
+  float: right;
+}
+
+

--- a/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
@@ -1,5 +1,5 @@
-{crmStyle ext=uk.co.compucorp.manualdirectdebit file=css/signUp.css}
-<div class="crm-block crm-direct-debit-sign-up-form-block">
+{crmStyle ext=uk.co.compucorp.manualdirectdebit file=css/setUp.css}
+<div class="crm-block crm-direct-debit-set-up-form-block">
   {if $errorMessage}
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>
@@ -35,8 +35,8 @@
             </div>
             {if $payment_date_value}
               <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-text">
-                <div class="label"></div>
-                <div class="content">{ts}Your payment will be taken on or around {$payment_date_value} of the month.{/ts}</div>
+                <div class="label"><label> {ts}Payment Date:{/ts}</label></div>
+                <div class="content">{ts}To be taken on or around {$payment_date_value} of the month.{/ts}</div>
                 <div class="clear"></div>
               </div>
             {else}
@@ -75,7 +75,7 @@
         </div>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
         <div class="clear"></div>
-        <div class="crm-block crm-direct-debit-sign-up-guarantee">
+        <div class="crm-block crm-direct-debit-set-up-guarantee">
           <div class="dd-guarantee">
             <h5>{ts}Direct Debit Guarantee{/ts}</h5>
             <img class="dd-logo" src="{crmResURL ext=uk.co.compucorp.manualdirectdebit file=Images/debit.png}"

--- a/templates/CRM/ManualDirectDebit/Form/SignUp.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SignUp.tpl
@@ -1,3 +1,112 @@
-{if $errorMessage}
-  {$errorMessage} <a href="/civicrm">{ts}Return to dashboard{/ts}</a>
-{/if}
+{crmStyle ext=uk.co.compucorp.manualdirectdebit file=css/signUp.css}
+<div class="crm-block crm-direct-debit-sign-up-form-block">
+  {if $errorMessage}
+    <div class="messages status no-popup">
+      <div class="icon inform-icon"></div>
+      {$errorMessage} <a href="/civicrm">{ts}Return to dashboard{/ts}</a>
+    </div>
+  {else}
+    <div class="crm-container crm-public">
+      <div class="crm-block crm-manual-direct-debit-form-block">
+        <div class="crm-public-form-item crm-section crm-manual-direct-debit-form-payment-information">
+          <fieldset class="crm-profile">
+            <legend>{ts}Payment Information{/ts}</legend>
+            <div class="crm-section form-item crm-manual-direct-debit-form-invoice-number">
+              <div class="label"><label> {ts}Invoice number:{/ts}</label></div>
+              <div class="content">{$invoiceNumber}</div>
+              <div class="clear"></div>
+            </div>
+            <div class="crm-section form-item crm-manual-direct-debit-form-amount">
+              <div class="label"><label> {ts}Amount:{/ts}</label></div>
+              <div class="content">{$amount|crmMoney:$currency}</div>
+              <div class="clear"></div>
+            </div>
+            {if $taxAmount}
+              <div class="crm-section form-item crm-manual-direct-debit-form-vat">
+                <div class="label"><label>{ts}VAT:{/ts}</label></div>
+                <div class="content">{$taxAmount|crmMoney:$currency}</div>
+                <div class="clear"></div>
+              </div>
+            {/if}
+            <div class="crm-section form-item crm-manual-direct-debit-form-total-amount">
+              <div class="label"><label>{ts}Total Amount:{/ts}</label></div>
+              <div class="content">{$totalAmount|crmMoney:$currency}</div>
+              <div class="clear"></div>
+            </div>
+            {if $payment_date_value}
+              <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-text">
+                <div class="label"></div>
+                <div class="content">{ts}Your payment will be taken on or around {$payment_date_value} of the month.{/ts}</div>
+                <div class="clear"></div>
+              </div>
+            {else}
+              <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-select">
+                <div class="label">{$form.payment_dates.label}</div>
+                <div class="content">{$form.payment_dates.html}</div>
+                <div class="clear"></div>
+              </div>
+            {/if}
+          </fieldset>
+        </div>
+        <div class="crm-public-form-item crm-section crm-manual-direct-debit-form-bank-details">
+          <fieldset class="crm-profile">
+            <legend>{ts}Direct Debit Details{/ts}</legend>
+            <div class="crm-section form-item crm-manual-direct-debit-form-bank-name">
+              <div class="label">{$form.bank_name.label}</div>
+              <div class="content">{$form.bank_name.html}</div>
+              <div class="clear"></div>
+            </div>
+            <div class="crm-section form-item crm-manual-direct-debit-form-bank-account-holder">
+              <div class="label">{$form.bank_account_holder.label}</div>
+              <div class="content">{$form.bank_account_holder.html}</div>
+              <div class="clear"></div>
+            </div>
+            <div class="crm-section form-item crm-manual-direct-debit-form-bank-account-number">
+              <div class="label">{$form.bank_account_number.label}</div>
+              <div class="content">{$form.bank_account_number.html}</div>
+              <div class="clear"></div>
+            </div>
+            <div class="crm-section form-item crm-manual-direct-debit-form-bank-account-sort-code">
+              <div class="label">{$form.bank_sort_code.label}</div>
+              <div class="content">{$form.bank_sort_code.html}</div>
+              <div class="clear"></div>
+            </div>
+          </fieldset>
+        </div>
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+        <div class="clear"></div>
+        <div class="crm-block crm-direct-debit-sign-up-guarantee">
+          <div class="dd-guarantee">
+            <h5>{ts}Direct Debit Guarantee{/ts}</h5>
+            <img class="dd-logo" src="{crmResURL ext=uk.co.compucorp.manualdirectdebit file=Images/debit.png}"
+                 alt="Direct Debit"/>
+          </div>
+          <div class="clear"></div>
+          <ul>
+            <li>
+              {ts}The Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits{/ts}
+            </li>
+            <li>
+              {ts} there are any changes to the amount, date or frequency of your Direct Debit the organisation will notify you
+                (normally 10 working days) in advance of your account being debited or as otherwise agreed.
+                If you request the organisation to collect a payment,
+                confirmation of the amount and date will be given to you at the time of the request{/ts}
+            </li>
+            <li>
+              {ts}If an error is made in the payment of your Direct Debit, by the organisation or your bank or building society,
+                you are entitled to a full and immediate refund of the amount paid from your bank or building society{/ts}
+              <ul>
+                <li>
+                  {ts}If you receive a refund you are not entitled to, you must pay it back when the organisation asks you to{/ts}
+                </li>
+              </ul>
+            <li>
+              {ts}You can cancel a Direct Debit at any time by simply contacting your bank or building society.
+                Written confirmation may be required. Please also notify the organisation{/ts}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -41,9 +41,9 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
-    <path>civicrm/direct_debit/signup</path>
-    <page_callback>CRM_ManualDirectDebit_Form_SignUp</page_callback>
-    <title>SignUp</title>
+    <path>civicrm/direct_debit/setup</path>
+    <page_callback>CRM_ManualDirectDebit_Form_SetUp</page_callback>
+    <title>Set Up a Direct Debit</title>
     <access_arguments>profile create</access_arguments>
     <is_public>true</is_public>
   </item>


### PR DESCRIPTION
This PR is to add information, input forms, direct debit text to the direct debit set up form. 


## Before
The form only showed the error message if invalid contribution_id parameter was passed.

## After
The form that shows the payment date as a text. 

![Screenshot from 2020-06-16 10-44-49](https://user-images.githubusercontent.com/208713/84759569-cf03c800-afbe-11ea-857a-109d3d1f2229.png)

The form that shows payment dates as a drop-down list.

![Screenshot from 2020-06-16 10-39-18](https://user-images.githubusercontent.com/208713/84759580-d2974f00-afbe-11ea-8363-927a225cad76.png)


## Technical Details
The majority of CSS classes used in the form was copied from CiviCRM public profile. 

There is also the custom css file that was created for fixing the issue of Bootstrap theme, so the label colour is displayed correctly. 

The custom CSS file also used for formatting the direct debit logo and submit the button layout. css
