### PR TITLE
RSE-1128: Hide tax amount

### DIFF
--- a/CRM/ManualDirectDebit/Form/SetUp.php
+++ b/CRM/ManualDirectDebit/Form/SetUp.php
@@ -47,7 +47,7 @@ class CRM_ManualDirectDebit_Form_SetUp extends CRM_Core_Form {
     $this->assign('invoiceNumber', $contribution['invoice_number']);
     $this->assign('amount', $this->calculateAmount($contribution['total_amount'], $contribution['tax_amount']));
 
-    if (!empty($contribution['tax_amount'])) {
+    if (!empty($contribution['tax_amount']) && $contribution['tax_amount'] != '0.00') {
       $this->assign('taxAmount', $contribution['tax_amount']);
     }
     $this->assign('totalAmount', $contribution['total_amount']);


### PR DESCRIPTION
## Overview
This PRs to hide VAT field if no VAT is configured on the membership type.

## Before
VAT is displayed with £0.00 if no VAT is configured on the membership type.

![Screenshot_2020-07-09_19 44 46](https://user-images.githubusercontent.com/208713/88678284-321c6a80-d0e6-11ea-804e-9733d008419a.png)

## After
VAT will not display if no VAT is configured on the membership type.

![Screenshot from 2020-07-28 15-09-08](https://user-images.githubusercontent.com/208713/88678042-ee296580-d0e5-11ea-847f-a1dba97d5d87.png)
