### PR TITLE
IO-84: Change Sumbission Message per Batch Type

### DIFF
--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -55,12 +55,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         CRM_Core_Action::EXPORT => [
           'name' => ts('Export'),
           'title' => ts('Export Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'export' . '\' );"',
+          'extra' => 'onclick = "assignRemove( %%id%%, \'export\' );"',
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Submit'),
           'title' => ts('Submit Transaction'),
-          'extra' => 'onclick = "submitBatch(%%id%%);"',
+          'extra' => 'onclick = "submitBatch(%%id%%, \'%%submitMessage%%\');"',
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Update'),
@@ -71,7 +71,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         CRM_Core_Action::DISABLE => [
           'name' => ts('Discard'),
           'title' => ts('Discard Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'discard' . '\' );"',
+          'extra' => 'onclick = "assignRemove( %%id%%, \'discard\' );"',
         ],
       ];
     }
@@ -205,8 +205,16 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         $action -= CRM_Core_Action::DISABLE;
       }
 
-      $batch['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        ['id' => $id], ts('more'), FALSE, '', 'Batch', $id
+      $submitMessage = base64_encode(BatchHandler::getSubmitAlertMessage($batch['type_id']));
+      $batch['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        ['id' => $id, 'submitMessage' => $submitMessage],
+        ts('more'),
+        FALSE,
+        '',
+        'Batch',
+        $id
       );
 
       $param = [];

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -84,14 +84,12 @@
     order: []
   });
 
-  function submitBatch(batchId) {
+  function submitBatch(batchId, batchMessage) {
     CRM.$("#enableDisableStatusMsg").dialog({
       title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
       modal: true,
       open: function () {
-        var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
-
-        CRM.$('#enableDisableStatusMsg').show().html(msg);
+        CRM.$('#enableDisableStatusMsg').show().html(atob(batchMessage));
       },
       buttons: {
         {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {


### PR DESCRIPTION
## Overview
After submitting Cancelled Instruction batch, a confirmation message popup is displayed as below, 

https://nimb.ws/rPpXij

We need to modify the above message and match with existing Payment batch & Instruction batch confirmation messages, when done from the detailed view of the batch.

Cancelled Instruction batch - New message
"Submit Batch  
"You are submitting all items within this batch:
Please note that this process is not reversible."

New DD Instruction batch 
"You are submitting all items within this batch:
- All mandates in the batch that currently have instruction code 0N will be transitioned to instruction code 01
- The status of this batch will be updated to 'Submitted'. Please note that this process is not reversible."

DD Payment batch
"You are submitting all items within this batch:
- All mandates in the batch that currently have instruction code 0N will be transitioned to instruction code 01
- The status of this batch will be updated to 'Submitted'. Please note that this process is not reversible"

## Before
There was a generic message being used for each batch, when clicking on submit from the list of batches.

## After
Sent the message that is supposed to be used as a parameter to the call that builds the message, using the same function that builds the message for when the submission is done from batch detail view.
