### PR TITLE
MAE-327: 2.2.0 release

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,8 +18,8 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-05-04</releaseDate>
-  <version>2.1.0</version>
+  <releaseDate>2020-06-24</releaseDate>
+  <version>2.2.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
This release include the following fixes and changes : 

- BASW-623: Fix attachment bewteen Contribution and mandate after recording a payment without selecting mandate (https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/162)
- BASW-622 : Hide and reserve DD activity types (https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/163)

