### PR TITLE
CGP-1480: Open Contact and Contribution From Payment Batch View

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -610,8 +610,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'view' => [
           'name' => ts('View'),
           'title' => ts('View Contribution'),
-          'url' => "civicrm/contact/view/contribution",
-          'qs' => "reset=1&id=%%contribution_id%%&cid=%%contact_id%%&action=view&context=contribution&selectedChild=contribute",
+          'url' => "civicrm/contact/view",
+          'qs' => "reset=1&openContribution=%%contribution_id%%&cid=%%contact_id%%&action=view&context=contribution&selectedChild=contribute",
         ],
       ],
       NULL,
@@ -621,7 +621,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       ]
     );
 
-    return $linkToRecurringContribution;
+    return strtr($linkToRecurringContribution, ['action-item' => '']);
   }
 
   /**

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -23,14 +23,14 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   /**
    * Search element
    *
-   * @var boolean
+   * @var bool
    */
   protected $notPresent;
 
   /**
    * Limit element
    *
-   * @var boolean
+   * @var bool
    */
   protected $total;
 
@@ -44,6 +44,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   /**
    * What column does select in SQL query
    *
+   * @var array
    * @code
    *
    *  $returnValues = [
@@ -51,14 +52,13 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    *  ]
    *
    * @endcode
-   *
-   * @var array
    */
   protected $returnValues = [];
 
   /**
    * What column does select in SQL query
    *
+   * @var array
    * @code
    *
    *  $columnHeader = [
@@ -66,8 +66,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    *  ]
    *
    * @endcode
-   *
-   * @var array
    */
   protected $columnHeader = [];
 
@@ -247,7 +245,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => ts('Transaction Type'),
       ];
 
-      if($batch->getBatchType() == 'dd_payments') {
+      if ($batch->getBatchType() == 'dd_payments') {
         $columnHeader['receive_date'] = ts('Received Date');
       }
     }
@@ -279,7 +277,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
       ];
 
-      if($batch->getBatchType() == 'dd_payments') {
+      if ($batch->getBatchType() == 'dd_payments') {
         $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
       }
     }
@@ -298,7 +296,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
     return $this->getBatchRows($batch);
   }
-
 
   /**
    * Gets prepared data about previously serialized mandates
@@ -460,7 +457,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
     $this->addContributionCancelDateCondition($query);
 
-
     if ($this->notPresent) {
       $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
       $excluded = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
@@ -501,7 +497,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $mandateItems = CRM_Core_DAO::executeQuery($query->toSQL());
 
     $rows = [];
-    while($mandateItems->fetch()) {
+    while ($mandateItems->fetch()) {
       $mandateItem = [];
       foreach ($this->returnValues as $key => $value) {
         if (isset($mandateItems->$key)) {
@@ -516,7 +512,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
       $rows[] = $mandateItem;
     }
-
 
     return $rows;
   }
@@ -551,7 +546,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
     return $this->returnValues;
   }
-
 
   /**
    * Adds new columns for rows
@@ -641,7 +635,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
                      ['receive_date_start' => date('Ymd', strtotime($this->params['receive_date_low']))]
                    );
     }
-    if(!empty($this->params['receive_date_high'])) {
+    if (!empty($this->params['receive_date_high'])) {
       $query->where('DATE_FORMAT(civicrm_contribution.receive_date, "%Y%m%d") <= @receive_date_end',
                      ['receive_date_end' => date('Ymd', strtotime($this->params['receive_date_high']))]
                    );
@@ -665,7 +659,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
                      ['cancel_date_start' => date('Ymd', strtotime($this->params['contribution_cancel_date_low']))]
                    );
     }
-    if(!empty(!empty($this->params['contribution_cancel_date_high']))) {
+    if (!empty(!empty($this->params['contribution_cancel_date_high']))) {
       $query->where('civicrm_contribution.cancel_date <= @cancel_date_end',
                      ['cancel_date_end' => date('Ymd', strtotime($this->params['contribution_cancel_date_high']))]
                    );


### PR DESCRIPTION
## Overview
When you create a payment batch and click the View button on one of the listed contributions, it should navigate to the contact's contribution page and open the exact contribution in a popup. However it just opens a popup on the batch page and shows the contribution.

## Before
Clicking the view action on a line of the manage payment batch screen opened a popup with the infromation for the contribution related to the payment in the batch.

![CGP-1480-before](https://user-images.githubusercontent.com/21999940/96290056-a101b500-0fab-11eb-8c9c-f7a0c4440d6a.gif)

## After
View action now takes the user to the contact's detail view, preloads the Contribution tab, and opens the specific contribution in a popup.

![CGP-1480-after](https://user-images.githubusercontent.com/21999940/96290156-c8f11880-0fab-11eb-8382-997b9bd17bf1.gif)

## Technical Details
I found a JS script added some time ago that already altered the Contact's detail view, so that if a parameter is passed in the url, the JS is added and the contribution ID used to open it in a popup.

See:
https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/CGP-1480-open-contact-contribution-from-batch-detail-view/manualdirectdebit.php#L312-L314

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/CGP-1480-open-contact-contribution-from-batch-detail-view/js/openContribution.js