### PR TITLE
IO-83: Implement Cancellation Batch Management

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -361,6 +361,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $dataForExport = [];
     switch ($this->getBatchType()) {
       case self::BATCH_TYPE_INSTRUCTIONS:
+      case self::BATCH_TYPE_CANCELLATIONS:
         $entityTable = 'civicrm_value_dd_mandate';
         break;
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -183,8 +183,9 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
    */
   public static function getSubmitAlertMessage($typeId) {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
+    $batchTypeName = CRM_Utils_Array::value($typeId, $batchTypes, '');
 
-    if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
+    if ($batchTypeName == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
         1 => '0N',
@@ -193,7 +194,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
-    elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
+    elseif ($batchTypeName == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
         1 => '01',
@@ -379,6 +380,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
         case self::BATCH_TYPE_INSTRUCTIONS:
+        case self::BATCH_TYPE_CANCELLATIONS:
           $entityId = $mandateItem['mandate_id'];
           unset($mandateItem['mandate_id']);
           $dataForExport[$entityId] = $mandateItem;

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -157,7 +157,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       'context' => '',
     ];
 
-    switch (true) {
+    switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
         $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
         break;

--- a/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
+++ b/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
@@ -40,8 +40,6 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
    * @return array
    */
   private static function getPageBatches($filterParams) {
-    $batches = [];
-
     $apiParams['status_id'] = ['NOT IN' => ['Data Entry']];
 
     if (!empty($filterParams['id'])) {
@@ -50,6 +48,10 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
 
     if (!empty($filterParams['type_id'])) {
       $apiParams['type_id'] = $filterParams['type_id'];
+    }
+
+    if (!empty($filterParams['created_date'])) {
+      $apiParams['created_date'] = $filterParams['created_date'];
     }
 
     if (!empty($filterParams['rowCount']) && is_numeric($filterParams['rowCount'])
@@ -77,10 +79,10 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
 
     $result = civicrm_api3('Batch', 'get', $apiParams);
     if (!empty($result['values'])) {
-      $batches = $result['values'];
+      return $result['values'];
     }
 
-    return $batches;
+    return [];
   }
 
   /**

--- a/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
+++ b/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
@@ -103,7 +103,7 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
     $linksMask = array_sum(array_keys($rowLinks));
 
     if ($batchStatuses[$rowValues['status_id']] == 'Closed') {
-      $rowLinks =[];
+      $rowLinks = [];
     }
     $linksValues = ['id' => $rowValues['id'], 'status' => $rowValues['status_id']];
 

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -159,9 +159,31 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'description' => 'Direct debit mandates that need to be cancelled.',
     ]);
     $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
+    $this->updateMenuLabelsFromViewToManage();
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
+  }
+
+  /**
+   * Updates menu items for View New Instructions/Payment Batches.
+   *
+   * Changes the labels for 'View New Instruction Batches' to 'Manage
+   * Instruction Batches', and 'View Payment Collection Batches' to 'Manage
+   * Payment Collection Batches'.
+   */
+  private function updateMenuLabelsFromViewToManage() {
+    $viewInstructionsItem = new CRM_Core_BAO_Navigation();
+    $viewInstructionsItem->name = 'view_new_instruction_batches';
+    $viewInstructionsItem->find(TRUE);
+    $viewInstructionsItem->label = 'Manage Instruction Batches';
+    $viewInstructionsItem->save();
+
+    $viewPaymentsItem = new CRM_Core_BAO_Navigation();
+    $viewPaymentsItem->name = 'view_payment_batches';
+    $viewPaymentsItem->find(TRUE);
+    $viewPaymentsItem->label = 'Manage Payment Collection Batches';
+    $viewPaymentsItem->save();
   }
 
   /**
@@ -511,7 +533,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'parent_name' => 'direct_debit',
       ],
       [
-        'label' => ts('View New Instruction Batches'),
+        'label' => ts('Manage Instruction Batches'),
         'name' => 'view_new_instruction_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
@@ -520,7 +542,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'parent_name' => 'direct_debit',
       ],
       [
-        'label' => ts('View Payment Collection Batches'),
+        'label' => ts('Manage Payment Collection Batches'),
         'name' => 'view_payment_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -1,4 +1,28 @@
 <div id="enableDisableStatusMsg" class="crm-container" style="display:none;"></div>
+
+<div class="crm-form-block crm-search-form-block">
+  <div class="page-civicrm-group">
+    <form id="searchForm">
+      <div class="crm-section">
+        <div class="content float-left">
+          Batch Type: {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
+        </div>
+        <div class="content float-left">
+          From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
+          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_from}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+        </div>
+        <div class="float-left">&nbsp;</div>
+        <div>
+          <span class="crm-button crm-button-type-refresh crm-button_qf_Basic_refresh crm-i-button">
+            <i class="crm-i fa-check" aria-hidden="true"></i>
+            <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Basic_refresh" value="Search" type="submit" id="_qf_Basic_refresh">
+          </span>
+        </div>
+        <div class="clear"></div>
+      </div>
+    </form>
+  </div>
+</div>
 <div class="batch-list crm-results-block">
   {include file="CRM/common/pager.tpl" location="top"}
     {strip}
@@ -6,6 +30,7 @@
     <thead class="sticky">
     <tr>
       <th class="crm-batch-name">{ts}Batch Name{/ts}</th>
+      <th class="crm-batch-name">{ts}Batch Type{/ts}</th>
       <th class="crm-batch-item_count">{ts}{$type} Count{/ts}</th>
       <th class="crm-batch-status">{ts}Status{/ts}</th>
       <th class="crm-batch-created_date">{ts}Created Date{/ts}</th>
@@ -18,6 +43,9 @@
       <tr class="crm-entity" data-entity="batch" data-id="{$batch.id}">
         <td class="crm-batch-name">
           {$batch.name}
+        </td>
+        <td class="crm-batch-item_count">
+          {$batch.batch_type_name}
         </td>
         <td class="crm-batch-item_count">
           {$batch.transaction_count}

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -9,7 +9,7 @@
         </div>
         <div class="content float-left">
           From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_from}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
         <div class="float-left">&nbsp;</div>
         <div>


### PR DESCRIPTION
## Overview
After creating a cancellation batch, we need to be able to add/remove instructions from the batch and save, export or discard it. Furthermore, we need to be able to view the list of batches, and use a search form to find the batch we need by type and created date.

## Before
- Although it was possible to add instructions to a cancellation batch, exporting it would always result in an empty CSV.
- After saving a batch, system redirected user to list of batches, where all batches not related to payments would be shown. There was no way to filter list of batches to find the one user needs.

![image](https://user-images.githubusercontent.com/21999940/95609058-bfa00300-0a23-11eb-9aa1-94f1e875c0c6.png)

## After
- Exporting was fixed so CSV is now populated with instructions added to cancellations batch.
- View that displays list of batches now has a filter to search byt batch type and by created date, allowing user to select "from" and "to values", to obtain batches created in that range.

![image](https://user-images.githubusercontent.com/21999940/95609176-eeb67480-0a23-11eb-8a89-30b6dbd8dcf7.png)

Run of batch creation and basic management:
![IO-54-showcase](https://user-images.githubusercontent.com/21999940/95610025-47d2d800-0a25-11eb-8b39-85e28202d3d2.gif)
