### PR TITLE
SPAB-1045: Fix Delete mandate

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -342,7 +342,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
         WHERE civicrm_value_dd_information.mandate_id = %1
       ';
       CRM_Core_DAO::executeQuery($query, [
-        1 => [$mandateID, 'Integer'],
+        1 => [$mandateID, 'String'],
       ]);
 
       $dao = CRM_Core_BAO_CustomGroup::class;

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -27,6 +27,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    * @var mixed
    */
   private $originatorNumber;
+  /**
+   * @var CRM_ManualDirectDebit_Common_MandateStorageManager
+   */
+  private $storageManager;
 
   /**
    * setUp test
@@ -51,6 +55,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
 
     //Fabricate default settings
     SettingFabricator::fabricate();
+
+    $this->storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
   }
 
   /**
@@ -60,8 +66,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    */
   public function testSaveDirectDebitMandate() {
 
-    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
+    $mandate = $this->storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
     $this->assertNotNull($mandate->id);
     $this->assertEquals($mandate->bank_name, 'Lloyds Bank');
     $this->assertEquals($mandate->account_holder_name, 'John Doe');
@@ -83,9 +88,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
 
     $recurringContribution = RecurringContributionFabricator::fabricate(['contact_id' => $this->contact['id']]);
     $this->mandateValues['entity_id'] = $this->contact['id'];
-    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
-    $storageManager->assignRecurringContributionMandate($recurringContribution['id'], $mandate->id);
+    $mandate = $this->storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
+    $this->storageManager->assignRecurringContributionMandate($recurringContribution['id'], $mandate->id);
 
     $recurrMandateId =
       CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContribution['id']);
@@ -102,12 +106,9 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    */
   public function testAssignContributionMandate() {
 
-    $fabricatedContribution = ContributionFabricator::fabricate(['contact_id' => $this->contact['id']]);
-    $this->mandateValues['entity_id'] = $this->contact['id'];
-
-    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
-    $storageManager->assignContributionMandate($fabricatedContribution['id'], $mandate->id);
+    $fabricatedContributionWithMandate = $this->fabricateContributionWithMandate();
+    $mandate = $fabricatedContributionWithMandate['mandate'];
+    $fabricatedContribution = $fabricatedContributionWithMandate['contribution'];
 
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
@@ -122,7 +123,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
   }
 
   /**
-   * @depends testSaveDirectDebitMandate
+   * @depends testAssignContributionMandate
    * Tests ChangeMandateForContribution function
    * @return void
    * @throws CiviCRM_API3_Exception
@@ -130,15 +131,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
    */
   public function testChangeMandateForContribution() {
 
-    $this->mandateValues['entity_id'] = $this->contact['id'];
-    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
+    $fabricatedContributionWithMandate = $this->fabricateContributionWithMandate();
+    $mandate = $fabricatedContributionWithMandate['mandate'];
+    $fabricatedContribution = $fabricatedContributionWithMandate['contribution'];
 
-    $fabricatedContribution = ContributionFabricator::fabricate([
-      'contact_id' => $this->contact['id'],
-    ]);
-
-    $storageManager->assignContributionMandate($fabricatedContribution['id'], $mandate->id);
     $mandateIdCustomFieldId =
       CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
 
@@ -162,13 +158,64 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
       'originator_number' => $this->originatorNumber,
     ];
 
-    $newMandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $newMandate);
-    $storageManager->changeMandateForContribution($newMandate->id, $mandate->id);
+    $newMandate = $this->storageManager->saveDirectDebitMandate($this->contact['id'], $newMandate);
+    $this->storageManager->changeMandateForContribution($newMandate->id, $mandate->id);
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
       'id' => $fabricatedContribution['id'],
     ]);
     $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $newMandate->id);
+  }
+
+  /**
+   * @depends testAssignContributionMandate
+   * Tests DeleteMandate function
+   * @return void
+   * @throws CiviCRM_API3_Exception
+   * @throws Exception
+   */
+  public function testDeleteMandate() {
+
+    $fabricatedContributionWithMandate = $this->fabricateContributionWithMandate();
+    $mandate = $fabricatedContributionWithMandate['mandate'];
+    $fabricatedContribution = $fabricatedContributionWithMandate['contribution'];
+
+    $mandateIdCustomFieldId =
+      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $fabricatedContribution['id'],
+    ]);
+
+    $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $mandate->id);
+
+    $this->storageManager->deleteMandate($mandate->id);
+
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $fabricatedContribution['id'],
+    ]);
+
+    $this->assertEmpty($contribution['values'][0]['custom_' . $mandateIdCustomFieldId]);
+
+  }
+
+  /**
+   * Generates Contribution with mandate.
+   * @throws Exception
+   */
+  private function fabricateContributionWithMandate() {
+    $fabricatedContribution = ContributionFabricator::fabricate([
+      'contact_id' => $this->contact['id'],
+    ]);
+    $this->mandateValues['entity_id'] = $this->contact['id'];
+    $storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $mandate = $storageManager->saveDirectDebitMandate($this->contact['id'], $this->mandateValues);
+    $storageManager->assignContributionMandate($fabricatedContribution['id'], $mandate->id);
+
+    return ['mandate' => $mandate, 'contribution' => $fabricatedContribution];
+
   }
 
 }


### PR DESCRIPTION
## Overview

This PR is to fix error when delete mandate similar to PR https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/192 

This issue happens with MYSQL database that has STRICT_TRANS_TABLES, mode on 

## Before

The parameter mandate id that was passing to query was Integer.


## After

The parameter mandate id that is now passing to query as String.

## Technical details. 

Mandate id that links to contribution is liking via CiviCRM custom field and the mandate is stored as varchar  so when the mandate id is passed to SQL as  integer, MySQL that has STRICT_TRANS_TABLES mode on will throw the error. 
