### PR TITLE
IO-115: Exclude Mandates From List if Added to Other Batch of Same Type

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -466,7 +466,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       }
       $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
-      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON civicrm_batch.id = ' . $this->batchID);
+      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON current_batch.id = ' . $this->batchID);
       $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
       $excluded->where('civicrm_batch.type_id = current_batch.type_id');
 


### PR DESCRIPTION
## Overview
Mandates/Payments should be excluded if they have been including in any other batch unless that batch has been "discarded".

This is not working now in Instruction batch, cancelled instruction batch or payment batch screens  after IO-113: Unify Batch Management in Single Screen fix. 

Mandates/Payments  are still available in the main batch screen even if they have been included in other batch.

## Before
A mistake was made on the query to exclude mandates in other batches.

## After
Fixed the query.
