### PR TITLE
RSE-1147:  Update recurring contribution

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -19,7 +19,7 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     if ($this->contributionId == NULL) {
       CRM_Utils_System::redirect('/');
     }
-    CRM_Utils_System::setTitle(E::ts('Set up a Direct Debit'));
+    CRM_Utils_System::setTitle(E::ts('Set up your Direct Debit'));
   }
 
   public function buildQuickForm() {
@@ -49,7 +49,7 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     if (count($paymentDates) == 1) {
       $this->assign('payment_date_value', reset($paymentDates));
       $this->add('hidden', 'payment_dates', key($paymentDates));
-    }else {
+    } else {
       $this->add('select', 'payment_dates', E::ts('Payment Date'), $paymentDates);
     }
 
@@ -57,6 +57,8 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     $this->add('text', 'bank_account_holder', E::ts('Name of Account holder:'), ['size' => 40], TRUE);
     $this->add('text', 'bank_account_number', E::ts('Account number:'), ['size' => 40], TRUE);
     $this->add('text', 'bank_sort_code', E::ts('Sort code:'), ['size' => 40], TRUE);
+    $this->add('hidden', 'contribution_id', $this->contributionId);
+    $this->add('hidden', 'contact_id', $contribution['contact_id']);
 
     $this->addButtons([
       [
@@ -70,6 +72,68 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
 
   public function postProcess() {
     parent::postProcess();
+
+    $values = $this->exportValues();
+
+    $contributionRecur = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $values['contribution_id'],
+      'api.ContributionRecur.get' => [],
+    ])['api.ContributionRecur.get']['values'][0];
+
+    $cycleDay = $this->getCycleDay($values['payment_dates'], $contributionRecur['frequency_unit']);
+
+    $test = civicrm_api3('ContributionRecur', 'create', [
+      'id' => $contributionRecur['id'],
+      'payment_instrument_id' => 'direct_debit',
+      'cycle_day' => $cycleDay,
+    ]);
+
+    $defaultDDCode = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'direct_debit_codes',
+      'label' => "0N",
+    ])['values'][0]['value'];
+
+    $now = new DateTime();
+    $mandateValues = [
+      'entity_id' => $values['contact_id'],
+      'bank_name' => $values['bank_name'],
+      'account_holder_name' => $values['bank_account_holder'],
+      'ac_number' => $values['bank_account_number'],
+      'sort_code' => $values['bank_sort_code'],
+      'dd_code' => $defaultDDCode,
+      'start_date' => $now->format('Y-m-d H:i:s'),
+    ];
+
+    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandate = $storageManager->saveDirectDebitMandate($values['contact_id'], $mandateValues);
+    $storageManager->assignRecurringContributionMandate($contributionRecur['id'], $mandate->id);
+    $storageManager->assignContributionMandate($values['contribution_id'], $mandate->id);
+
+    $url = CRM_Utils_System::url('civicrm/direct_debit/setup/confirmation');
+    CRM_Utils_System::redirect( $url);
+  }
+
+  /**
+   * @param $paymentDay
+   * @param $frequencyUnit
+   * @return integer
+   */
+  private function getCycleDay($paymentDay, $frequencyUnit) {
+
+    if ($frequencyUnit != 'year') {
+      return $paymentDay;
+    }
+
+    $now = new DateTime();
+    $cycleDate = DateTime::createFromFormat('Y-m-d', $now->format('Y-m'. '-' . $paymentDay));
+
+    //If cycle date is in the past, set cycle date should be next month.
+    if ($cycleDate < $now) {
+      $cycleDate = $cycleDate->modify('next month');
+    }
+
+    return (int) $cycleDate->format('z') + 1;
   }
 
   /**
@@ -92,12 +156,12 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     $locale = civicrm_api3('Setting', 'get', [
       'sequential' => 1,
       'return' => ["lcMessages"],
-    ])['values']['lcMessages'];
+    ])['values'][0]['lcMessages'];
     $ordinalSuffixFormatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
 
     $paymentDates = [];
-    foreach ($settings['payment_collection_run_dates'] as $day){
-      $paymentDates[$day] =  $ordinalSuffixFormatter->format($day);
+    foreach ($settings['payment_collection_run_dates'] as $day) {
+      $paymentDates[$day] = $ordinalSuffixFormatter->format($day);
     }
 
     return $paymentDates;

--- a/CRM/ManualDirectDebit/Page/Setup/Confirmation.php
+++ b/CRM/ManualDirectDebit/Page/Setup/Confirmation.php
@@ -1,0 +1,11 @@
+<?php
+use CRM_ManualDirectDebit_ExtensionUtil as E;
+
+class CRM_ManualDirectDebit_Page_Setup_Confirmation extends CRM_Core_Page {
+
+  public function run() {
+    CRM_Utils_System::setTitle(E::ts('Direct Debit Setup Confirmation'));
+    parent::run();
+  }
+
+}

--- a/css/setUp.css
+++ b/css/setUp.css
@@ -8,10 +8,20 @@
   height: 50px;
 }
 
+.crm-direct-debit-set-up-guarantee {
+  display: block;
+  border: 1px solid #ccc;
+  padding: 0.01em 16px;
+  width: 100%;
+  height: 100%;
+}
+
 .crm-direct-debit-set-up-guarantee .dd-logo{
   width: 90px;
   height: auto;
   float: right;
 }
+
+
 
 

--- a/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
@@ -36,7 +36,10 @@
             {if $payment_date_value}
               <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-text">
                 <div class="label"><label> {ts}Payment Date:{/ts}</label></div>
-                <div class="content">{ts}To be taken on or around {$payment_date_value} of the month.{/ts}</div>
+                <div class="content">
+                  {ts}To be taken on or around {$payment_date_value} of the month.{/ts}
+                  {$form.payment_dates.html}
+                </div>
                 <div class="clear"></div>
               </div>
             {else}
@@ -72,6 +75,10 @@
               <div class="clear"></div>
             </div>
           </fieldset>
+        </div>
+        <div class="crm-manual-direct-debit-form-hidden-elements">
+          {$form.contribution_id.html}
+          {$form.contact_id.html}
         </div>
         <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
         <div class="clear"></div>

--- a/templates/CRM/ManualDirectDebit/Page/Setup/Confirmation.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/Setup/Confirmation.tpl
@@ -1,0 +1,5 @@
+<p>{ts}Thank you for setting up your Direct Debit. You will shortly receive your Direct Debit confirmation email with full details of the Direct Debit Guarantee. {/ts}</p>
+<span class="crm-button crm-button-type-submit">
+  <input class="crm-form-submit default" onclick="window.location='/'"  value="Home" type="submit" >
+</span>
+

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -43,7 +43,14 @@
   <item>
     <path>civicrm/direct_debit/setup</path>
     <page_callback>CRM_ManualDirectDebit_Form_SetUp</page_callback>
-    <title>Set Up a Direct Debit</title>
+    <title>Set up your Direct Debit</title>
+    <access_arguments>profile create</access_arguments>
+    <is_public>true</is_public>
+  </item>
+  <item>
+    <path>civicrm/direct_debit/setup/confirmation</path>
+    <page_callback>CRM_ManualDirectDebit_Page_Setup_Confirmation</page_callback>
+    <title>Direct Debit Setup Confirmation</title>
     <access_arguments>profile create</access_arguments>
     <is_public>true</is_public>
   </item>


### PR DESCRIPTION
## Overview
This PR is to add functionalities to update, a recurring contribution record, selected contribution record, create a direct debit mandate and attach a created mandate to existing contribution record. 

## Before
The functionality does not exist. 

## After

After the form is submitted: 
- Recurring Contribution payment method is updated to 'direct_debit'
- Cycle day is set to next payment run date from today's date. 
- Create a new  mandate 
- Attach a created mandate to existing recurring contribution and a selected contribution.
- Confirmation page is shown after the form is submitted.
