### PR TITLE
MAE-252: Show Only One Mandate When Clicking View on Batch Management Screen

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -319,7 +319,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       if (!empty($mandateValue['contact_id'])) {
         switch ($batch->getBatchType()) {
           case "instructions_batch":
-            $row['action'] = $this->getLinkToMandate($mandateValue['contact_id']);
+            $row['action'] = $this->getLinkToMandate($mandateId, $mandateValue['contact_id']);
             break;
 
           case "dd_payments":
@@ -369,7 +369,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       switch ($batch->getBatchType()) {
         case "instructions_batch":
           if (!empty($mandateItem['contact_id'])) {
-            $row['action'] = $this->getLinkToMandate($mandateItem['contact_id']);
+            $row['action'] = $this->getLinkToMandate($mandateItem['id'], $mandateItem['contact_id']);
           }
 
           $rows[$mandateItem['mandate_id']] = $row;
@@ -564,11 +564,12 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   /**
    * Gets link to mandate
    *
+   * @param $mandateID
    * @param $contactId
    *
-   * @return string
+   * @return string|null
    */
-  private function getLinkToMandate($contactId) {
+  private function getLinkToMandate($mandateID, $contactId) {
     $mandateCustomGroupId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName('direct_debit_mandate');
     $linkToMandate = CRM_Core_Action::formLink(
       [
@@ -576,13 +577,14 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           'name' => ts('View'),
           'title' => ts('View Mandate'),
           'url' => "civicrm/contact/view/cd",
-          'qs' => "reset=1&cid=%%contact_id%%&selectedChild=custom_%%mandate_custom_group_id%%&gid=%%mandate_custom_group_id%%",
+          'qs' => 'reset=1&type=Individual&gid=%%mandate_custom_group_id%%&cid=%%contact_id%%&multiRecordDisplay=single&mode=view&recId=%%mandate_id%%',
         ],
       ],
       NULL,
       [
         'contact_id' => $contactId,
         'mandate_custom_group_id' => $mandateCustomGroupId,
+        'mandate_id' => $mandateID,
       ]
     );
 

--- a/CRM/ManualDirectDebit/Hook/PageRun/ViewCustomData.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ViewCustomData.php
@@ -1,0 +1,115 @@
+<?php
+use CRM_ManualDirectDebit_ExtensionUtil as E;
+
+class CRM_ManualDirectDebit_Hook_PageRun_ViewCustomData {
+
+  private $path;
+
+  private $multiRecordDisplay;
+
+  private $mode;
+
+  /**
+   * Mandate storage manager object.
+   *
+   * @var \CRM_ManualDirectDebit_Common_MandateStorageManager
+   */
+  private $mandateStorageManager;
+
+  /**
+   * Page that needs to be processed.
+   *
+   * @var \CRM_Contact_Page_View_CustomData
+   */
+  private $page;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_PageRun_ViewCustomData constructor.
+   *
+   * @param string $path
+   * @param string $multiRecordDisplay
+   * @param string $mode
+   * @param \CRM_ManualDirectDebit_Common_MandateStorageManager $mandateStorageManager
+   * @param \CRM_Contact_Page_View_CustomData $page
+   */
+  public function __construct($path, $multiRecordDisplay, $mode, CRM_ManualDirectDebit_Common_MandateStorageManager $mandateStorageManager, CRM_Contact_Page_View_CustomData $page) {
+    $this->path = $path;
+    $this->multiRecordDisplay = $multiRecordDisplay;
+    $this->mode = $mode;
+    $this->mandateStorageManager = $mandateStorageManager;
+    $this->page = $page;
+  }
+
+  /**
+   * Processes the page.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function process() {
+    $this->addContactTypeAsVar();
+    $this->addEditAndDeleteButtons();
+  }
+
+  /**
+   * Adds the contact's type as a var to the page.
+   */
+  private function addContactTypeAsVar() {
+    $contactId = $this->page->getVar('_contactId');
+    CRM_Core_Resources::singleton()->addVars('uk.co.compucorp.manualdirectdebit', [
+      'contactType' => _manualdirectdebit_getContactType($contactId),
+    ]);
+  }
+
+  /**
+   * Adds edit and delete mandate buttons to the page.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function addEditAndDeleteButtons() {
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
+
+    if ($this->path === 'civicrm/contact/view/cd' && $this->multiRecordDisplay === 'single' && $this->mode = 'view') {
+      $mandateID = CRM_Utils_Request::retrieveValue('recId', 'Integer', 0);
+      $this->page->assign('mandate_id', $mandateID);
+
+      $contactId = $this->page->getVar('_contactId');
+      $cgCount = $this->calculateCGCountForMandate($contactId, $mandateID);
+      $this->page->assign('cgcount', $cgCount);
+
+      CRM_Core_Region::instance('page-body')->add([
+        'template' => E::path() . "/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl",
+      ]);
+    }
+  }
+
+  /**
+   * Calculates what count is the given mandate within the contact's records.
+   *
+   * Ugh... civicrm's view to edit the mandate actually requires the mandate's
+   * count, instead of the mandate ID, to build the form. For example, if a user
+   * has mandates with ID's 20, 25 and 27, and you need to edit mandate 25, you
+   * need to send the value "2" to the form, as mandate 25 is that contact's
+   * second mandate...
+   *
+   * @param int $contactID
+   * @param int $mandateID
+   *
+   * @return int
+   */
+  private function calculateCGCountForMandate($contactID, $mandateID) {
+    $mandates = $this->mandateStorageManager->getMandatesForContact($contactID);
+    $count = 1;
+
+    foreach ($mandates as $checkedMandate) {
+      if ($checkedMandate['id'] == $mandateID) {
+        return $count;
+      }
+
+      $count++;
+    }
+
+    return 0;
+  }
+
+}

--- a/js/mandateEdit.js
+++ b/js/mandateEdit.js
@@ -1,9 +1,8 @@
 CRM.$('document').ready(function () {
   var customGroupTitle = CRM.$('.section-shown.form-item .crm-accordion-header').first().text().trim();
+
   if (customGroupTitle == "Direct Debit Mandate") {
-
     CRM.$('.form-item a.button').parent().hide();
-
     CRM.$('.crm-hover-button.crm-custom-value-del').each(function () {
       var that = this;
       var mandateTitle = CRM.$(this).attr('title').split(' ');
@@ -73,4 +72,37 @@ CRM.$('document').ready(function () {
     return url;
   }
 
+  CRM.$('#mandate_delete_btn').each(function () {
+    var that = this;
+
+    CRM.$(this).click(function () {
+      CRM.confirm({
+        title: ts('Delete Mandate?'),
+        message: ts('Are you sure you want to delete this mandate? This action cannot be undone.'),
+        options: {
+          no: ts('Cancel'),
+          yes: ts('Apply')
+        }
+      }).on('crmConfirm:yes', function() {
+        var mandateData = JSON.parse(CRM.$(that).attr('data-post'));
+
+        CRM.api3('ManualDirectDebit', 'deletemandate', {
+          mandate_id: mandateData.valueID,
+        }).done(function(result) {
+          if (result.is_error) {
+            CRM.alert(result.error_message, null, 'error');
+          } else {
+            var mandateDiealog = CRM.$('div.ui-dialog-content.ui-widget-content.modal-dialog.crm-ajax-container');
+            mandateDiealog.dialog('destroy');
+            CRM.alert(ts('Mandate has been deleted.'), null, 'success');
+            CRM.refreshParent('#crm-main-content-wrapper');
+          }
+        });
+      }).on('crmConfirm:no', function() {
+        return;
+      });
+
+      return false;
+    });
+  });
 });

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -231,12 +231,13 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
       break;
 
     case 'CRM_Contact_Page_View_CustomData':
-      $contactId = $page->getVar('_contactId');
-      CRM_Core_Resources::singleton()->addVars('uk.co.compucorp.manualdirectdebit', [
-        'contactType' => _manualdirectdebit_getContactType($contactId),
-      ]);
-      CRM_Core_Resources::singleton()
-        ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
+      $path = CRM_Utils_System::currentPath();
+      $multiRecordDisplay = CRM_Utils_Request::retrieveValue('multiRecordDisplay', 'String', '');
+      $mode = CRM_Utils_Request::retrieveValue('mode', 'String', '');
+      $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+
+      $pageProcessor = new CRM_ManualDirectDebit_Hook_PageRun_ViewCustomData($path, $multiRecordDisplay, $mode, $mandateStorageManager, $page);
+      $pageProcessor->process();
       break;
 
     case 'CRM_Contribute_Page_Tab':

--- a/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
@@ -1,9 +1,9 @@
 <div class="crm-submit-buttons">
   <a href="/civicrm/contact/view/cd/edit?reset=1&amp;type=Individual&amp;groupID=10&amp;entityID={$contactId}&amp;cgcount={$cgcount}&amp;multiRecordDisplay=single&amp;mode=edit&amp;mandateId={$mandate_id}" class="button edit" id="edit_direct_debit_mandate_1" title="Edit Direct Debit Mandate">
-    <span><i class="crm-i fa-pencil"></i> Edit </span>
+    <span><i class="crm-i fa-pencil"></i> {ts}Edit{/ts} </span>
   </a>
   <a href="#" id="mandate_delete_btn" class="button delete" data-post="{ldelim}&quot;valueID&quot;: &quot;{$mandate_id}&quot;, &quot;groupID&quot;: &quot;10&quot;, &quot;contactId&quot;: &quot;{$contactId}&quot;, &quot;key&quot;: &quot;ad6ba0055f16b015e7228c2eba077526&quot;{rdelim}" title="Delete Direct Debit Mandate 1">
     <i class="crm-i fa-trash" aria-hidden="true"></i>
-    Delete
+    {ts}Delete{/ts}
   </a>
 </div>

--- a/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
@@ -1,0 +1,9 @@
+<div class="crm-submit-buttons">
+  <a href="/civicrm/contact/view/cd/edit?reset=1&amp;type=Individual&amp;groupID=10&amp;entityID={$contactId}&amp;cgcount={$cgcount}&amp;multiRecordDisplay=single&amp;mode=edit&amp;mandateId={$mandate_id}" class="button edit" id="edit_direct_debit_mandate_1" title="Edit Direct Debit Mandate">
+    <span><i class="crm-i fa-pencil"></i> Edit </span>
+  </a>
+  <a href="#" id="mandate_delete_btn" class="button delete" data-post="{ldelim}&quot;valueID&quot;: &quot;{$mandate_id}&quot;, &quot;groupID&quot;: &quot;10&quot;, &quot;contactId&quot;: &quot;{$contactId}&quot;, &quot;key&quot;: &quot;ad6ba0055f16b015e7228c2eba077526&quot;{rdelim}" title="Delete Direct Debit Mandate 1">
+    <i class="crm-i fa-trash" aria-hidden="true"></i>
+    Delete
+  </a>
+</div>


### PR DESCRIPTION
## Overview
If a contact had several mandates, clicking the "View" action from the batch management screen opened a popup that showed all mandates for the contact, instead of just the one that was clicked on. 

## Before
The URL used for the action corresponded to the one used by CiviCRM to show the list of custom field group records associated to a contact.

https://drive.google.com/file/d/1asTI8AVDCLVke2etzAPZp8Krq2CI7YQx/view

## After
The URL of the action was replaced with the one useed in CiviCRM to display a specific record of a custom group.

![image](https://user-images.githubusercontent.com/21999940/98839960-3b6ee000-2414-11eb-93a3-4edf328c6887.png)

