### PR TITLE
SPAB-976: Implement Handling of Exceptions on Collection Reminder Job

### DIFF
--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -121,7 +121,9 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'id' => $this->contributionData['contact_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CiviCRM_API3_Exception $e) {
+      return;
+    }
   }
 
   /**
@@ -132,6 +134,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       $this->recurringContributionId = $this->contributionData['contribution_recur_id'];
     }
   }
+
   /**
    * Collects mandate data
    */
@@ -158,7 +161,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->contributionId, 'Integer']
+      1 => [$this->contributionId, 'Integer'],
     ]);
 
     while ($dao->fetch()) {
@@ -190,7 +193,8 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
   private function obfuscateAccountNumber($accountNumber) {
     if (strlen($accountNumber) > 4) {
       $accountNumber = str_repeat('*', strlen($accountNumber) - 4) . substr($accountNumber, -4);
-    } else {
+    }
+    else {
       $accountNumber = '****';
     }
 
@@ -215,7 +219,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       $total += $recurringContributionRow['amount'];
       $totalTax += $recurringContributionRow['tax'];
       $dueDate = DateTime::createFromFormat('Y-m-d H:i:s', $recurringContributionRow['receive_date']);
-      $recurringContributionPlan[$index]['index'] = $index+1;
+      $recurringContributionPlan[$index]['index'] = $index + 1;
       $recurringContributionPlan[$index]['amount'] = $this->formatAmount($recurringContributionRow['amount']);
       $recurringContributionPlan[$index]['tax'] = $this->formatAmount($recurringContributionRow['tax']);
       $recurringContributionPlan[$index]['sub_total'] = $this->formatAmount($recurringContributionRow['amount'] - $recurringContributionRow['tax']);
@@ -269,7 +273,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$currencyString, 'String']
+      1 => [$currencyString, 'String'],
     ]);
 
     while ($dao->fetch()) {
@@ -310,7 +314,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     }
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->recurringContributionId, 'Integer']
+      1 => [$this->recurringContributionId, 'Integer'],
     ]);
 
     $rows = [];
@@ -325,7 +329,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
         'recur_frequency_unit' => $dao->recur_frequency_unit,
         'recur_interval' => $dao->recur_interval,
         'recur_installments' => $dao->recur_installments,
-        'recur_start_date' =>$dao->recur_start_date,
+        'recur_start_date' => $dao->recur_start_date,
       ];
     }
 
@@ -468,7 +472,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     while ($dao->fetch()) {
       $this->tplParams['nextMembershipPayment'] = [
         'date' => $dao->next_payment_date,
-        'amount' => round($dao->next_payment_amount, 2)
+        'amount' => round($dao->next_payment_amount, 2),
       ];
     }
   }
@@ -487,7 +491,8 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     if ($this->recurringContributionId !== FALSE) {
       $recurringContributionBao = CRM_Contribute_BAO_ContributionRecur::findById($this->recurringContributionId);
       $this->tplParams['currency'] = $this->getCurrencySymbol($recurringContributionBao->currency);
-    } else {
+    }
+    else {
       $contributionBao = CRM_Contribute_BAO_Contribution::findById($this->contributionId);
       $this->tplParams['currency'] = $this->getCurrencySymbol($contributionBao->currency);
     }
@@ -500,7 +505,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       $smarty->assign($param, $this->tplParams[$param]);
     }
 
-    $this->tplParams['orderSummaryTable']  =  $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl');
+    $this->tplParams['orderSummaryTable'] = $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/OrderSummary.tpl');
   }
 
   private function generateActiveMembershipsTable() {
@@ -508,7 +513,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $smarty->assign('activeMemberships', $this->tplParams['activeMemberships']);
     $smarty->assign('shortDateFormat', $this->tplParams['shortDateFormat']);
 
-    $this->tplParams['activeMembershipsTable']  =  $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl');
+    $this->tplParams['activeMembershipsTable'] = $smarty->fetch('CRM/ManualDirectDebit/MessageTemplate/Snippets/ActiveMemberships.tpl');
   }
 
   /**

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -55,6 +55,9 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
    * Retrieves tpl params for template
    *
    * @return array
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    */
   public function retrieve() {
     $this->setShortDateFormat();
@@ -360,6 +363,12 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
     $this->tplParams['recurringContributionData']['total'] = $this->formatAmount($total);
   }
 
+  /**
+   * Obtains data for the membership payment plan.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
   private function collectPaymentPlanMembershipsData() {
     if (empty($this->tplParams['orderLineItems'])) {
       return;
@@ -386,6 +395,11 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
       'options' => ['limit' => 0],
       'api.MembershipType.get' => ['id' => '$value.membership_type_id'],
     ]);
+
+    if ($membershipsResponse['count'] < 1) {
+      $membershipIds = implode(', ', $membershipIds);
+      throw new CRM_Core_Exception("Memberships with IDs $membershipIds don't exist!");
+    }
 
     foreach ($membershipsResponse['values'] as $membership) {
       $paymentPlanMemberships[$membership['id']]['id'] = $membership['id'];

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Base.php
@@ -402,7 +402,7 @@ abstract class CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
     if ($membershipsResponse['count'] < 1) {
       $membershipIds = implode(', ', $membershipIds);
-      throw new CRM_Core_Exception("Memberships with IDs $membershipIds don't exist!");
+      throw new CRM_Core_Exception("Memberships with the following IDs: $membershipIds, do no longer exist!");
     }
 
     foreach ($membershipsResponse['values'] as $membership) {

--- a/CRM/ManualDirectDebit/Mail/Notification.php
+++ b/CRM/ManualDirectDebit/Mail/Notification.php
@@ -190,23 +190,22 @@ class CRM_ManualDirectDebit_Mail_Notification {
   }
 
   /**
-   * Sends mail
+   * Sends mail.
    *
    * @param CRM_ManualDirectDebit_Mail_DataCollector_Base $collector
-   * @param $templateId
+   * @param int $templateId
    *
    * @return bool
-   *
    */
   private function sendEmail($collector, $templateId) {
-    $tplParams = $collector->retrieve();
-    $contactEmailData = $collector->retrieveContactEmailData();
-
-    if (empty($contactEmailData['email']) || $contactEmailData['do_not_email'] == 1 ) {
-      return FALSE;
-    }
-
     try {
+      $tplParams = $collector->retrieve();
+      $contactEmailData = $collector->retrieveContactEmailData();
+
+      if (empty($contactEmailData['email']) || $contactEmailData['do_not_email'] == 1 ) {
+        return FALSE;
+      }
+
       civicrm_api3('MessageTemplate', 'send', [
         'id' => $templateId,
         'template_params' => $tplParams,
@@ -216,7 +215,7 @@ class CRM_ManualDirectDebit_Mail_Notification {
 
       return TRUE;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (Exception $e) {
       return FALSE;
     }
   }

--- a/CRM/ManualDirectDebit/Mail/Notification.php
+++ b/CRM/ManualDirectDebit/Mail/Notification.php
@@ -3,8 +3,8 @@
 use CRM_ManualDirectDebit_Common_MessageTemplate as MessageTemplate;
 
 /**
-* Sends mails
-*/
+ * Sends mails.
+ */
 class CRM_ManualDirectDebit_Mail_Notification {
 
   /**
@@ -202,7 +202,7 @@ class CRM_ManualDirectDebit_Mail_Notification {
       $tplParams = $collector->retrieve();
       $contactEmailData = $collector->retrieveContactEmailData();
 
-      if (empty($contactEmailData['email']) || $contactEmailData['do_not_email'] == 1 ) {
+      if (empty($contactEmailData['email']) || $contactEmailData['do_not_email'] == 1) {
         return FALSE;
       }
 

--- a/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
@@ -33,32 +33,10 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
     $from = CRM_Utils_Array::value('from_email_address', $formValues);
     $from = CRM_Utils_Mail::formatFromAddress($from);
 
-    $subject = $formValues['subject'];
-
     // CRM-13378: Append CC and BCC information at the end of Activity Details and format cc and bcc fields
-    $elements = array('cc_id', 'bcc_id');
     $additionalDetails = NULL;
-    $ccValues = $bccValues = array();
-    foreach ($elements as $element) {
-      if (!empty($formValues[$element])) {
-        $allEmails = explode(',', $formValues[$element]);
-        foreach ($allEmails as $value) {
-          list($contactId, $email) = explode('::', $value);
-          $contactURL = CRM_Utils_System::url('civicrm/contact/view', "reset=1&force=1&cid={$contactId}", TRUE);
-          switch ($element) {
-            case 'cc_id':
-              $ccValues['email'][] = '"' . $form->_contactDetails[$contactId]['sort_name'] . '" <' . $email . '>';
-              $ccValues['details'][] = "<a href='{$contactURL}'>" . $form->_contactDetails[$contactId]['display_name'] . "</a>";
-              break;
-
-            case 'bcc_id':
-              $bccValues['email'][] = '"' . $form->_contactDetails[$contactId]['sort_name'] . '" <' . $email . '>';
-              $bccValues['details'][] = "<a href='{$contactURL}'>" . $form->_contactDetails[$contactId]['display_name'] . "</a>";
-              break;
-          }
-        }
-      }
-    }
+    $ccValues = self::getCCValues($form, $formValues, 'cc_id');
+    $bccValues = self::getCCValues($form, $formValues, 'bcc_id');
 
     $cc = $bcc = '';
     if (!empty($ccValues)) {
@@ -70,7 +48,7 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
       $additionalDetails .= "\nbcc : " . implode(", ", $bccValues['details']);
     }
 
-    // CRM-5916: prepend case id hash to CiviCase-originating emails’ subjects
+    $subject = $formValues['subject'];
     if (isset($form->_caseId) && is_numeric($form->_caseId)) {
       $hash = substr(sha1(CIVICRM_SITE_KEY . $form->_caseId), 0, 7);
       $subject = "[case #$hash] $subject";
@@ -104,49 +82,113 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
       }
     }
 
-    $contributionIds = array();
-    if ($form->getVar('_contributionIds')) {
-      $contributionIds = $form->getVar('_contributionIds');
-    }
-
     $errors = [];
+    $mailDetails = new CRM_ManualDirectDebit_Mail_Task_MailDetailsModel();
+    $mailDetails->setSubject($subject);
+    $mailDetails->setFrom($from);
+    $mailDetails->setCc($cc);
+    $mailDetails->setBcc($bcc);
+    $mailDetails->setAdditionalDetails($additionalDetails);
+    $mailDetails->setAttachments($attachments);
+
     foreach ($formattedContactDetails as $formattedContactDetail) {
-      $contactId = $formattedContactDetail['contact_id'];
-      $selectedContributionIdsForCurrentContact = self::getSelectedContributionIdsForCurrentContact($contactId, $contributionIds);
-      foreach ($selectedContributionIdsForCurrentContact as $contributionId) {
-        try {
-          $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($contributionId);
-          $tplParams = $dataCollector->retrieve();
-          $contactDetail = [$formattedContactDetail];
-          CRM_ManualDirectDebit_Mail_Task_Mail::sendEmail(
-            $contactDetail,
-            $subject,
-            $formValues['text_message'],
-            $formValues['html_message'],
-            NULL,
-            NULL,
-            $from,
-            $attachments,
-            $cc,
-            $bcc,
-            array_keys($form->_toContactDetails),
-            $additionalDetails,
-            $contributionIds,
-            CRM_Utils_Array::value('campaign_id', $formValues),
-            $tplParams
-          );
-        }
-        catch (Exception $e) {
-          $errors[] = ts('Exception found processing e-mail for contact with ID %1: %2', [
-            1 => $contactId,
-            2 => $e->getMessage(),
-          ]);
-        }
-      }
+      self::sendEmailsForContact($form, $formValues, $mailDetails, $formattedContactDetail, $errors);
     }
 
     if ($errors) {
       CRM_Core_Error::statusBounce(ts('Errors found: %1', [1 => implode('; ', $errors)]));
+    }
+  }
+
+  /**
+   * Obtains list of CC values.
+   *
+   * @param $form
+   * @param $formValues
+   * @param $ccType
+   *
+   * @return array
+   */
+  private static function getCCValues($form, $formValues, $ccType) {
+    $ccValues = [];
+
+    if (!empty($formValues[$ccType])) {
+      $allEmails = explode(',', $formValues[$ccType]);
+
+      foreach ($allEmails as $value) {
+        list($contactId, $email) = explode('::', $value);
+        $contactURL = CRM_Utils_System::url('civicrm/contact/view', "reset=1&force=1&cid={$contactId}", TRUE);
+        $ccValues['email'][] = '"' . $form->_contactDetails[$contactId]['sort_name'] . '" <' . $email . '>';
+        $ccValues['details'][] = "<a href='{$contactURL}'>" . $form->_contactDetails[$contactId]['display_name'] . "</a>";
+      }
+    }
+
+    return $ccValues;
+  }
+
+  /**
+   * Sends emails for the contributions that were selected for the contact.
+   *
+   * @param object $form
+   * @param array $formValues
+   * @param \CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails
+   * @param array $formattedContactDetail
+   * @param array $errors
+   */
+  private static function sendEmailsForContact($form, $formValues, CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
+    $contributionIds = array();
+    if ($form->getVar('_contributionIds')) {
+      $contributionIds = $form->getVar('_contributionIds');
+    }
+    $mailDetails->setAllContributionIDS($contributionIds);
+
+    $contactId = $formattedContactDetail['contact_id'];
+    $selectedContributionIdsForCurrentContact = self::getSelectedContributionIdsForCurrentContact($contactId, $contributionIds);
+    foreach ($selectedContributionIdsForCurrentContact as $contributionId) {
+      $mailDetails->setContributionID($contributionId);
+      self::sendEmailForContribution($form, $formValues, $mailDetails, $formattedContactDetail, $errors);
+    }
+  }
+
+  /**
+   * Performs the sending of the email.
+   *
+   * @param object $form
+   * @param array $formValues
+   * @param \CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails
+   * @param array $formattedContactDetail
+   * @param array $errors
+   */
+  private static function sendEmailForContribution($form, $formValues, CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
+    try {
+      $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($mailDetails->getContributionID());
+      $tplParams = $dataCollector->retrieve();
+      $contactDetail = [$formattedContactDetail];
+      $subject = $mailDetails->getSubject();
+      CRM_ManualDirectDebit_Mail_Task_Mail::sendEmail(
+        $contactDetail,
+        $subject,
+        $formValues['text_message'],
+        $formValues['html_message'],
+        NULL,
+        NULL,
+        $mailDetails->getFrom(),
+        $mailDetails->getAttachments(),
+        $mailDetails->getCc(),
+        $mailDetails->getBcc(),
+        array_keys($form->_toContactDetails),
+        $mailDetails->getAdditionalDetails(),
+        $mailDetails->getAllContributionIDs(),
+        CRM_Utils_Array::value('campaign_id', $formValues),
+        $tplParams
+      );
+    }
+    catch (Exception $e) {
+      $contactId = $formattedContactDetail['contact_id'];
+      $errors[] = ts('Exception found processing e-mail for contact with ID %1: %2', [
+        1 => $contactId,
+        2 => $e->getMessage(),
+      ]);
     }
   }
 

--- a/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Mail_Task_MailDetailsModel as MailDetailsModel;
 
 class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contact_Form_Task_EmailCommon {
 
@@ -83,7 +84,7 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
     }
 
     $errors = [];
-    $mailDetails = new CRM_ManualDirectDebit_Mail_Task_MailDetailsModel();
+    $mailDetails = new MailDetailsModel();
     $mailDetails->setSubject($subject);
     $mailDetails->setFrom($from);
     $mailDetails->setCc($cc);
@@ -135,7 +136,7 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
    * @param array $formattedContactDetail
    * @param array $errors
    */
-  private static function sendEmailsForContact($form, $formValues, CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
+  private static function sendEmailsForContact($form, $formValues, MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
     $contributionIds = array();
     if ($form->getVar('_contributionIds')) {
       $contributionIds = $form->getVar('_contributionIds');
@@ -155,7 +156,7 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
    *
    * @param object $form
    * @param array $formValues
-   * @param \CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails
+   * @param MailDetailsModel $mailDetails
    * @param array $formattedContactDetail
    * @param array $errors
    */

--- a/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
@@ -135,10 +135,11 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
             CRM_Utils_Array::value('campaign_id', $formValues),
             $tplParams
           );
-        } catch (Exception $e) {
+        }
+        catch (Exception $e) {
           $errors[] = ts('Exception found processing e-mail for contact with ID %1: %2', [
             1 => $contactId,
-            $e->getMessage()
+            2 => $e->getMessage(),
           ]);
         }
       }
@@ -164,11 +165,11 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
       SELECT contribution.id AS contribution_id
       FROM civicrm_contribution AS contribution
       WHERE contribution.contact_id = %1
-        AND contribution.id IN(". $validatedContributionIdsImploded .")
+        AND contribution.id IN(" . $validatedContributionIdsImploded . ")
     ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [(int) $contactId, 'Integer']
+      1 => [(int) $contactId, 'Integer'],
     ]);
 
     $contactContributionIds = [];

--- a/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/ContributionEmailCommon.php
@@ -156,11 +156,11 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
    *
    * @param object $form
    * @param array $formValues
-   * @param MailDetailsModel $mailDetails
+   * @param \CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails
    * @param array $formattedContactDetail
    * @param array $errors
    */
-  private static function sendEmailForContribution($form, $formValues, CRM_ManualDirectDebit_Mail_Task_MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
+  private static function sendEmailForContribution($form, $formValues, MailDetailsModel $mailDetails, $formattedContactDetail, &$errors) {
     try {
       $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($mailDetails->getContributionID());
       $tplParams = $dataCollector->retrieve();

--- a/CRM/ManualDirectDebit/Mail/Task/MailDetailsModel.php
+++ b/CRM/ManualDirectDebit/Mail/Task/MailDetailsModel.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * Class CRM_ManualDirectDebit_Mail_Task_MailDetailsModel.
+ */
+class CRM_ManualDirectDebit_Mail_Task_MailDetailsModel {
+
+  /**
+   * Subject for the e-mail.
+   *
+   * @var string
+   */
+  private $subject;
+
+  /**
+   * From e-mail address.
+   *
+   * @var string
+   */
+  private $from;
+
+  /**
+   * CC addresses for the e-mail.
+   *
+   * @var string
+   */
+  private $cc;
+
+  /**
+   * Blind CC for the e-mail.
+   *
+   * @var string
+   */
+  private $bcc;
+
+  /**
+   * Additional details for the e-mail.
+   *
+   * @var string
+   */
+  private $additionalDetails;
+
+  /**
+   * Attachments to be included in the e-mail.
+   *
+   * @var array
+   */
+  private $attachments = [];
+
+  /**
+   * Specific contribution ID for the mail.
+   *
+   * @var string
+   */
+  private $contributionID;
+
+  /**
+   * List of contribution IDs associated to the e-mail.
+   *
+   * @var array
+   */
+  private $allContributionIDs = [];
+
+  /**
+   * Sets the subject of the e-mail.
+   *
+   * @param $subject
+   */
+  public function setSubject($subject) {
+    $this->subject = $subject;
+  }
+
+  /**
+   * Sets from e-mail address for the e-mail.
+   *
+   * @param $from
+   */
+  public function setFrom($from) {
+    $this->from = $from;
+  }
+
+  /**
+   * Sets the CC for the e-mail.
+   *
+   * @param $cc
+   */
+  public function setCc($cc) {
+    $this->cc = $cc;
+  }
+
+  /**
+   * Stes BCC dor the e-mail.
+   *
+   * @param $bcc
+   */
+  public function setBcc($bcc) {
+    $this->bcc = $bcc;
+  }
+
+  /**
+   * Sets additional detail for the e-mail.
+   *
+   * @param $additionalDetails
+   */
+  public function setAdditionalDetails($additionalDetails) {
+    $this->additionalDetails = $additionalDetails;
+  }
+
+  /**
+   * Sets the attachments for the e-mail.
+   *
+   * @param $attachments
+   */
+  public function setAttachments($attachments) {
+    $this->attachments = $attachments;
+  }
+
+  /**
+   * Sets list of contribution IDs for the e-mail.
+   *
+   * @param $contributionIDs
+   */
+  public function setAllContributionIDS($contributionIDs) {
+    $this->allContributionIDs = $contributionIDs;
+  }
+
+  /**
+   * Sets the specific contribution ID being used for the e-mail.
+   *
+   * @param $contributionID
+   */
+  public function setContributionID($contributionID) {
+    $this->contributionID = $contributionID;
+  }
+
+  /**
+   * Returns the subject of the e-mail.
+   *
+   * @return string
+   */
+  public function getSubject() {
+    return $this->subject;
+  }
+
+  /**
+   * Returns the from address for the e-mail.
+   *
+   * @return string
+   */
+  public function getFrom() {
+    return $this->from;
+  }
+
+  /**
+   * Returns the cc adresses for the e-mail.
+   *
+   * @return string
+   */
+  public function getCc() {
+    return $this->cc;
+  }
+
+  /**
+   * Returns bcc addresses for the e-mail.
+   *
+   * @return string
+   */
+  public function getBcc() {
+    return $this->bcc;
+  }
+
+  /**
+   * Returns additional details for the e-mail.
+   *
+   * @return string
+   */
+  public function getAdditionalDetails() {
+    return $this->additionalDetails;
+  }
+
+  /**
+   * Returns list of attachments.
+   *
+   * @return array
+   */
+  public function getAttachments() {
+    return $this->attachments;
+  }
+
+  /**
+   * Return contribution ID for the e-mail.
+   *
+   * @return string
+   */
+  public function getContributionID() {
+    return $this->contributionID;
+  }
+
+  /**
+   * Returns list of contributions that will be used for the e-mail.
+   *
+   * @return mixed
+   */
+  public function getAllContributionIDs() {
+    return $this->allContributionIDs;
+  }
+
+}

--- a/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
@@ -49,10 +49,13 @@ class CRM_ManualDirectDebit_ScheduleJob_Reminder {
    * @param array $targetContributionData
    */
   private function processTargetContribution($targetContributionData) {
-    $this->setLog(ts("Contribution with id = %1", [1 => $targetContributionData['contributionId']]));
+    $this->setLog(ts("Processing contribution with id = %1", [1 => $targetContributionData['contributionId']]));
 
     if (empty($targetContributionData['email'])) {
-      $this->setLog(ts("Email not sent. Related contact doesn't have an e-mail or has the 'do not send e-mail' flag set."));
+      $this->setLog(ts(
+        "Could not send email for contribution with id = %1. Related contact doesn't have an e-mail or has the 'do not send e-mail' flag set.",
+        [1 => $targetContributionData['contributionId']]
+      ));
       $this->setLog(ts(""));
 
       return;

--- a/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/Reminder.php
@@ -68,7 +68,7 @@ class CRM_ManualDirectDebit_ScheduleJob_Reminder {
     catch (Exception $e) {
       $this->setLog(ts("Exception found processing contribution with id %1: %2", [
         1 => $targetContributionData['contributionId'],
-        2 => $e->getMessage()
+        2 => $e->getMessage(),
       ]));
     }
 


### PR DESCRIPTION
## Overview
For each contribution satisfying conditions for the scheduled job "Send Direct Debit Payment Collection Reminders" an e-mail with the "Direct Debit Payment Collection Reminder" message template should get sent. These conditions are:
- Payment Method is Direct Debit
- Contribution Status is Pending or Cancelled
- Receipt Date is empty
- "Received Date" minus "Days in advance for Collection Reminder" is equal to or smaller than today

However, running the job on SPAB results in failure, logged on the job's execution job:
> Job is failed with'Failure, Error message: One of parameters  (value: ) is not of the type Integer'

No DD payment collection reminder emails are triggered.

No Activities are created.

## Before
If an exception was thrown amidst the sending of reminders for direct debit collections, the process was halted and remaining contributions never got their reminder sent. In the specific case of SPAB, the first contribution had a line item related to a membership that no longer exists in the database. When trying to use the membership to obtain the information for the next payment, a validation of the value being an integer caused the exception to be thrown, as a null value was given.

## After
Fixed by capturing exceptions and logging any problems found on the job log. Also added check to see if the membership exists when pulling its info with the API call, and throwing an exception with a less cryptic message. 

Added exception handling to other classes that used the same class to collect and build the data for messages.
