### PR TITLE
MAE-385: Bump version to 3.0.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,8 +18,8 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-09-07</releaseDate>
-  <version>2.4.0</version>
+  <releaseDate>2020-10-07</releaseDate>
+  <version>3.0.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>


### PR DESCRIPTION
## Overview

This PR is to bump version 3.0.0 for Manual Direct Debit extension for ME v3 release. 