### PR TITLE
IO-76: Implement Cancellation Batch Management Form

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -18,7 +18,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   /**
    * Batch id
    *
-   * @var integer
+   * @var int
    */
   private $batchID;
 
@@ -131,7 +131,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       ts('Transaction Type'),
     ];
 
-    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $headers[] = ts('Received Date');
     }
 
@@ -149,8 +149,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
    * Output CSV File
    *
    * @param array $headers
-   *
-   * @param array
+   * @param array $export
    */
   private function outputCSVFile($headers, $export) {
     $out = fopen('php://temp/maxmemory:' . (12 * 1024 * 1024), 'r+');
@@ -188,18 +187,18 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
-          1 => '0N',
-          2 => '01',
-        ]) . '</p>';
+        1 => '0N',
+        2 => '01',
+      ]) . '</p>';
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
-          1 => '01',
-          2 => '17',
-        ]) . '</p>';
+        1 => '01',
+        2 => '17',
+      ]) . '</p>';
 
       $submittedMessage .= '<p>' . ts('- All contributions in the batch with status \'Pending\' will be marked as \'Completed\'') . '</p>';
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
@@ -339,10 +338,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       'transaction_type' => 'CONCAT("\t",civicrm_option_value.label) as transaction_type',
     ];
 
-    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
-    } else {
+    }
+    else {
       $returnValues['mandate_id'] = 'civicrm_value_dd_mandate.id as mandate_id';
     }
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -131,7 +131,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       ts('Transaction Type'),
     ];
 
-    if($this->getBatchType() == 'dd_payments') {
+    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $headers[] = ts('Received Date');
     }
 
@@ -185,7 +185,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   public static function getSubmitAlertMessage($typeId) {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
-    if ($batchTypes[$typeId] == 'instructions_batch') {
+    if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
           1 => '0N',
@@ -194,7 +194,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
-    elseif ($batchTypes[$typeId] == 'dd_payments') {
+    elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
           1 => '01',
@@ -224,10 +224,10 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       return FALSE;
     }
 
-    if ($this->getBatchType() == 'instructions_batch') {
+    if ($this->getBatchType() == self::BATCH_TYPE_INSTRUCTIONS) {
       $submitted = $this->submitInstructionsBatch();
     }
-    if ($this->getBatchType() == 'dd_payments') {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $submitted = $this->submitDDPayments();
     }
 
@@ -339,7 +339,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       'transaction_type' => 'CONCAT("\t",civicrm_option_value.label) as transaction_type',
     ];
 
-    if($this->getBatchType() == 'dd_payments') {
+    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
     } else {
@@ -359,11 +359,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   public function getMandateCurrentState($returnValues) {
     $dataForExport = [];
     switch ($this->getBatchType()) {
-      case 'instructions_batch':
+      case self::BATCH_TYPE_INSTRUCTIONS:
         $entityTable = 'civicrm_value_dd_mandate';
         break;
 
-      case 'dd_payments':
+      case self::BATCH_TYPE_PAYMENTS:
         $entityTable = 'civicrm_contribution';
         break;
     }
@@ -378,13 +378,13 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $mandateItems = $batchTransaction->getDDMandateInstructions();
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
-        case 'instructions_batch':
+        case self::BATCH_TYPE_INSTRUCTIONS:
           $entityId = $mandateItem['mandate_id'];
           unset($mandateItem['mandate_id']);
           $dataForExport[$entityId] = $mandateItem;
           break;
 
-        case 'dd_payments':
+        case self::BATCH_TYPE_PAYMENTS:
           $entityId = $mandateItem['contribute_id'];
           unset($mandateItem['contribute_id']);
           $dataForExport[$entityId] = $mandateItem;

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -1,10 +1,12 @@
 <?php
 
 /**
- * This class is used for batch handling
- *
+ * This class is used for batch handling.
  */
 class CRM_ManualDirectDebit_Batch_BatchHandler {
+  const BATCH_TYPE_INSTRUCTIONS = 'instructions_batch';
+  const BATCH_TYPE_PAYMENTS = 'dd_payments';
+  const BATCH_TYPE_CANCELLATIONS = 'cancellations_batch';
 
   /**
    * Batch

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -24,14 +24,14 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   /**
    * Search element
    *
-   * @var boolean
+   * @var bool
    */
   protected $notPresent;
 
   /**
    * Limit element
    *
-   * @var boolean
+   * @var bool
    */
   protected $total;
 
@@ -45,30 +45,28 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   /**
    * What column does select in SQL query
    *
+   * @var array
+   *
    * @code
    *
    *  $returnValues = [
    *    'name' => 'tableName.column as alias',
    *  ]
-   *
    * @endcode
-   *
-   * @var array
    */
   protected $returnValues = [];
 
   /**
    * What column does select in SQL query
    *
+   * @var array
+   *
    * @code
    *
    *  $columnHeader = [
    *    'alias' => 'label',
    *  ]
-   *
    * @endcode
-   *
-   * @var array
    */
   protected $columnHeader = [];
 
@@ -248,7 +246,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => ts('Transaction Type'),
       ];
 
-      if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+      if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $columnHeader['receive_date'] = ts('Received Date');
       }
     }
@@ -280,7 +278,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
       ];
 
-      if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+      if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
       }
     }
@@ -457,9 +455,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     }
 
     $this->addContributionReceiveDateCondition($query);
-
     $this->addContributionCancelDateCondition($query);
-
 
     if ($this->notPresent) {
       $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
@@ -501,7 +497,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $mandateItems = CRM_Core_DAO::executeQuery($query->toSQL());
 
     $rows = [];
-    while($mandateItems->fetch()) {
+    while ($mandateItems->fetch()) {
       $mandateItem = [];
       foreach ($this->returnValues as $key => $value) {
         if (isset($mandateItems->$key)) {
@@ -639,7 +635,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
                      ['receive_date_start' => date('Ymd', strtotime($this->params['receive_date_low']))]
                    );
     }
-    if(!empty($this->params['receive_date_high'])) {
+    if (!empty($this->params['receive_date_high'])) {
       $query->where('DATE_FORMAT(civicrm_contribution.receive_date, "%Y%m%d") <= @receive_date_end',
                      ['receive_date_end' => date('Ymd', strtotime($this->params['receive_date_high']))]
                    );
@@ -663,7 +659,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
                      ['cancel_date_start' => date('Ymd', strtotime($this->params['contribution_cancel_date_low']))]
                    );
     }
-    if(!empty(!empty($this->params['contribution_cancel_date_high']))) {
+    if (!empty(!empty($this->params['contribution_cancel_date_high']))) {
       $query->where('civicrm_contribution.cancel_date <= @cancel_date_end',
                      ['cancel_date_end' => date('Ymd', strtotime($this->params['contribution_cancel_date_high']))]
                    );

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -248,7 +248,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => ts('Transaction Type'),
       ];
 
-      if($batch->getBatchType() == 'dd_payments') {
+      if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $columnHeader['receive_date'] = ts('Received Date');
       }
     }
@@ -280,7 +280,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
       ];
 
-      if($batch->getBatchType() == 'dd_payments') {
+      if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
       }
     }
@@ -321,11 +321,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
       if (!empty($mandateValue['contact_id'])) {
         switch ($batch->getBatchType()) {
-          case "instructions_batch":
+          case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
             $row['action'] = $this->getLinkToMandate($mandateValue['contact_id']);
             break;
 
-          case "dd_payments":
+          case BatchHandler::BATCH_TYPE_PAYMENTS:
             $row['action'] = $this->getLinkToContribution($mandateValue['contribute_id'], $mandateValue['contact_id']);
             break;
         }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class is used to retrieve and display a range of direct debit mandates
@@ -235,7 +236,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setColumnHeader($columnHeader = []) {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     if (empty($columnHeader)) {
       $columnHeader = [
         'contact_id' => ts('ID'),
@@ -265,7 +266,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setReturnValues($returnValues = []) {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     if (empty($returnValues) || !is_array($returnValues)) {
       $returnValues = [
         'id' => $this->params['entityTable'] . '.id as id',
@@ -295,10 +296,9 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   public function getRows() {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     return $this->getBatchRows($batch);
   }
-
 
   /**
    * Gets prepared data about previously serialized mandates
@@ -370,7 +370,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $row['check'] = $this->getCheckRow($batch, $mandateItem['id']);
 
       switch ($batch->getBatchType()) {
-        case "instructions_batch":
+        case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+        case BatchHandler::BATCH_TYPE_CANCELLATIONS:
           if (!empty($mandateItem['contact_id'])) {
             $row['action'] = $this->getLinkToMandate($mandateItem['contact_id']);
           }
@@ -378,7 +379,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           $rows[$mandateItem['mandate_id']] = $row;
           break;
 
-        case "dd_payments":
+        case BatchHandler::BATCH_TYPE_PAYMENTS:
           if (isset($mandateItem['contribute_id'])) {
             $contributionId = $mandateItem['contribute_id'];
           }
@@ -393,7 +394,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           $rows[$contributionId] = $row;
           break;
       }
-
     }
 
     return $rows;
@@ -517,7 +517,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $rows[] = $mandateItem;
     }
 
-
     return $rows;
   }
 
@@ -551,7 +550,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
     return $this->returnValues;
   }
-
 
   /**
    * Adds new columns for rows

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class generates form components for Create Instructions Batch
@@ -24,7 +25,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
 
     CRM_Utils_System::setTitle(E::ts('Create %1', [1 => $this->batchType['label']]));
 
-    $newBatchID = CRM_ManualDirectDebit_Batch_BatchHandler::getMaxBatchId() + 1;
+    $newBatchID = BatchHandler::getMaxBatchId() + 1;
     $this->assign('batch_id', $newBatchID);
     $this->add('hidden', 'batch_id', $newBatchID);
     $this->add('hidden', 'type_id', $this->batchType['value']);
@@ -72,7 +73,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
    */
   public static function validateBatchID($fields, $files, $self) {
 
-    if ($fields['batch_id'] <= CRM_ManualDirectDebit_Batch_BatchHandler::getMaxBatchId()) {
+    if ($fields['batch_id'] <= BatchHandler::getMaxBatchId()) {
       $errors['batch_id'] = ts(
         'Batch ID %1 already exists. It is likely another batch has just been created a moment ago. Please %2 to reload the page and try again.',
         [
@@ -97,16 +98,16 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $sql = "SELECT max(id) FROM civicrm_batch";
     $batchNo = CRM_Core_DAO::singleValueQuery($sql) + 1;
 
-    if ($this->batchType['name'] == 'instructions_batch') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_INSTRUCTIONS) {
       $defaults['title'] = ts('New Instruction Batch - %1', [1 => $batchNo]);
     }
 
-    if ($this->batchType['name'] == 'dd_payments') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $defaults['title'] = ts('Direct Debit Batch - %1', [1 => $batchNo]);
       $defaults['end_date_filter'] = (new DateTime())->format('Y-m-d');
     }
 
-    if ($this->batchType['name'] == 'cancellations_batch') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_CANCELLATIONS) {
       $defaults['title'] = ts('Cancelled Instruction Batch - %1', [1 => $batchNo]);
     }
 

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -138,6 +138,8 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
    * @return array[]
    */
   private function assignCancellationsSearchProperties() {
+    CRM_Utils_System::setTitle(ts('Cancelled Instructions Batch - %1', [1 => $this->batch->id]));
+
     $this->addElement('hidden', 'entityTable', 'civicrm_value_dd_mandate');
     $this->assign('tableTitle', ts('Available instructions'));
     $this->assign('entityTable', 'civicrm_value_dd_mandate');

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -16,7 +16,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
   /**
    * Batch id.
    *
-   * @var integer
+   * @var int
    */
   protected $batchID;
 

--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -20,7 +20,7 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
    * @param $recurringContributionId
    */
   public function alterRecurContributionLinks(&$values, $recurringContributionId) {
-    $contactId =  CRM_Utils_Request::retrieve('cid', 'Integer');
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Integer');
     $contactType = $this->getContactType($contactId);
 
     $this->links[] = [

--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -62,7 +62,7 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
   public function alterBatchLinks($objectId) {
     $batch = CRM_Batch_BAO_Batch::findById($objectId);
 
-    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', 'instructions_batch', 'name', 'String', FALSE);
+    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', CRM_ManualDirectDebit_Batch_BatchHandler::BATCH_TYPE_INSTRUCTIONS, 'name', 'String', FALSE);
     if ($batch->type_id == $instructionsBatchTypeId['value']) {
       foreach ($this->links as &$link) {
         switch ($link['name']) {

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -33,7 +33,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
 
     $batch = (new BatchHandler($entityID));
-    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+    if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $sortMapper[] = 'receive_date';
     }
 
@@ -74,7 +74,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'transaction_type',
     ];
 
-    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+    if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $selectorElements[] = 'receive_date';
     }
     $selectorElements[] = 'action';
@@ -120,10 +120,10 @@ class CRM_ManualDirectDebit_Page_AJAX {
         // since we are using it to quote the field value.
         // str_replace helps to provide a break for new-line
         $sOutput .= '"' . $element . '" :"' . addcslashes(str_replace([
-            "\r\n",
-            "\n",
-            "\r",
-          ], '<br />', $value[$element]), '"\\') . '"';
+          "\r\n",
+          "\n",
+          "\r",
+        ], '<br />', $value[$element]), '"\\') . '"';
 
         // remove extra spaces and tab character that breaks dataTable CRM-12551
         $sOutput = preg_replace("/\s+/", " ", $sOutput);
@@ -218,6 +218,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
               'batch_id' => $entityID,
             ];
             break;
+
           case 'discard':
             $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
             $params['status_id'] = CRM_Utils_Array::key('Discarded', $batchStatus);

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class contains all the function that are called using AJAX
@@ -31,8 +32,8 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $entityTable = CRM_Utils_Request::retrieveValue('entityTable', 'String', NULL);
     $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
 
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($entityID));
-    if($batch->getBatchType() == 'dd_payments') {
+    $batch = (new BatchHandler($entityID));
+    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $sortMapper[] = 'receive_date';
     }
 
@@ -73,7 +74,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'transaction_type',
     ];
 
-    if($batch->getBatchType() == 'dd_payments') {
+    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $selectorElements[] = 'receive_date';
     }
     $selectorElements[] = 'action';
@@ -250,7 +251,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
    */
   public static function export() {
     $id = CRM_Utils_Request::retrieveValue('id', 'String');
-    $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($id);
+    $batch = new BatchHandler($id);
     $batch->createExportFile();
   }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -11,7 +11,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    *
    * @var array
    */
-  static $links = NULL;
+  public static $links = NULL;
 
   /**
    * Pager
@@ -79,8 +79,8 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
-    // get the requested action
-    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse'); // default to 'browse'
+    // get the requested action - default to 'browse'
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $action);
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
@@ -121,10 +121,11 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       $batch['transaction_count'] = $batchTransaction->getTotalNumber();
     }
 
-    if(BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]){
+    if (BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]) {
       $type = 'Payment';
       CRM_Utils_System::setTitle(ts('View Payment Batches'));
-    } else {
+    }
+    else {
       $type = 'Instruction';
       CRM_Utils_System::setTitle(ts('View New Instruction Batches'));
     }

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Page for displaying the list of financial batches
@@ -84,7 +85,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     $typeId = CRM_Utils_Request::retrieve('type_id', 'String', $this, FALSE);
-    $typeId = $typeId ?: array_search('instructions_batch', $batchTypes);
+    $typeId = $typeId ?: array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes);
 
     $param = [
       'type_id' => $typeId,
@@ -115,12 +116,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         ['id' => $id], ts('more'), FALSE, '', 'Batch', $id
       );
 
-      $param['entityTable'] = 'dd_payments' == $batchTypes[$batch['type_id']] ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
+      $param['entityTable'] = BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$batch['type_id']] ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
       $batch['transaction_count'] = $batchTransaction->getTotalNumber();
     }
 
-    if('dd_payments' == $batchTypes[$typeId]){
+    if(BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]){
       $type = 'Payment';
       CRM_Utils_System::setTitle(ts('View Payment Batches'));
     } else {
@@ -128,7 +129,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       CRM_Utils_System::setTitle(ts('View New Instruction Batches'));
     }
 
-    $submittedMessage = CRM_ManualDirectDebit_Batch_BatchHandler::getSubmitAlertMessage($typeId);
+    $submittedMessage = BatchHandler::getSubmitAlertMessage($typeId);
     $this->assign('submittedMessage', $submittedMessage);
     $this->assign('batches', $batchList);
     $this->assign('type', $type);

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -14,7 +14,7 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     parent::__construct($title, $mode);
 
     $this->queue = CRM_ManualDirectDebit_Queue_BatchSubmission::getQueue();
-    $this->batchId =  CRM_Utils_Request::retrieveValue('batchId', 'Int');
+    $this->batchId = CRM_Utils_Request::retrieveValue('batchId', 'Int');
   }
 
   public function run() {
@@ -77,7 +77,7 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     $runner = new CRM_Queue_Runner([
       'title' => ts('Submitting the batch, this may take a while depending on how many records are processed ..'),
       'queue' => $this->queue,
-      'errorMode'=> CRM_Queue_Runner::ERROR_ABORT,
+      'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
       'onEnd' => array('CRM_ManualDirectDebit_Page_BatchSubmissionQueue', 'onEnd'),
       'onEndUrl' => CRM_Utils_System::url('civicrm/direct_debit/batch-transaction', ['reset' => 1, 'action' => 'view', 'bid' => $this->batchId]),
     ]);
@@ -89,4 +89,5 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     $message = ts('Batch Submission Completed');
     CRM_Core_Session::setStatus($message, '', 'success');
   }
+
 }

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -2,6 +2,7 @@
 
 use CRM_ManualDirectDebit_Queue_Build_InstructionsQueueBuilder as InstructionsQueueBuilder;
 use CRM_ManualDirectDebit_Queue_Build_PaymentsQueueBuilder as PaymentsQueueBuilder;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
 
@@ -43,10 +44,11 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
   private function addTasksToQueue() {
     $batchType = $this->getBatchType();
     switch ($batchType) {
-      case 'instructions_batch':
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
         $queueBuilder = new InstructionsQueueBuilder($this->queue, $this->batchId);
         break;
-      case 'dd_payments':
+
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
         $queueBuilder = new PaymentsQueueBuilder($this->queue, $this->batchId);
         break;
     }

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Page for displaying list of Batch Transaction
@@ -30,7 +31,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
       $param = ['id' => $batchID, 'context' => ''];
       $batch = CRM_ManualDirectDebit_Page_BatchTableListHandler::generateRows($param);
       $batch = $batch[$batchID];
-      $param['entityTable'] = $batchTypes[$batch['type_id']] == 'instructions_batch' ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
+      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_INSTRUCTIONS ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
 
       $batchInfo = [
@@ -40,8 +41,8 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
         'created_date' => $batch['created_date'],
         'created_by' => $batch['created_by'],
       ];
-      $type = 'dd_payments' == $batchTypes[$batch['type_id']] ? 'Payment' : 'Instruction';
-      $submittedMessage = CRM_ManualDirectDebit_Batch_BatchHandler::getSubmitAlertMessage($batch['type_id']);
+      $type = BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$batch['type_id']] ? 'Payment' : 'Instruction';
+      $submittedMessage = BatchHandler::getSubmitAlertMessage($batch['type_id']);
 
       $this->assign('batchInfo', $batchInfo);
       $this->assign('submittedMessage', $submittedMessage);

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -14,7 +14,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
   protected $links = NULL;
 
   /**
-   * @var integer
+   * @var int
    */
   protected $entityID;
 
@@ -22,8 +22,8 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
    * Runs the page.
    */
   public function run() {
-    // get the requested action
-    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse'); // default to 'browse'
+    // get the requested action - default to 'browse'
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
 
     if ($action == CRM_Core_Action::VIEW) {
       $batchID = CRM_Utils_Request::retrieve('bid', 'Positive') ?: CRM_Utils_Array::value('batch_id', $_POST);

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -21,17 +21,17 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "instructions_batch",
+      "searchValue" => BatchHandler::BATCH_TYPE_INSTRUCTIONS,
       "optionGroup" => "batch_type",
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "cancellations_batch",
+      "searchValue" => BatchHandler::BATCH_TYPE_PAYMENTS,
       "optionGroup" => "batch_type",
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "dd_payments",
+      "searchValue" => BatchHandler::BATCH_TYPE_CANCELLATIONS,
       "optionGroup" => "batch_type",
     ],
     [
@@ -182,13 +182,18 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     }
   }
 
+  /**
+   * Builds menu item to create mandate cancellation batches.
+   *
+   * @return array
+   */
   private function buildCreateCancelledInstructionsBatchMenuItem() {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     return [
       'label' => ts('Create Cancelled Instructions Batch'),
       'name' => 'create_cancellation_batch',
-      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('cancellations_batch', $batchTypes),
+      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_CANCELLATIONS, $batchTypes),
       'permission' => 'can manage direct debit batches',
       'operator' => NULL,
       'separator' => NULL,
@@ -491,7 +496,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('Create New Instructions Batch'),
         'name' => 'create_new_instructions_batch',
-        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('instructions_batch', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'separator' => 1,
         'parent_name' => 'direct_debit',
@@ -499,7 +504,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('Create Payment Collection Batch'),
         'name' => 'export_direct_debit_payments',
-        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('dd_payments', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,
@@ -508,7 +513,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('View New Instruction Batches'),
         'name' => 'view_new_instruction_batches',
-        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('instructions_batch', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => 1,
@@ -517,7 +522,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('View Payment Collection Batches'),
         'name' => 'view_payment_batches',
-        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('dd_payments', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Collection of upgrade steps.
@@ -152,7 +153,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->addOptionValue([
       'option_group_id' => 'batch_type',
       'name' => 'cancellations_batch',
-      'label' => 'Direct Debit Cancellations',
+      'label' => 'Cancelled Instructions',
       'is_active' => 1,
       'weight' => 6,
       'description' => 'Direct debit mandates that need to be cancelled.',


### PR DESCRIPTION
## Overview
The form that shows available mandates to be cancelled in a batch should mee these criteria:
- Title: Cancelled Instructions
- The screen should filter to only show mandates with status code = 0C.
- Mandates should be excluded if they have been including in any other "Cancelled Instruction" batch unless that batch has been "discarded".

## Before
When showing the form to manage mandates in batch, all mandates were shown. 

## After
Only mandates with dd_code = 0C are shown. Also implemented some class constants to hold the batch type's machine name, to have a single source of truth, and refactored the code to used those class constants throughout batch management logic.
