### PR TITLE
MAE-225: Fix Contribution Search by Batch for Payment Batches

### DIFF
--- a/CRM/ManualDirectDebit/Hook/QueryObjects/Contribution.php
+++ b/CRM/ManualDirectDebit/Hook/QueryObjects/Contribution.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution.
+ */
+class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution extends CRM_Contact_BAO_Query_Interface {
+
+  /**
+   * Obtains list of fields for the query.
+   */
+  public function &getFields() {
+    $fields = [];
+
+    return $fields;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function from($fieldName, $mode, $side) {
+    if (!$this->isContributionSearchForm()) {
+      return '';
+    }
+
+    $from = '';
+    if ($fieldName == 'contribution_batch') {
+      $from = "
+        $side JOIN (
+          SELECT civicrm_entity_batch.entity_id, civicrm_entity_batch.batch_id
+          FROM civicrm_entity_batch, civicrm_batch
+          WHERE civicrm_entity_batch.entity_table = 'civicrm_contribution'
+          AND civicrm_entity_batch.batch_id = civicrm_batch.id
+        ) payment_batches ON payment_batches.entity_id = civicrm_contribution.id
+      ";
+    }
+
+    return $from;
+  }
+
+  /**
+   * Alters where statement.
+   */
+  public function where(&$query) {
+    if (!$this->isContributionSearchForm()) {
+      return;
+    }
+
+    $batchLookupParams = CRM_Utils_Array::value('contribution_batch_id', $query->_paramLookup, []);
+    if (!isset($batchLookupParams[0][1]) || !isset($batchLookupParams[0][2]) || intval($batchLookupParams[0][2]) === 0) {
+      return;
+    }
+
+    foreach ($query->_where as $grouping => $clauses) {
+      foreach ($clauses as $clauseKey => $analyzedClause) {
+        if (stripos($analyzedClause, 'civicrm_entity_batch.batch_id') === FALSE) {
+          continue;
+        }
+
+        $paymentBatchClause = CRM_Contact_BAO_Query::buildClause('payment_batches.batch_id', $batchLookupParams[0][1], $batchLookupParams[0][2]);
+        $query->_where[$grouping][$clauseKey] = "
+          (
+            {$query->_where[$grouping][$clauseKey]}
+            OR {$paymentBatchClause}
+          )
+        ";
+      }
+    }
+  }
+
+  /**
+   * Checks if the current path is the one for contribution searches.
+   *
+   * @return bool
+   */
+  private function isContributionSearchForm() {
+    if (CRM_Utils_System::currentPath() == 'civicrm/contribute/search') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Implements getPanesMapper, required by getPanesMapper hook.
+   *
+   * @param array $panes
+   *   Panes.
+   */
+  public function getPanesMapper(array &$panes) {
+    return;
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -3,7 +3,6 @@
 require_once 'manualdirectdebit.civix.php';
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Implements hook_civicrm_config().
@@ -149,7 +148,6 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/', $directDebitMenuItem);
 
-
   $subMenuItems = [
     [
       'name' => ts('Direct Debit Codes'),
@@ -188,7 +186,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
   $paymentInstrumentId = CRM_Utils_Array::value('payment_instrument_id', $form->getVar('_submitValues'));
   $isDirectDebit = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($paymentInstrumentId);
 
-  switch (true) {
+  switch (TRUE) {
     case $formName == 'CRM_Contribute_Form_UpdateSubscription' && $action == CRM_Core_Action::UPDATE:
       $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_RecurContribution_DirectDebitMandate($form);
       $manualDirectDebit->saveMandateData();
@@ -226,8 +224,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
  * Implements hook_civicrm_pageRun().
  */
 function manualdirectdebit_civicrm_pageRun(&$page) {
-  switch(get_class($page)) {
-
+  switch (get_class($page)) {
     case 'CRM_Contribute_Page_ContributionRecur':
       $injectCustomGroup = new CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInjector($page);
       $injectCustomGroup->inject();
@@ -295,7 +292,7 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
 }
 
 /**
- * Implements hook_civicrm_post.
+ * Implements hook_civicrm_post().
  */
 function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($op == 'create' && $objectName == 'Contribution') {
@@ -305,12 +302,12 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
 }
 
 /**
- * Implements hook_civicrm_buildForm()
+ * Implements hook_civicrm_buildForm().
  */
 function manualdirectdebit_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Activity_Form_ActivityLinks') {
     $openContributionId = CRM_Utils_Request::retrieveValue('openContribution', 'Integer', FALSE);
-    if ($openContributionId){
+    if ($openContributionId) {
       $form->add('hidden', 'optionContributionId', $openContributionId);
     }
   }
@@ -343,10 +340,9 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
 }
 
 /**
- * Implements hook_civicrm_validateForm()
+ * Implements hook_civicrm_validateForm().
  */
 function manualdirectdebit_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-
   if ($formName == 'CRM_Member_Form_Membership' || $formName === 'CRM_Member_Form_MembershipRenewal') {
     $directDebitValidator = new CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator($form, $fields, $errors);
     $directDebitValidator->checkValidation();
@@ -377,7 +373,7 @@ function manualdirectdebit_civicrm_links($op, $objectName, $objectId, &$links, &
 }
 
 /**
- * Implements hook_membershipextras_postOfflineAutoRenewal()
+ * Implements hook_membershipextras_postOfflineAutoRenewal().
  */
 function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId, $previousRecurContributionId) {
   $activity = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Activity($recurContributionId);
@@ -387,25 +383,25 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
   $mandate->process();
 }
 
-function manualdirectdebit_civicrm_searchTasks( $objectName, &$tasks ){
-  if($objectName == 'contribution') {
+function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {
+  if ($objectName == 'contribution') {
     $tasks[] = [
       'title' => 'Send Direct Debit Notifications',
       'class' => 'CRM_ManualDirectDebit_Form_Email_Contribution',
-      'result' => FALSE
+      'result' => FALSE,
     ];
   }
 
-  if($objectName == 'membership') {
+  if ($objectName == 'membership') {
     $tasks[] = [
       'title' => 'Send Direct Debit Notifications',
       'class' => 'CRM_ManualDirectDebit_Form_Email_Membership',
-      'result' => FALSE
+      'result' => FALSE,
     ];
     $tasks[] = [
       'title' => 'Print Direct Debit Letters',
       'class' => 'CRM_ManualDirectDebit_Form_PrintMergeDocument',
-      'result' => FALSE
+      'result' => FALSE,
     ];
   }
 
@@ -421,4 +417,13 @@ function manualdirectdebit_civicrm_container($container) {
 function _manualdirectdebit_civicrm_tokenRenderEventListener($event) {
   $tokenRenderListener = new CRM_ManualDirectDebit_Event_Listener_TokenRender($event);
   $tokenRenderListener->replaceDirectDebitTokens();
+}
+
+/**
+ * Implements hook_civicrm_queryObjects().
+ */
+function manualdirectdebit_civicrm_queryObjects(&$queryObjects, $type) {
+  if ($type === 'Contact') {
+    $queryObjects[] = new CRM_ManualDirectDebit_Hook_QueryObjects_Contribution();
+  }
 }


### PR DESCRIPTION
## Overview
'Find Contributions' by 'Batch Name' filter is not returning any records  though we have open DD batch records.

## Before
Filtering of contributions by batch records expected the financial transaction associated with the contribution  (civicrm_financial_trxn), to be the entity referenced in the batch. Thus the JOIN clause looked something like:
```sql
LEFT JOIN civicrm_entity_batch ON ( 
  civicrm_entity_batch.entity_table = 'civicrm_financial_trxn'
  AND civicrm_financial_trxn.id = civicrm_entity_batch.entity_id 
) 
LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id
```

This was then followed by a WHERE clause like:
```sql
...
AND (
  civicrm_entity_batch.batch_id = '13'
  AND civicrm_contribution.id != 0
)
```

## After
Implemented hook_civicrm_queryObjects hook to add a class that alters the join and where clauses so that the contribution is taken into account when cross-referencing with the batch.

A new statement was added to the old left joins, that cross-references batches with contributions:
```sql
LEFT JOIN civicrm_entity_batch ON ( 
  civicrm_entity_batch.entity_table = 'civicrm_financial_trxn'
  AND civicrm_financial_trxn.id = civicrm_entity_batch.entity_id 
) 
LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id

        LEFT JOIN (
          SELECT civicrm_entity_batch.entity_id, civicrm_entity_batch.batch_id
          FROM civicrm_entity_batch, civicrm_batch
          WHERE civicrm_entity_batch.entity_table = 'civicrm_contribution'
          AND civicrm_entity_batch.batch_id = civicrm_batch.id
        ) payment_batches ON payment_batches.entity_id = civicrm_contribution.id

```

Where clause was altered to include both contributions directly referenced in batches (as in DD payment batches) and other batches that use finanial transactions:

```sql
AND (
  (civicrm_entity_batch.batch_id = '13' OR payment_batches.batch_id = '13') 
  AND civicrm_contribution.id != 0
)
```
