### PR TITLE
IO-114: Fix Warning Message When Submitting Cancellations Batch

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -206,7 +206,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     else {
-      $submittedMessage = '<p>' . ts('Are you sure you want to submit this batch?') . '</p>';
+      $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
 


### PR DESCRIPTION
## Overview
After submitting Cancelled Instruction batch, a confirmation message popup is displayed as below,

**Cancelled Instruction batch - Current behavior** 

https://nimb.ws/rPpXij

"Are you sure you want to submit this batch?
Please note that this process is not reversible."

**Cancelled Instruction batch - New message**

We need to modify the above message and match with existing Payment batch & Instruction batch confirmation message.

"You are submitting all items within this batch:

Please note that this process is not reversible."

## Before
Default message used for cacnellations submit was 
> Are you sure you want to submit this batch?
> Please note that this process is not reversible."

## After
Updated message to:

> You are submitting all items within this batch:
> 
> Please note that this process is not reversible."
