### PR TITLE
MAE-404: Menu changes

### DIFF
--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -128,7 +128,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     "direct_debit_mandate",
     "direct_debit_information",
     "direct_debit_message_template",
-    "direct_debit_collection_reminder_sendflag"
+    "direct_debit_collection_reminder_sendflag",
   ];
 
   public function install() {
@@ -179,7 +179,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
           'is_reserved' => 1,
         ];
         civicrm_api3('OptionValue', 'create', $updateParams);
-      } else {
+      }
+      else {
         $activityTypeParams['option_group_id'] = 'activity_type';
         $activityTypeParams['filter'] = 1;
         $activityTypeParams['is_reserved'] = 1;
@@ -286,7 +287,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -299,9 +301,9 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function setDefaultMinimumMandateReferenceLength() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
     civicrm_api3('setting', 'create', [
-        'manualdirectdebit_minimum_reference_prefix_length' =>
-        $configFields['manualdirectdebit_minimum_reference_prefix_length']['default']
-      ]);
+      'manualdirectdebit_minimum_reference_prefix_length' =>
+      $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
+    ]);
   }
 
   public function upgrade_0004() {
@@ -309,7 +311,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -319,7 +322,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createScheduledJob();
 
       return TRUE;
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return FALSE;
     }
   }
@@ -393,8 +397,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function createScheduledJob() {
     $domainID = CRM_Core_Config::domainID();
 
-    if($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')){
-      $this->alterEntity('Job','Send Direct Debit Payment Collection Reminders','name',FALSE,'uninstall');
+    if ($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')) {
+      $this->alterEntity('Job', 'Send Direct Debit Payment Collection Reminders', 'name', FALSE, 'uninstall');
     }
 
     $params = [
@@ -571,7 +575,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       ],
     ];
 
-    foreach($paramsPerType as $typeParams) {
+    foreach ($paramsPerType as $typeParams) {
       $params = array_merge($defaultProcessorPrams, $typeParams);
       civicrm_api3('PaymentProcessor', 'create', $params);
     }
@@ -583,7 +587,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function setDefaultSettingValues() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
-    foreach ($configFields  as $name => $config) {
+    foreach ($configFields as $name => $config) {
       civicrm_api3('setting', 'create', [$name => $config['default']]);
     }
   }
@@ -759,7 +763,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
    * Deletes Direct Debit payment processor
    */
   private function deletePaymentProcessor() {
-    foreach([0, 1] as $isTest) {
+    foreach ([0, 1] as $isTest) {
       civicrm_api3('PaymentProcessor', 'get', [
         'name' => 'Direct Debit',
         'is_test' => $isTest,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -218,7 +218,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function createCollectionReminderFlagRecords() {
     CRM_Core_DAO::executeQuery("
-      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag 
+      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag
       (entity_id, is_notification_sent) SELECT id,0 FROM civicrm_contribution
       ");
   }
@@ -439,8 +439,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'name' => 'direct_debit',
         'url' => NULL,
         'permission' => 'can manage direct debit batches',
-        'separator' => NULL,
-        'parent_name' => 'menumain',
+        'separator' => 1,
+        'parent_name' => 'Contributions',
       ],
       [
         'label' => ts('Create New Instructions Batch'),


### PR DESCRIPTION
## Overview

This PR is to change the location of Direct Debit Batch menu from main menu to locate under Contribution menu

## Before
![Screenshot from 2020-11-16 10-45-19](https://user-images.githubusercontent.com/208713/99244869-97fa4280-27fa-11eb-9c27-2182d080477f.png)

## After

![Screenshot from 2020-11-16 11-01-26](https://user-images.githubusercontent.com/208713/99245524-9e3cee80-27fb-11eb-86c8-ead1542d9b43.png)

## Technical Details

The menu was not used navigation hook to create a menu. The menu is installed directly to the database during the extension installation. Since we do not need to move the menu for existing installation, the upgrader is not required and the change is made on the installation step.  