### PR TITLE
RSE-1174: Create a new direct debit recurring payment activity

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -89,9 +89,24 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
       $values['contribution_id'],
       $recurringContribution['id']
     );
+    $this->createActivity($recurringContribution['id'], $values['contact_id']);
 
     $url = CRM_Utils_System::url('civicrm/direct_debit/setup/confirmation');
     CRM_Utils_System::redirect( $url);
+  }
+
+  /**
+   * @param $recurringContributionId
+   * @param $contactId
+   */
+  private function createActivity($recurringContributionId, $contactId) {
+    CRM_ManualDirectDebit_Common_Activity::create(
+      ts("New Direct Debit Recurring Payment"),
+      "new_direct_debit_recurring_payment",
+      $recurringContributionId,
+      $contactId,
+      $contactId
+    );
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR is to create a new activity after the form is summited. 

## Before
The activity has never been created when the form is summited. 

## After
_new_direct_debit_recurring_payment_ activity type is created after the form is submitted 

## Technical Details
Activity source contact is assigned to a contact linked to the selected contribution as the form is a public form.
