### PR TITLE
IO-74: Add "Create Cancelled Instructions Batch" Menu Item

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -93,7 +93,6 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
   ];
 
-
   /**
    * List of processor types
    *
@@ -805,6 +804,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'export_direct_debit_payments',
       'view_new_instruction_batches',
       'view_payment_batches',
+      'create_cancelled_batches',
     ];
 
     foreach ($menuItems as $item) {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -144,6 +144,21 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->createDirectDebitPaymentProcessor();
   }
 
+  public function upgrade_0014() {
+    $this->addNav([
+      'label' => ts('Create Cancelled Instructions Batch'),
+      'name' => 'create_cancelled_batches',
+      'url' => 'civicrm/direct_debit/cancelled-batch-list',
+      'permission' => 'can manage direct debit batches',
+      'operator' => NULL,
+      'separator' => NULL,
+      'parent_name' => 'direct_debit',
+    ]);
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
   public function upgrade_0013() {
     $this->hideAndReserveDDActivityTypes();
     return TRUE;
@@ -218,7 +233,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function createCollectionReminderFlagRecords() {
     CRM_Core_DAO::executeQuery("
-      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag 
+      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag
       (entity_id, is_notification_sent) SELECT id,0 FROM civicrm_contribution
       ");
   }
@@ -472,6 +487,15 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'label' => ts('View Payment Collection Batches'),
         'name' => 'view_payment_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('dd_payments', $batchTypes),
+        'permission' => 'can manage direct debit batches',
+        'operator' => NULL,
+        'separator' => NULL,
+        'parent_name' => 'direct_debit',
+      ],
+      [
+        'label' => ts('Create Cancelled Instructions Batch'),
+        'name' => 'create_cancelled_batches',
+        'url' => 'civicrm/direct_debit/cancelled-batch-list',
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -316,9 +316,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function setDefaultMinimumMandateReferenceLength() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
     civicrm_api3('setting', 'create', [
-        'manualdirectdebit_minimum_reference_prefix_length' =>
-          $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
-      ]);
+      'manualdirectdebit_minimum_reference_prefix_length' => $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
+    ]);
   }
 
   public function upgrade_0004() {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -128,7 +128,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     "direct_debit_mandate",
     "direct_debit_information",
     "direct_debit_message_template",
-    "direct_debit_collection_reminder_sendflag"
+    "direct_debit_collection_reminder_sendflag",
   ];
 
   public function install() {
@@ -194,7 +194,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
           'is_reserved' => 1,
         ];
         civicrm_api3('OptionValue', 'create', $updateParams);
-      } else {
+      }
+      else {
         $activityTypeParams['option_group_id'] = 'activity_type';
         $activityTypeParams['filter'] = 1;
         $activityTypeParams['is_reserved'] = 1;
@@ -301,7 +302,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -315,7 +317,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
     civicrm_api3('setting', 'create', [
         'manualdirectdebit_minimum_reference_prefix_length' =>
-        $configFields['manualdirectdebit_minimum_reference_prefix_length']['default']
+          $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
       ]);
   }
 
@@ -324,7 +326,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -334,7 +337,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createScheduledJob();
 
       return TRUE;
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return FALSE;
     }
   }
@@ -408,8 +412,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function createScheduledJob() {
     $domainID = CRM_Core_Config::domainID();
 
-    if($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')){
-      $this->alterEntity('Job','Send Direct Debit Payment Collection Reminders','name',FALSE,'uninstall');
+    if ($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')) {
+      $this->alterEntity('Job', 'Send Direct Debit Payment Collection Reminders', 'name', FALSE, 'uninstall');
     }
 
     $params = [
@@ -595,7 +599,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       ],
     ];
 
-    foreach($paramsPerType as $typeParams) {
+    foreach ($paramsPerType as $typeParams) {
       $params = array_merge($defaultProcessorPrams, $typeParams);
       civicrm_api3('PaymentProcessor', 'create', $params);
     }
@@ -607,7 +611,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function setDefaultSettingValues() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
-    foreach ($configFields  as $name => $config) {
+    foreach ($configFields as $name => $config) {
       civicrm_api3('setting', 'create', [$name => $config['default']]);
     }
   }
@@ -783,7 +787,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
    * Deletes Direct Debit payment processor
    */
   private function deletePaymentProcessor() {
-    foreach([0, 1] as $isTest) {
+    foreach ([0, 1] as $isTest) {
       civicrm_api3('PaymentProcessor', 'get', [
         'name' => 'Direct Debit',
         'is_test' => $isTest,


### PR DESCRIPTION
## Overview
We need to add a "Create Cancelled Instructions Batch" item to the Direct Debit Menu.

## Before
There was no menu item to create cancelled instructions batch.

## After
A place holder menu item has been added with a test url, that will be replaced once the create cancelled instructions batch form is created on IO-75.
