### PR TITLE
IO-75: Enable Form to Create Cancellation Batches

### DIFF
--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -16,7 +16,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     parent::preProcess();
 
     $batchTypeID = CRM_Utils_Request::retrieveValue('type_id', 'String', NULL);
-    $this->batchType =  CRM_Core_OptionGroup::getRowValues('batch_type', $batchTypeID, 'value', 'String', FALSE);
+    $this->batchType = CRM_Core_OptionGroup::getRowValues('batch_type', $batchTypeID, 'value', 'String', FALSE);
 
     // Set the user context.
     $session = CRM_Core_Session::singleton();
@@ -122,9 +122,11 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $params = $this->controller->exportValues($this->_name);
 
     $params['data'] = json_encode(
-      ['values' => [
-        'originator_number' => $params['originator_number'],
-      ]]
+      [
+        'values' => [
+          'originator_number' => $params['originator_number'],
+        ],
+      ]
     );
 
     $params['modified_date'] = date('YmdHis');

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -106,6 +106,9 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
       $defaults['end_date_filter'] = (new DateTime())->format('Y-m-d');
     }
 
+    if ($this->batchType['name'] == 'cancellations_batch') {
+      $defaults['title'] = ts('Cancelled Instruction Batch - %1', [1 => $batchNo]);
+    }
 
     return $defaults;
   }

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -25,6 +25,11 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
     [
       "entityType" => "OptionValue",
+      "searchValue" => "cancellations_batch",
+      "optionGroup" => "batch_type",
+    ],
+    [
+      "entityType" => "OptionValue",
       "searchValue" => "dd_payments",
       "optionGroup" => "batch_type",
     ],
@@ -144,18 +149,50 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   }
 
   public function upgrade_0014() {
-    $this->addNav([
+    $this->addOptionValue([
+      'option_group_id' => 'batch_type',
+      'name' => 'cancellations_batch',
+      'label' => 'Direct Debit Cancellations',
+      'is_active' => 1,
+      'weight' => 6,
+      'description' => 'Direct debit mandates that need to be cancelled.'
+    ]);
+    $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Adds the option value, if it exist.
+   *
+   * @param array $optionValueParams
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function addOptionValue($optionValueParams) {
+    $optionValue = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => $optionValueParams['option_group_id'],
+      'name' => $optionValueParams['name'],
+    ]);
+
+    if (!$optionValue['count']) {
+      civicrm_api3('OptionValue', 'create', $optionValueParams);
+    }
+  }
+
+  private function buildCreateCancelledInstructionsBatchMenuItem() {
+    $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
+
+    return [
       'label' => ts('Create Cancelled Instructions Batch'),
-      'name' => 'create_cancelled_batches',
-      'url' => 'civicrm/direct_debit/cancelled-batch-list',
+      'name' => 'create_cancellation_batch',
+      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('cancellations_batch', $batchTypes),
       'permission' => 'can manage direct debit batches',
       'operator' => NULL,
       'separator' => NULL,
       'parent_name' => 'direct_debit',
-    ]);
-    CRM_Core_BAO_Navigation::resetNavigation();
-
-    return TRUE;
+    ];
   }
 
   public function upgrade_0013() {
@@ -255,21 +292,12 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   }
 
   private function addMessageTemplateToCustomGroupEntities() {
-    $optionValueParams = [
+    $this->addOptionValue([
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_msg_template',
       'label' => 'MessageTemplate',
       'value' => 'MessageTemplate',
-    ];
-
-    $cgextendOptionValue = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => $optionValueParams['option_group_id'],
-      'name' => $optionValueParams['name'],
     ]);
-
-    if (!$cgextendOptionValue['count']) {
-      civicrm_api3('OptionValue', 'create', $optionValueParams);
-    }
   }
 
   private function addDDTemplateCustomGroup() {
@@ -494,15 +522,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'separator' => NULL,
         'parent_name' => 'direct_debit',
       ],
-      [
-        'label' => ts('Create Cancelled Instructions Batch'),
-        'name' => 'create_cancelled_batches',
-        'url' => 'civicrm/direct_debit/cancelled-batch-list',
-        'permission' => 'can manage direct debit batches',
-        'operator' => NULL,
-        'separator' => NULL,
-        'parent_name' => 'direct_debit',
-      ],
+      $this->buildCreateCancelledInstructionsBatchMenuItem(),
     ];
 
     foreach ($menuItems as $item) {
@@ -804,7 +824,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'export_direct_debit_payments',
       'view_new_instruction_batches',
       'view_payment_batches',
-      'create_cancelled_batches',
+      'create_cancellation_batch',
     ];
 
     foreach ($menuItems as $item) {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -155,7 +155,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'label' => 'Direct Debit Cancellations',
       'is_active' => 1,
       'weight' => 6,
-      'description' => 'Direct debit mandates that need to be cancelled.'
+      'description' => 'Direct debit mandates that need to be cancelled.',
     ]);
     $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
     CRM_Core_BAO_Navigation::resetNavigation();

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -401,6 +401,14 @@
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
+      <label>Direct Debit Cancellations</label>
+      <name>cancellations_batch</name>
+      <is_active>1</is_active>
+      <weight>6</weight>
+      <description>Direct debit mandates that need to be cancelled.</description>
+      <option_group_name>batch_type</option_group_name>
+    </OptionValue>
+    <OptionValue>
       <label>Submitted</label>
       <name>Submitted</name>
       <is_active>1</is_active>


### PR DESCRIPTION
## Overview
When clicking on the "Create New Cancellation Batch" Item on the DD menu, we need to show a form similar to the other batch creation forms where:
- Title: Create Cancelled Instructions Batch
- Batch ID: Incremental numbering - not editable.
- Batch name Defaults to: Cancelled Instruction Batch - "Batch ID" - required
- Batch Type: Cancelled Instruction Batch
- Originator number
- Select list of Originator number - required

## Before
The form did not exist, and clicking the menu item showed a 404.

## After
Clicking on the menu item now shows the form. If the form is saved, the batch is created and the user is forwarded to the batch update view.
![IO-75-debug](https://user-images.githubusercontent.com/21999940/94449453-b4222180-0171-11eb-9ce3-40a0907b5e29.gif)
