### PR TITLE
RSE-1147: Save mandate

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -138,6 +138,12 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
       'label' => "0N",
     ])['values'][0]['value'];
 
+    //Get the first return value for originator number
+    $originatorNumber = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "direct_debit_originator_number",
+    ])['values'][0]['value'];
+
     $now = new DateTime();
     $mandateValues = [
       'entity_id' => $values['contact_id'],
@@ -147,6 +153,9 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
       'sort_code' => $values['bank_sort_code'],
       'dd_code' => $defaultDDCode,
       'start_date' => $now->format('Y-m-d H:i:s'),
+      'dd_ref' => 'DD Ref',
+      'authorisation_date' => $now->format('Y-m-d H:i:s'),
+      'originator_number' => $originatorNumber,
     ];
 
     $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();


### PR DESCRIPTION
## Overview
This PR adds additional required fields when saving a mandate.

## Before
dd_ref, authorisation_date and originator_number were not assigned to mandate values when saving a mandate 

## After
dd_ref, authorisation_date and originator_number will be saved to a mandate. 


## Technical Details

- dd_ref - dd ref is a required field and cannot be empty, so we need to pass a value 'DD Ref' to ensure that the actal DD ref will be generated. 

See:https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blame/master/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php#L71
and https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/100

- originator_number - Originator number is a required field and does not have default value as it will be set differently depends on organizations setup their direct debit and currently the direct setup form does not have the functionality to pre-set the originator number, we will use the first value of originator number list and assign to the mandate. 

