### PR TITLE
SPAB-1045: Fix new mandate

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -175,8 +175,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
     $setValueTemplate = implode(', ', $setValueTemplateFields);
 
     // write into Data Base
-    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . " 
-    SET $setValueTemplate 
+    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . "
+    SET $setValueTemplate
     WHERE " . self::DIRECT_DEBIT_TABLE_NAME . ".id = $mandateId";
     CRM_Core_DAO::executeQuery($query, $fieldsValues);
 
@@ -305,14 +305,20 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    * @param $oldMandateId
    */
   public function changeMandateForContribution($mandateId, $oldMandateId) {
-    $completedStatusId = CRM_ManualDirectDebit_Common_OptionValue::getValueForOptionValue('contribution_status', 'Completed');
+    $completedStatusId = CRM_ManualDirectDebit_Common_OptionValue::getValueForOptionValue(
+      'contribution_status', 'Completed'
+    );
 
-    $query = "UPDATE `civicrm_value_dd_information` AS dd_information 
-              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id 
-              SET dd_information.mandate_id = $mandateId 
-              WHERE dd_information.mandate_id = $oldMandateId 
-              AND contribution.contribution_status_id != $completedStatusId";
-    CRM_Core_DAO::executeQuery($query);
+    $query = "UPDATE `civicrm_value_dd_information` AS dd_information
+              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id
+              SET dd_information.mandate_id = %1
+              WHERE dd_information.mandate_id = %2
+              AND contribution.contribution_status_id != %3";
+    CRM_Core_DAO::executeQuery($query , [
+      1 => [$mandateId, 'String'],
+      2 => [$oldMandateId, 'String'],
+      3 => [$completedStatusId, 'Integer'],
+    ]);
   }
 
   /**
@@ -360,8 +366,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    */
   public function getMandate($mandateID) {
     $sqlSelectDebitMandateID = '
-      SELECT * 
-      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . ' 
+      SELECT *
+      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . '
       WHERE id = %1
     ';
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
@@ -381,8 +387,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    */
   public function getMandatesForContact($contactID) {
     $sqlSelectDebitMandateID = '
-      SELECT * 
-      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . ' 
+      SELECT *
+      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . '
       WHERE `entity_id` = %1
     ';
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -34,7 +34,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    * @param $mandateId
    */
   public function assignRecurringContributionMandate($contributionRecurId, $mandateId) {
-    $existingMandateId= CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
+    $existingMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
     if ($existingMandateId && $existingMandateId == $mandateId) {
       return;
     }
@@ -117,7 +117,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
 
       $mandateId = $this->getLastInsertedMandateId($currentContactId);
       $this->launchCustomHook($currentContactId, $mandateValues);
-    } catch (Exception $exception) {
+    }
+    catch (Exception $exception) {
       $transaction->rollback();
 
       throw $exception;
@@ -314,7 +315,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
               SET dd_information.mandate_id = %1
               WHERE dd_information.mandate_id = %2
               AND contribution.contribution_status_id != %3";
-    CRM_Core_DAO::executeQuery($query , [
+    CRM_Core_DAO::executeQuery($query, [
       1 => [$mandateId, 'String'],
       2 => [$oldMandateId, 'String'],
       3 => [$completedStatusId, 'Integer'],
@@ -341,13 +342,14 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
         WHERE civicrm_value_dd_information.mandate_id = %1
       ';
       CRM_Core_DAO::executeQuery($query, [
-        1 => [$mandateID, 'Integer']
+        1 => [$mandateID, 'Integer'],
       ]);
 
       $dao = CRM_Core_BAO_CustomGroup::class;
       $groupID = CRM_Core_DAO::getFieldValue($dao, 'direct_debit_mandate', 'id', 'name');
       CRM_Core_BAO_CustomValue::deleteCustomValue($mandateID, $groupID);
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       $transaction->rollback();
       $message = "An error occurred deleting mandate with id ({$mandateID}): " . $e->getMessage();
 

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -74,7 +74,7 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
    */
   public static function getInstance() {
     if (is_null(self::$instance)) {
-      self::$instance = new self;
+      self::$instance = new self();
     }
     return self::$instance;
   }

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -106,7 +106,6 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
    */
   public function setMandateId($mandateId) {
     $this->mandateId = $mandateId;
-
     if (isset($this->contributionId)) {
       $this->createDependency();
     }
@@ -128,7 +127,9 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
       }
     }
     else {
-      if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($this->currentPaymentInstrumentId)) {
+      if (isset($this->currentPaymentInstrumentId) &&
+        CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit(
+          $this->currentPaymentInstrumentId)) {
         $mandateStorage->assignContributionMandate($this->contributionId, $this->mandateId);
       }
     }

--- a/CRM/ManualDirectDebit/Test/Fabricator/Contribution.php
+++ b/CRM/ManualDirectDebit/Test/Fabricator/Contribution.php
@@ -47,7 +47,26 @@ class CRM_ManualDirectDebit_Test_Fabricator_Contribution extends BaseFabricator 
       'financial_type_id' => "Member Dues",
       'total_amount' => 100,
       'receive_date' => $now->format('Y-m-d H:i:s'),
+      'payment_instrument' => self::getDirectDebitPaymentInstrumentID(),
+      'contribution_status_id' => self::getPendingStatusID(),
     ];
+  }
+
+  private static function getDirectDebitPaymentInstrumentID() {
+    return civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "payment_instrument",
+      'name' => "direct_debit",
+    ])['values'][0]['value'];
+
+  }
+
+  private static function getPendingStatusID() {
+    return civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "contribution_status",
+      'name' => "Pending",
+    ])['values'][0]['value'];
   }
 
 }

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -123,12 +123,13 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
 
   /**
    * @depends testSaveDirectDebitMandate
-   * Tests assignContributionMandate function
+   * Tests ChangeMandateForContribution function
    * @return void
    * @throws CiviCRM_API3_Exception
    * @throws Exception
    */
   public function testChangeMandateForContribution() {
+
     $this->mandateValues['entity_id'] = $this->contact['id'];
     $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
     $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -23,6 +23,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    * @var array
    */
   protected $contact;
+  /**
+   * @var mixed
+   */
+  private $originatorNumber;
 
   /**
    * setUp test
@@ -30,7 +34,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    */
   public function setUp() {
     $this->contact = ContactFabricator::fabricate();
-    $originatorNumber = OriginatorNumberFabricator::fabricate()['values'][0]['value'];
+    $this->originatorNumber = OriginatorNumberFabricator::fabricate()['values'][0]['value'];
     $now = new DateTime();
     $this->mandateValues = [
       'entity_id' => $this->contact['id'],
@@ -42,12 +46,11 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
       'dd_ref' => 'DD Ref',
       'start_date' => $now->format('Y-m-d H:i:s'),
       'authorisation_date' => $now->format('Y-m-d H:i:s'),
-      'originator_number' => $originatorNumber,
+      'originator_number' => $this->originatorNumber,
     ];
 
     //Fabricate default settings
     SettingFabricator::fabricate();
-
   }
 
   /**
@@ -98,8 +101,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    * @throws Exception
    */
   public function testAssignContributionMandate() {
+
     $fabricatedContribution = ContributionFabricator::fabricate(['contact_id' => $this->contact['id']]);
     $this->mandateValues['entity_id'] = $this->contact['id'];
+
     $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
     $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
     $storageManager->assignContributionMandate($fabricatedContribution['id'], $mandate->id);
@@ -114,7 +119,55 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
     $mandateIdCustomFieldId =
       CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
     $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $mandate->id);
+  }
 
+  /**
+   * @depends testSaveDirectDebitMandate
+   * Tests assignContributionMandate function
+   * @return void
+   * @throws CiviCRM_API3_Exception
+   * @throws Exception
+   */
+  public function testChangeMandateForContribution() {
+    $this->mandateValues['entity_id'] = $this->contact['id'];
+    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
+
+    $fabricatedContribution = ContributionFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+    ]);
+
+    $storageManager->assignContributionMandate($fabricatedContribution['id'], $mandate->id);
+    $mandateIdCustomFieldId =
+      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $fabricatedContribution['id'],
+    ]);
+
+    $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $mandate->id);
+    $now = new DateTime();
+    $newMandate = [
+      'entity_id' => $this->contact['id'],
+      'bank_name' => 'HSBC',
+      'account_holder_name' => 'John Doe',
+      'ac_number' => '87654321',
+      'sort_code' => '56-32-12',
+      'dd_code' => 1,
+      'dd_ref' => 'DD Ref',
+      'start_date' => $now->format('Y-m-d H:i:s'),
+      'authorisation_date' => $now->format('Y-m-d H:i:s'),
+      'originator_number' => $this->originatorNumber,
+    ];
+
+    $newMandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $newMandate);
+    $storageManager->changeMandateForContribution($newMandate->id, $mandate->id);
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $fabricatedContribution['id'],
+    ]);
+    $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $newMandate->id);
   }
 
 }


### PR DESCRIPTION
## Overview

This PR mainly fixes the issue when updating mandate for contribution. 

The PR also fixes bad code reported by linter. 

## Before

Mandate id that links to contribution is liking via CiviCRM custom field and the mandate is stored in varchar by default so when the mandate id is passed to SQL and the mandate id was not casting to string. 

```

    $query = "UPDATE `civicrm_value_dd_information` AS dd_information);
              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id 	
              SET dd_information.mandate_id = $mandateId 	 
              WHERE dd_information.mandate_id = $oldMandateId 	           
              AND contribution.contribution_status_id != $completedStatusId";
```

The error occurred.  This issue happens with MYSQL database that has STRICT_TRANS_TABLES, mode on 

## After

The code has been updated to use query parameters instead, and we make sure that the type is String instead of integer. 

```
  $query = "UPDATE `civicrm_value_dd_information` AS dd_information
              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id
              SET dd_information.mandate_id = %1
              WHERE dd_information.mandate_id = %2
              AND contribution.contribution_status_id != %3";
    CRM_Core_DAO::executeQuery($query, [
      1 => [$mandateId, 'String'],
      2 => [$oldMandateId, 'String'],
      3 => [$completedStatusId, 'Integer'],
    ]);
```
    



