### PR TITLE
IO-101: Improve Batch Search Form Styling

### DIFF
--- a/css/batchSearch.css
+++ b/css/batchSearch.css
@@ -1,0 +1,7 @@
+div .batch-create-date-fields label {
+  margin-left: 20px;
+}
+
+div .crm-submit-buttons {
+  margin-bottom: 0 !important;
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -255,6 +255,10 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
       CRM_Core_Resources::singleton()
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/paymentMethodMandateSelection.js');
       break;
+
+    case CRM_ManualDirectDebit_Page_BatchList::class:
+      CRM_Core_Resources::singleton()->addStyleFile(E::LONG_NAME, 'css/batchSearch.css');
+      break;
   }
 }
 

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -3,23 +3,23 @@
 <div class="crm-form-block crm-search-form-block">
   <div class="page-civicrm-group">
     <form id="searchForm">
-      <div class="crm-section">
-        <div class="content float-left">
-          Batch Type: {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
+        <div class="float-left">
+          <label for="type_id">Batch Type:</label>
+          {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
         </div>
-        <div class="content float-left">
-          From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+        <div class="batch-create-date-fields float-right">
+          <label for="created_date_from">From:</label>
+          <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
+          <label for="created_date_to">To:</label>
+          <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
-        <div class="float-left">&nbsp;</div>
-        <div>
+        <div class="clear">&nbsp;</div>
+        <div class="crm-submit-buttons">
           <span class="crm-button crm-button-type-refresh crm-button_qf_Basic_refresh crm-i-button">
             <i class="crm-i fa-check" aria-hidden="true"></i>
             <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Basic_refresh" value="Search" type="submit" id="_qf_Basic_refresh">
           </span>
         </div>
-        <div class="clear"></div>
-      </div>
     </form>
   </div>
 </div>

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -4,13 +4,13 @@
   <div class="page-civicrm-group">
     <form id="searchForm">
         <div class="float-left">
-          <label for="type_id">Batch Type:</label>
+          <label for="type_id">{ts}Batch Type:{/ts}</label>
           {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
         </div>
         <div class="batch-create-date-fields float-right">
-          <label for="created_date_from">From:</label>
+          <label for="created_date_from">{ts}From:{/ts}</label>
           <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          <label for="created_date_to">To:</label>
+          <label for="created_date_to">{ts}To:{/ts}</label>
           <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
         <div class="clear">&nbsp;</div>


### PR DESCRIPTION
## Overview
A search form has been added to the Manage Instruction Batches list view to be able to filter by batch type and creation date. This was done in this PR:

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/195

Jamie has asked us to improve the styling of the form.

**Wireframe**

![image](https://user-images.githubusercontent.com/21999940/98141059-2b935100-1e94-11eb-8a4c-fd6f63445996.png)

## Before
The form required better styling.

![image](https://user-images.githubusercontent.com/21999940/98141175-51205a80-1e94-11eb-8515-9254fd1059c1.png)

## After
Form was styled according to provided wireframe.

![image](https://user-images.githubusercontent.com/21999940/98141389-8e84e800-1e94-11eb-876f-24935e9f666b.png)
