### PR TITLE
IO-84: Fixes and Improvements

### DIFF
--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -150,7 +150,14 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    */
   private function buildSearchParams($typeIdInRequest) {
     $createdDateFrom = CRM_Utils_Request::retrieve('created_date_from', 'String', $this, FALSE, NULL);
+    if (!empty($createdDateFrom)) {
+      $createdDateFrom .= ' 00:00:00';
+    }
+
     $createdDateTo = CRM_Utils_Request::retrieve('created_date_to', 'String', $this, FALSE, NULL);
+    if (!empty($createdDateTo)) {
+      $createdDateTo .= ' 23:59:59';
+    }
 
     $param = [
       'type_id' => $typeIdInRequest,
@@ -159,15 +166,15 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
 
     switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
-        $param['created_date'] = ['BETWEEN' => [$createdDateFrom . ' 00:00:00', $createdDateTo . ' 23:59:59']];
+        $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
         break;
 
       case !empty($createdDateFrom):
-        $param['created_date'] = ['>=' => $createdDateFrom . ' 00:00:00'];
+        $param['created_date'] = ['>=' => $createdDateFrom];
         break;
 
       case !empty($createdDateTo):
-        $param['created_date'] = ['<=' => $createdDateTo . ' 23:59:59'];
+        $param['created_date'] = ['<=' => $createdDateTo];
         break;
     }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -236,7 +236,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @return array
    */
   private function getBatchTypeOptions() {
-    $batchTypeNames = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'label');
+    $condition = " AND (
+      v.name = '" . BatchHandler::BATCH_TYPE_INSTRUCTIONS . "'
+      OR v.name = '" . BatchHandler::BATCH_TYPE_PAYMENTS . "'
+      OR v.name = '" . BatchHandler::BATCH_TYPE_CANCELLATIONS . "'
+    )";
+    $batchTypeNames = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, $condition, 'label');
 
     return ['' => 'All'] + $batchTypeNames;
   }

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -159,15 +159,15 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
 
     switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
-        $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
+        $param['created_date'] = ['BETWEEN' => [$createdDateFrom . ' 00:00:00', $createdDateTo . ' 23:59:59']];
         break;
 
       case !empty($createdDateFrom):
-        $param['created_date'] = ['>=' => $createdDateFrom];
+        $param['created_date'] = ['>=' => $createdDateFrom . ' 00:00:00'];
         break;
 
       case !empty($createdDateTo):
-        $param['created_date'] = ['<=' => $createdDateTo];
+        $param['created_date'] = ['<=' => $createdDateTo . ' 23:59:59'];
         break;
     }
 

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -31,7 +31,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
       $param = ['id' => $batchID, 'context' => ''];
       $batch = CRM_ManualDirectDebit_Page_BatchTableListHandler::generateRows($param);
       $batch = $batch[$batchID];
-      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_INSTRUCTIONS ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
+      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_PAYMENTS ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
 
       $batchInfo = [


### PR DESCRIPTION
## Overview
Issues were found when testing screen to manage batches:

1. Filter - Batch type - select list: Can we just show only Instruction batch & Cancelled Instruction batch types 
in this screen?  I think we should not show all the batch types in this screen.   https://nimb.ws/yzRY8V
2. -  Date range : 'To' Date filter is not working when used. IO-111:  Manage Instruction Batches- Date range : 'To' Date filter is not working when used.DEVELOPMENT IN PROGRESS is created separately to track
3. -  Instruction Count is always 0 in the DD Instruction View Batch screen  IO-112:  Instruction Count is always 0 in the DD Instruction View Batch screen READY FOR DEVELOPMENT is created to track

## Before
1. All batch types were baing showed on search field.
2. Value of to field was being used to filter any mandates with less or equal date, but since created date is a datetime field, any records with the same date, but time more than '00:00:00' would not be picked.
2. Batch entity used to filter instructions was contributions.

## After
1. Filtered out batch types that are not DD related.
2. Fixed 'To' date so it filters taking into account created date is a datetime field. Thus, it'll includ any dates with the same date, before 23:59:59.
3. Fixed count, which was using contributions instead of mandates on the query.
