### PR TITLE
MAE-355: Sagepay integration issue

### DIFF
--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -183,6 +183,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
     $directDebitPaymentInstrumentId = civicrm_api3('OptionValue', 'getvalue', [
       'return' => "value",
       'name' => "direct_debit",
+      'option_group_id' => "payment_instrument",
     ]);
 
     return $directDebitPaymentInstrumentId;

--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -43,7 +43,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    *
    * @return array
    */
-  public function getMandateCustomFieldDataForBuildingForm(){
+  public function getMandateCustomFieldDataForBuildingForm() {
     $mandateCustomGroupFieldData = [];
     foreach ($this->directDebitMandateCustomGroupFields['values'] as $value) {
       $params = [];
@@ -87,7 +87,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    *
    * @return array
    */
-  private function getOptionList($optionGroupId){
+  private function getOptionList($optionGroupId) {
     $optionValue = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => "$optionGroupId",
@@ -106,7 +106,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    *
    * @return array
    */
-  public function getMandateCustomFieldNames(){
+  public function getMandateCustomFieldNames() {
     $mandateCustomGroupFieldNames = [];
     foreach ($this->directDebitMandateCustomGroupFields['values'] as $value) {
       $mandateCustomGroupFieldNames[] = self::PREFIX . $value['name'];
@@ -126,7 +126,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
     $directDebitPaymentMethod = civicrm_api3('OptionValue', 'getvalue', [
       'return' => "value",
       'name' => "direct_debit",
-      'option_group_id' => "payment_instrument"
+      'option_group_id' => "payment_instrument",
     ]);
 
     return $currentMethodId == $directDebitPaymentMethod;
@@ -147,7 +147,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
       'is_test' => 0,
     ]);
 
-    if($directDebitPaymentProcessorId != $currentPaymentProcessor){
+    if ($directDebitPaymentProcessorId != $currentPaymentProcessor) {
       $directDebitPaymentProcessorId = civicrm_api3('PaymentProcessor', 'getvalue', [
         'return' => "id",
         'name' => "Direct Debit",


### PR DESCRIPTION
## Overview

This PR is to fix issues when error when navigate to create or edit Membership when manual direct debit  and Sagpay  (Omnipay version)  extensions are installed together. 

This PR also fixes the code format error threw by phpcs. 
 
## Before

![2b06c226-8f7a-41c7-8154-496e7a5bb268](https://user-images.githubusercontent.com/208713/86603467-f2a5a700-bf9b-11ea-8999-a26706abac75.png)

## After
![Screenshot from 2020-07-06 15-19-08](https://user-images.githubusercontent.com/208713/86603585-12d56600-bf9c-11ea-94db-9f9e3be7af13.png)


## Technical Details

Sagepay (Omnipay version) installs an option group called Payment Type (payment_type) that comes with option values and one of them are direct_debit.  The direct_debit name are duplicated with option_value name in payment_insturement  group.

To ensure that Manual Direct Debit extension will get the correct  direct_debit value that belongs to payment_instruement group. 
So we will pass payment_instrument option group parameter when calling OptionValue API.

```
civicrm_api3('OptionValue', 'getvalue', [
      'return' => "value",
      'name' => "direct_debit",
      'option_group_id' => "payment_instrument",
]);
```