### PR TITLE
IO-110: Fix List of Available Mandates When Tied to Other Batch Types

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -466,7 +466,9 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       }
       $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
+      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON civicrm_batch.id = ' . $this->batchID);
       $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
+      $excluded->where('civicrm_batch.type_id = current_batch.type_id');
 
       $query->where($this->params['entityTable'] . '.id NOT IN (' . $excluded->toSQL() . ')');
     }

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -138,7 +138,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
    * @return array[]
    */
   private function assignCancellationsSearchProperties() {
-    CRM_Utils_System::setTitle(ts('Cancelled Instructions Batch - %1', [1 => $this->batch->id]));
+    CRM_Utils_System::setTitle(ts('Cancelled Instructions'));
 
     $this->addElement('hidden', 'entityTable', 'civicrm_value_dd_mandate');
     $this->assign('tableTitle', ts('Available instructions'));

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -55,6 +55,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
     $this->entityID = CRM_Utils_Request::retrieve('bid', 'Positive');
 
     $this->edit($action, $this->entityID);
+
     return parent::run();
   }
 


### PR DESCRIPTION
## Overview
Batch number is included in the title - "Cancelled Instructions Batch - 15". As per Specification/ticket, it should be "Cancelled Instructions".

Mandate once processed in  Instruction batch, is not displayed again in Cancelled instruction batch though the status is updated to 'OC'.

## Before
Query to obtain list of available mandates was checking if the mandate was in any other batch that was not discarded. This meant if a batch was in a submitted new instructions batch, it would never appear on a cancellations batch.

## After
Added a condition to the query to obtain mandates so that the check is only done on batches of the same type.
