### PR TITLE
RSE-1147: Add weight in the parameter for getting Originator number

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -142,6 +142,7 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     $originatorNumber = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => "direct_debit_originator_number",
+      'weight' => 1,
     ])['values'][0]['value'];
 
     $now = new DateTime();


### PR DESCRIPTION
## Overview
This PR adds weight param when getting Originator Number to ensure that we get the first value from originator number list by weight instead of ID. 

## Before
The originator number was getting from the first value based on ID.

## After
The originator number  first value will be getting from the weight = 1 rather than value id. 
