### PR TITLE
IO-113: Fix Dynamic Page Title and Table Headers

### DIFF
--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -114,11 +114,18 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @param int $batchTypeID
    */
   private function setPageTitle($batchTypeID) {
-    if (BatchHandler::BATCH_TYPE_PAYMENTS == $this->getBatchTypeMachineName($batchTypeID)) {
-      CRM_Utils_System::setTitle(ts('View Payment Batches'));
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Manage Instruction Batches'));
+    switch ($this->getBatchTypeMachineName($batchTypeID)) {
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
+        CRM_Utils_System::setTitle(ts('Manage Payment Batches'));
+        break;
+
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+      case BatchHandler::BATCH_TYPE_CANCELLATIONS:
+        CRM_Utils_System::setTitle(ts('Manage Instruction Batches'));
+        break;
+
+      default:
+        CRM_Utils_System::setTitle(ts('Manage Direct Debit Batches'));
     }
   }
 
@@ -235,11 +242,18 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @return string
    */
   private function getEntityTypeName($typeId) {
-    if (BatchHandler::BATCH_TYPE_PAYMENTS == $this->getBatchTypeMachineName($typeId)) {
-      $entityTypeName = 'Payment';
-    }
-    else {
-      $entityTypeName = 'Instruction';
+    switch ($this->getBatchTypeMachineName($typeId)) {
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
+        $entityTypeName = 'Payment';
+        break;
+
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+      case BatchHandler::BATCH_TYPE_CANCELLATIONS:
+        $entityTypeName = 'Instruction';
+        break;
+
+      default:
+        $entityTypeName = '';
     }
 
     return $entityTypeName;


### PR DESCRIPTION
## Overview
After selecting the menu option "Manage Direct Batches",
1. Heading should be "Manage Direct Batches" instead of "Manage Instruction Batches"
2. Column name should be changed from Instruction count / to only ‘count’  

Heading and column name have been changed according to Batch Type selection. When "New Direct Debit Instruction / Cancelled Instructions" batch type is selected - Heading got changed to "Manage Instruction Batches" and Column name to 'Instruction Count". When "Direct Debit Payments" batch type is selected - Heading got changed to "View Payment Batches" and Column name to 'Payment Count".

## Before
Default values for page title and count column table header were those for instructions.

![image](https://user-images.githubusercontent.com/21999940/98261296-4fb56780-1f52-11eb-9d35-01f72ba46cf0.png)

## After
Added generic default values, for when no batch type is selected.

![image](https://user-images.githubusercontent.com/21999940/98261144-209ef600-1f52-11eb-9e4b-3ffe625c88a4.png)
