### PR TITLE
IO-87: Implement Validation of Cancellation Batch Submission

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -12,6 +12,11 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
   const DIRECT_DEBIT_TABLE_NAME = 'civicrm_value_dd_mandate';
 
   /**
+   * Names available for dd_code field.
+   */
+  const DD_CODE_NAME_CANCELDIRECTDEBIT = 'cancel_a_direct_debit';
+
+  /**
    * Assigns depandency between contribution and mandate
    *
    * @param $contributionId
@@ -175,8 +180,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
     $setValueTemplate = implode(', ', $setValueTemplateFields);
 
     // write into Data Base
-    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . " 
-    SET $setValueTemplate 
+    $query = "UPDATE " . self::DIRECT_DEBIT_TABLE_NAME . "
+    SET $setValueTemplate
     WHERE " . self::DIRECT_DEBIT_TABLE_NAME . ".id = $mandateId";
     CRM_Core_DAO::executeQuery($query, $fieldsValues);
 
@@ -307,10 +312,10 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
   public function changeMandateForContribution($mandateId, $oldMandateId) {
     $completedStatusId = CRM_ManualDirectDebit_Common_OptionValue::getValueForOptionValue('contribution_status', 'Completed');
 
-    $query = "UPDATE `civicrm_value_dd_information` AS dd_information 
-              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id 
-              SET dd_information.mandate_id = $mandateId 
-              WHERE dd_information.mandate_id = $oldMandateId 
+    $query = "UPDATE `civicrm_value_dd_information` AS dd_information
+              LEFT JOIN `civicrm_contribution` AS contribution ON dd_information.entity_id = contribution.id
+              SET dd_information.mandate_id = $mandateId
+              WHERE dd_information.mandate_id = $oldMandateId
               AND contribution.contribution_status_id != $completedStatusId";
     CRM_Core_DAO::executeQuery($query);
   }
@@ -360,8 +365,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    */
   public function getMandate($mandateID) {
     $sqlSelectDebitMandateID = '
-      SELECT * 
-      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . ' 
+      SELECT *
+      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . '
       WHERE id = %1
     ';
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [
@@ -381,8 +386,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    */
   public function getMandatesForContact($contactID) {
     $sqlSelectDebitMandateID = '
-      SELECT * 
-      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . ' 
+      SELECT *
+      FROM ' . self::DIRECT_DEBIT_TABLE_NAME . '
       WHERE `entity_id` = %1
     ';
     $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID, [

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -39,7 +39,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    * @param $mandateId
    */
   public function assignRecurringContributionMandate($contributionRecurId, $mandateId) {
-    $existingMandateId= CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
+    $existingMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
     if ($existingMandateId && $existingMandateId == $mandateId) {
       return;
     }
@@ -122,7 +122,8 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
 
       $mandateId = $this->getLastInsertedMandateId($currentContactId);
       $this->launchCustomHook($currentContactId, $mandateValues);
-    } catch (Exception $exception) {
+    }
+    catch (Exception $exception) {
       $transaction->rollback();
 
       throw $exception;
@@ -340,13 +341,14 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
         WHERE civicrm_value_dd_information.mandate_id = %1
       ';
       CRM_Core_DAO::executeQuery($query, [
-        1 => [$mandateID, 'Integer']
+        1 => [$mandateID, 'Integer'],
       ]);
 
       $dao = CRM_Core_BAO_CustomGroup::class;
       $groupID = CRM_Core_DAO::getFieldValue($dao, 'direct_debit_mandate', 'id', 'name');
       CRM_Core_BAO_CustomValue::deleteCustomValue($mandateID, $groupID);
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       $transaction->rollback();
       $message = "An error occurred deleting mandate with id ({$mandateID}): " . $e->getMessage();
 

--- a/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
@@ -13,7 +13,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
   private $contactID;
   private $params;
   private $mandateStorageManager;
-  private $dd_codes;
+  private $ddCodes;
 
   /**
    * CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker constructor.
@@ -26,7 +26,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
     $this->contactID = $contactID;
     $this->params = $params;
     $this->mandateStorageManager = $mandateStorageManager;
-    $this->dd_codes = $this->getDDCodes();
+    $this->ddCodes = $this->getDDCodes();
   }
 
   /**
@@ -92,7 +92,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
    * @return bool
    */
   private function isCancelledMandate($mandate) {
-    if ($this->dd_codes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
+    if ($this->ddCodes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
       return TRUE;
     }
 

--- a/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
@@ -1,0 +1,161 @@
+<?php
+use CRM_ManualDirectDebit_Common_MandateStorageManager as MandateStorageManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker.
+ *
+ * Checks if the mandate's status has changed vs active cancellations, to remove
+ * it from the batch if need be. MAndates that change their status from '0C' to
+ * anything else should be removed from pending (unsubmitted) batches.
+ */
+class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
+
+  private $contactID;
+  private $params;
+  private $mandateStorageManager;
+  private $dd_codes;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker constructor.
+   *
+   * @param $contactID
+   * @param $params
+   * @param \CRM_ManualDirectDebit_Common_MandateStorageManager $mandateStorageManager
+   */
+  public function __construct($contactID, $params, MandateStorageManager $mandateStorageManager) {
+    $this->contactID = $contactID;
+    $this->params = $params;
+    $this->mandateStorageManager = $mandateStorageManager;
+    $this->dd_codes = $this->getDDCodes();
+  }
+
+  /**
+   * Obtains list of dd codes, mapping their name to their value.
+   *
+   * @return array
+   */
+  private function getDDCodes() {
+    return CRM_Core_OptionGroup::values('direct_debit_codes', FALSE, FALSE, FALSE, NULL, 'name');
+  }
+
+  /**
+   * Runs the check for invalid mandates in cancellations.
+   *
+   * Processes the contact to check for mandates in cancellation batches with
+   * stuats different to '0C'.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function process() {
+    $mandates = $this->getMandates();
+
+    foreach ($mandates as $checkedMandate) {
+      $this->checkMandate($checkedMandate);
+    }
+  }
+
+  /**
+   * Returns array of mandates associated to contact.
+   *
+   * @return array
+   */
+  private function getMandates() {
+    return $this->mandateStorageManager->getMandatesForContact($this->contactID);
+  }
+
+  /**
+   * Checks if the mandate needs to be removed from a cancellations batch.
+   *
+   * @param array $mandate
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function checkMandate($mandate) {
+    if ($this->isCancelledMandate($mandate)) {
+      return;
+    }
+
+    $pendingCancellationBatches = $this->getPendingCancellationBatches();
+    foreach ($pendingCancellationBatches as $batch) {
+      $batchItemID = $this->getPendingCancellationBatchItemID($mandate, $batch);
+      if ($batchItemID) {
+        $this->removeBatchItem($batchItemID);
+      }
+    }
+  }
+
+  /**
+   * Checks if the given mandate has been cancelled.
+   *
+   * @param $mandate
+   *
+   * @return bool
+   */
+  private function isCancelledMandate($mandate) {
+    if ($this->dd_codes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Obtains list of open cancellation batches.
+   *
+   * @return array|mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPendingCancellationBatches() {
+    $result = civicrm_api3('Batch', 'get', [
+      'sequential' => 1,
+      'type_id' => 'cancellations_batch',
+      'status_id' => 'Open',
+    ]);
+
+    if (!empty($result['values'])) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+  /**
+   * Obteins batch item ofr the mandate in the given batch.
+   *
+   * @param array $mandate
+   * @param array $batch
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPendingCancellationBatchItemID($mandate, $batch) {
+    $result = civicrm_api3('EntityBatch', 'get', [
+      'sequential' => 1,
+      'batch_id' => $batch['id'],
+      'entity_id' => $mandate['id'],
+      'entity_table' => MandateStorageManager::DIRECT_DEBIT_TABLE_NAME,
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0]['id'];
+    }
+
+    return 0;
+  }
+
+  /**
+   * Deletes the given batch item.
+   *
+   * @param int $batchItemID
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function removeBatchItem($batchItemID) {
+    civicrm_api3('EntityBatch', 'delete', [
+      'sequential' => 1,
+      'id' => $batchItemID,
+      'options' => ['limit' => 0],
+    ]);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -26,7 +26,8 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
       $this->validateBatch();
       $this->addTasksToQueue();
       $this->runQueue();
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       CRM_Core_Session::setStatus($e->getMessage(), 'Error Submitting Batch!', 'error');
       $this->redirectToBatchViewPage();
     }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -278,11 +278,11 @@ function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
     if ($op == 'edit' || $op == 'update') {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->generateMandateData();
-    }
 
-    $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
-    $cancellationChecker->process();
+      $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+      $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
+      $cancellationChecker->process();
+    }
   }
 }
 

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -270,7 +270,6 @@ function _manualdirectdebit_getContactType($contactId) {
 
 /**
  * Implements hook_civicrm_custom().
- *
  */
 function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
   if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
@@ -283,6 +282,10 @@ function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->generateMandateData();
     }
+
+    $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
+    $cancellationChecker->process();
   }
 }
 
@@ -298,6 +301,11 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
  * Implements hook_civicrm_post.
  */
 function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  if ($op == 'create' && $objectName == 'Contribution') {
+    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
+    $postContributionHook->process();
+  }
+
   if ($op == 'create' && $objectName == 'Contribution') {
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -3,7 +3,6 @@
 require_once 'manualdirectdebit.civix.php';
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Implements hook_civicrm_config().
@@ -149,7 +148,6 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/', $directDebitMenuItem);
 
-
   $subMenuItems = [
     [
       'name' => ts('Direct Debit Codes'),
@@ -188,7 +186,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
   $paymentInstrumentId = CRM_Utils_Array::value('payment_instrument_id', $form->getVar('_submitValues'));
   $isDirectDebit = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId);
 
-  switch (true) {
+  switch (TRUE) {
     case $formName == 'CRM_Contribute_Form_UpdateSubscription' && $action == CRM_Core_Action::UPDATE:
       $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_RecurContribution_DirectDebitMandate($form);
       $manualDirectDebit->saveMandateData();
@@ -226,8 +224,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
  * Implements hook_civicrm_pageRun().
  */
 function manualdirectdebit_civicrm_pageRun(&$page) {
-  switch(get_class($page)) {
-
+  switch (get_class($page)) {
     case 'CRM_Contribute_Page_ContributionRecur':
       $injectCustomGroup = new CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInjector($page);
       $injectCustomGroup->inject();
@@ -298,7 +295,7 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
 }
 
 /**
- * Implements hook_civicrm_post.
+ * Implements hook_civicrm_post().
  */
 function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($op == 'create' && $objectName == 'Contribution') {
@@ -313,15 +310,16 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
 }
 
 /**
- * Implements hook_civicrm_buildForm()
+ * Implements hook_civicrm_buildForm().
  */
 function manualdirectdebit_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Activity_Form_ActivityLinks') {
     $openContributionId = CRM_Utils_Request::retrieveValue('openContribution', 'Integer', FALSE);
-    if ($openContributionId){
+    if ($openContributionId) {
       $form->add('hidden', 'optionContributionId', $openContributionId);
     }
   }
+
   if ($formName == 'CRM_Contact_Form_CustomData') {
     if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'))) {
       $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);
@@ -351,7 +349,7 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
 }
 
 /**
- * Implements hook_civicrm_validateForm()
+ * Implements hook_civicrm_validateForm().
  */
 function manualdirectdebit_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
 
@@ -385,7 +383,7 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
 }
 
 /**
- * Implements hook_membershipextras_postOfflineAutoRenewal()
+ * Implements hook_membershipextras_postOfflineAutoRenewal().
  */
 function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId, $previousRecurContributionId) {
   $activity = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Activity($recurContributionId);
@@ -395,25 +393,25 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
   $mandate->process();
 }
 
-function manualdirectdebit_civicrm_searchTasks( $objectName, &$tasks ){
-  if($objectName == 'contribution') {
+function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {
+  if ($objectName == 'contribution') {
     $tasks[] = [
       'title' => 'Send Direct Debit Notifications',
       'class' => 'CRM_ManualDirectDebit_Form_Email_Contribution',
-      'result' => FALSE
+      'result' => FALSE,
     ];
   }
 
-  if($objectName == 'membership') {
+  if ($objectName == 'membership') {
     $tasks[] = [
       'title' => 'Send Direct Debit Notifications',
       'class' => 'CRM_ManualDirectDebit_Form_Email_Membership',
-      'result' => FALSE
+      'result' => FALSE,
     ];
     $tasks[] = [
       'title' => 'Print Direct Debit Letters',
       'class' => 'CRM_ManualDirectDebit_Form_PrintMergeDocument',
-      'result' => FALSE
+      'result' => FALSE,
     ];
   }
 


### PR DESCRIPTION
## Overview
We need to add the following validations to manage Direct Debit batches with 0C status:
- Remove Mandates for Cancelled mandates batches if their status changes from 0C: If the status of a mandate is changed from 0C to another status, and that mandate was previously in a draft batch (a batch which has been saved but is not submitted) then it should be removed immediately from that batch. Mandates which are in a submitted batch and subsequently have their status changed should not be removed from the batch.
- If I have a draft batch (saved but not submitted) then when I submit the batch the system should validate that all of the mandates have a status of 0C. If any do not then show an error message: 
  > The batch contains the following mandates that no longer has the status of 0C:
  > - List Mandate References
  > Please remove them in order to submit the batch.

## Before
Subission of a cancellations batch was causing a fatal error. No validations were done on the mandates. If existing validation failed, a white screen was shown.

## After
Fixed fatal error on batch submission and created a queue with a single task that updates the batch's status to "Submitted".

Added hook to intercept update of custom group table, such that on mandate update, a check is run to see if mandates of the contact are not cancelled, but belong to a cancellations batch. If mandates are found, they are removed from the cancellations batch.

Added validation on batch submission so if any mandates don't have the 0C dd_code, an exception is thrown.

If any validations fail, user is now redirected to batch view screen, where ststus message will explain failure, instead of just showing a blank screen.
