### PR TITLE
RSE-1129: Set Contribution Recurring cycle day automatically

### DIFF
--- a/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/SetUp.tpl
@@ -33,22 +33,6 @@
               <div class="content">{$totalAmount|crmMoney:$currency}</div>
               <div class="clear"></div>
             </div>
-            {if $payment_date_value}
-              <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-text">
-                <div class="label"><label> {ts}Payment Date:{/ts}</label></div>
-                <div class="content">
-                  {ts}To be taken on or around the {$payment_date_value} of the month.{/ts}
-                  {$form.payment_dates.html}
-                </div>
-                <div class="clear"></div>
-              </div>
-            {else}
-              <div class="crm-section form-item crm-manual-direct-debit-form-payment-date-select">
-                <div class="label">{$form.payment_dates.label}</div>
-                <div class="content">{$form.payment_dates.html}</div>
-                <div class="clear"></div>
-              </div>
-            {/if}
           </fieldset>
         </div>
         <div class="crm-public-form-item crm-section crm-manual-direct-debit-form-bank-details">


### PR DESCRIPTION
## Overview
This PR is to update the behaviour  of setting contribution recurring cycle day when sign up with Direct Debit on public form.

## Before
The public Direct Debit sign up form allows the end user to select the payment date from payment collection run date. 

## After
The option to select payment run date is removed and the Recurring Contribution cycle day will be calculated automatically based on the Manual Direct debit configuration and the sign up date. 

## Technical Details
The calculation of contribution Recurring Cycle day will only be calculated if the frequency is yearly and will be calculated base on. 

1. The payment collection run date.
2. The minimum days to first payment. 
3. The sign up date. 

For example, 

if the payment run date is set on 7th and 21st and the minimum days to first payment is set to 5 days.

Scenario 1: 

if user sign up on 06/09/2020 the first payment will be 21/09/2020

Scenario 2:

if user sign up on 01/09/2020 the first payment will be 07/09/2020

Scenario 3: 

if user sign up on 18/09/2020 the first payment will be 07/10/2020


