### PR TITLE
IO-54: Managing Cancelled Mandates

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -18,7 +18,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   /**
    * Batch id
    *
-   * @var integer
+   * @var int
    */
   private $batchID;
 
@@ -131,7 +131,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       ts('Transaction Type'),
     ];
 
-    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $headers[] = ts('Received Date');
     }
 
@@ -149,8 +149,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
    * Output CSV File
    *
    * @param array $headers
-   *
-   * @param array
+   * @param array $export
    */
   private function outputCSVFile($headers, $export) {
     $out = fopen('php://temp/maxmemory:' . (12 * 1024 * 1024), 'r+');
@@ -188,18 +187,18 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
-          1 => '0N',
-          2 => '01',
-        ]) . '</p>';
+        1 => '0N',
+        2 => '01',
+      ]) . '</p>';
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
-          1 => '01',
-          2 => '17',
-        ]) . '</p>';
+        1 => '01',
+        2 => '17',
+      ]) . '</p>';
 
       $submittedMessage .= '<p>' . ts('- All contributions in the batch with status \'Pending\' will be marked as \'Completed\'') . '</p>';
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
@@ -339,10 +338,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       'transaction_type' => 'CONCAT("\t",civicrm_option_value.label) as transaction_type',
     ];
 
-    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
-    } else {
+    }
+    else {
       $returnValues['mandate_id'] = 'civicrm_value_dd_mandate.id as mandate_id';
     }
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -206,7 +206,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
     else {
-      $submittedMessage = '<p>' . ts('Are you sure you want to submit this batch?') . '</p>';
+      $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -361,6 +361,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $dataForExport = [];
     switch ($this->getBatchType()) {
       case self::BATCH_TYPE_INSTRUCTIONS:
+      case self::BATCH_TYPE_CANCELLATIONS:
         $entityTable = 'civicrm_value_dd_mandate';
         break;
 

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -183,8 +183,9 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
    */
   public static function getSubmitAlertMessage($typeId) {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
+    $batchTypeName = CRM_Utils_Array::value($typeId, $batchTypes, '');
 
-    if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
+    if ($batchTypeName == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
         1 => '0N',
@@ -193,7 +194,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
-    elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
+    elseif ($batchTypeName == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
         1 => '01',
@@ -379,6 +380,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
         case self::BATCH_TYPE_INSTRUCTIONS:
+        case self::BATCH_TYPE_CANCELLATIONS:
           $entityId = $mandateItem['mandate_id'];
           unset($mandateItem['mandate_id']);
           $dataForExport[$entityId] = $mandateItem;

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -131,7 +131,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       ts('Transaction Type'),
     ];
 
-    if($this->getBatchType() == 'dd_payments') {
+    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $headers[] = ts('Received Date');
     }
 
@@ -185,7 +185,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   public static function getSubmitAlertMessage($typeId) {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
-    if ($batchTypes[$typeId] == 'instructions_batch') {
+    if ($batchTypes[$typeId] == self::BATCH_TYPE_INSTRUCTIONS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have instruction code %1 will be transitioned to instruction code %2', [
           1 => '0N',
@@ -194,7 +194,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $submittedMessage .= '<p>' . ts('- The status of this batch will be updated to \'Submitted\'') . '</p>';
       $submittedMessage .= '<p>' . ts('Please note that this process is not reversible.') . '</p>';
     }
-    elseif ($batchTypes[$typeId] == 'dd_payments') {
+    elseif ($batchTypes[$typeId] == self::BATCH_TYPE_PAYMENTS) {
       $submittedMessage = '<p>' . ts('You are submitting all items within this batch:') . '</p>';
       $submittedMessage .= '<p>' . ts('- All mandates in the batch that currently have the code %1 will be transitioned to the code %2', [
           1 => '01',
@@ -224,10 +224,10 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       return FALSE;
     }
 
-    if ($this->getBatchType() == 'instructions_batch') {
+    if ($this->getBatchType() == self::BATCH_TYPE_INSTRUCTIONS) {
       $submitted = $this->submitInstructionsBatch();
     }
-    if ($this->getBatchType() == 'dd_payments') {
+    if ($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $submitted = $this->submitDDPayments();
     }
 
@@ -339,7 +339,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       'transaction_type' => 'CONCAT("\t",civicrm_option_value.label) as transaction_type',
     ];
 
-    if($this->getBatchType() == 'dd_payments') {
+    if($this->getBatchType() == self::BATCH_TYPE_PAYMENTS) {
       $returnValues['contribute_id'] = 'civicrm_contribution.id as contribute_id';
       $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
     } else {
@@ -359,11 +359,11 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
   public function getMandateCurrentState($returnValues) {
     $dataForExport = [];
     switch ($this->getBatchType()) {
-      case 'instructions_batch':
+      case self::BATCH_TYPE_INSTRUCTIONS:
         $entityTable = 'civicrm_value_dd_mandate';
         break;
 
-      case 'dd_payments':
+      case self::BATCH_TYPE_PAYMENTS:
         $entityTable = 'civicrm_contribution';
         break;
     }
@@ -378,13 +378,13 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $mandateItems = $batchTransaction->getDDMandateInstructions();
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
-        case 'instructions_batch':
+        case self::BATCH_TYPE_INSTRUCTIONS:
           $entityId = $mandateItem['mandate_id'];
           unset($mandateItem['mandate_id']);
           $dataForExport[$entityId] = $mandateItem;
           break;
 
-        case 'dd_payments':
+        case self::BATCH_TYPE_PAYMENTS:
           $entityId = $mandateItem['contribute_id'];
           unset($mandateItem['contribute_id']);
           $dataForExport[$entityId] = $mandateItem;

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -1,10 +1,12 @@
 <?php
 
 /**
- * This class is used for batch handling
- *
+ * This class is used for batch handling.
  */
 class CRM_ManualDirectDebit_Batch_BatchHandler {
+  const BATCH_TYPE_INSTRUCTIONS = 'instructions_batch';
+  const BATCH_TYPE_PAYMENTS = 'dd_payments';
+  const BATCH_TYPE_CANCELLATIONS = 'cancellations_batch';
 
   /**
    * Batch

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -246,7 +246,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => ts('Transaction Type'),
       ];
 
-      if ($batch->getBatchType() == 'dd_payments') {
+      if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $columnHeader['receive_date'] = ts('Received Date');
       }
     }
@@ -278,7 +278,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'transaction_type' => 'civicrm_option_value.label as transaction_type',
       ];
 
-      if ($batch->getBatchType() == 'dd_payments') {
+      if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
         $returnValues['receive_date'] = 'DATE_FORMAT(civicrm_contribution.receive_date, "%d-%m-%Y") as receive_date';
       }
     }
@@ -319,11 +319,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
 
       if (!empty($mandateValue['contact_id'])) {
         switch ($batch->getBatchType()) {
-          case "instructions_batch":
+          case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
             $row['action'] = $this->getLinkToMandate($mandateId, $mandateValue['contact_id']);
             break;
 
-          case "dd_payments":
+          case BatchHandler::BATCH_TYPE_PAYMENTS:
             $row['action'] = $this->getLinkToContribution($mandateValue['contribute_id'], $mandateValue['contact_id']);
             break;
         }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class is used to retrieve and display a range of direct debit mandates
@@ -233,7 +234,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setColumnHeader($columnHeader = []) {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     if (empty($columnHeader)) {
       $columnHeader = [
         'contact_id' => ts('ID'),
@@ -263,7 +264,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function setReturnValues($returnValues = []) {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     if (empty($returnValues) || !is_array($returnValues)) {
       $returnValues = [
         'id' => $this->params['entityTable'] . '.id as id',
@@ -293,7 +294,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   public function getRows() {
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($this->batchID));
+    $batch = (new BatchHandler($this->batchID));
     return $this->getBatchRows($batch);
   }
 
@@ -367,7 +368,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $row['check'] = $this->getCheckRow($batch, $mandateItem['id']);
 
       switch ($batch->getBatchType()) {
-        case "instructions_batch":
+        case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+        case BatchHandler::BATCH_TYPE_CANCELLATIONS:
           if (!empty($mandateItem['contact_id'])) {
             $row['action'] = $this->getLinkToMandate($mandateItem['id'], $mandateItem['contact_id']);
           }
@@ -375,7 +377,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           $rows[$mandateItem['mandate_id']] = $row;
           break;
 
-        case "dd_payments":
+        case BatchHandler::BATCH_TYPE_PAYMENTS:
           if (isset($mandateItem['contribute_id'])) {
             $contributionId = $mandateItem['contribute_id'];
           }
@@ -390,7 +392,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
           $rows[$contributionId] = $row;
           break;
       }
-
     }
 
     return $rows;

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -46,12 +46,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * What column does select in SQL query
    *
    * @var array
-   * @code
    *
+   * @code
    *  $returnValues = [
    *    'name' => 'tableName.column as alias',
    *  ]
-   *
    * @endcode
    */
   protected $returnValues = [];
@@ -60,12 +59,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * What column does select in SQL query
    *
    * @var array
-   * @code
    *
+   * @code
    *  $columnHeader = [
    *    'alias' => 'label',
    *  ]
-   *
    * @endcode
    */
   protected $columnHeader = [];
@@ -455,7 +453,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     }
 
     $this->addContributionReceiveDateCondition($query);
-
     $this->addContributionCancelDateCondition($query);
 
     if ($this->notPresent) {

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -466,7 +466,9 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       }
       $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
+      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON civicrm_batch.id = ' . $this->batchID);
       $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
+      $excluded->where('civicrm_batch.type_id = current_batch.type_id');
 
       $query->where($this->params['entityTable'] . '.id NOT IN (' . $excluded->toSQL() . ')');
     }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -466,7 +466,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       }
       $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
-      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON civicrm_batch.id = ' . $this->batchID);
+      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON current_batch.id = ' . $this->batchID);
       $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
       $excluded->where('civicrm_batch.type_id = current_batch.type_id');
 

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -12,6 +12,11 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
   const DIRECT_DEBIT_TABLE_NAME = 'civicrm_value_dd_mandate';
 
   /**
+   * Names available for dd_code field.
+   */
+  const DD_CODE_NAME_CANCELDIRECTDEBIT = 'cancel_a_direct_debit';
+
+  /**
    * Assigns depandency between contribution and mandate
    *
    * @param $contributionId

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class generates form components for Create Instructions Batch
@@ -24,7 +25,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
 
     CRM_Utils_System::setTitle(E::ts('Create %1', [1 => $this->batchType['label']]));
 
-    $newBatchID = CRM_ManualDirectDebit_Batch_BatchHandler::getMaxBatchId() + 1;
+    $newBatchID = BatchHandler::getMaxBatchId() + 1;
     $this->assign('batch_id', $newBatchID);
     $this->add('hidden', 'batch_id', $newBatchID);
     $this->add('hidden', 'type_id', $this->batchType['value']);
@@ -74,7 +75,7 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
    */
   public static function validateBatchID($fields, $files, $self) {
 
-    if ($fields['batch_id'] <= CRM_ManualDirectDebit_Batch_BatchHandler::getMaxBatchId()) {
+    if ($fields['batch_id'] <= BatchHandler::getMaxBatchId()) {
       $errors['batch_id'] = ts(
         'Batch ID %1 already exists. It is likely another batch has just been created a moment ago. Please %2 to reload the page and try again.',
         [
@@ -99,16 +100,16 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $sql = "SELECT max(id) FROM civicrm_batch";
     $batchNo = CRM_Core_DAO::singleValueQuery($sql) + 1;
 
-    if ($this->batchType['name'] == 'instructions_batch') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_INSTRUCTIONS) {
       $defaults['title'] = ts('New Instruction Batch - %1', [1 => $batchNo]);
     }
 
-    if ($this->batchType['name'] == 'dd_payments') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $defaults['title'] = ts('Direct Debit Batch - %1', [1 => $batchNo]);
       $defaults['end_date_filter'] = (new DateTime())->format('Y-m-d');
     }
 
-    if ($this->batchType['name'] == 'cancellations_batch') {
+    if ($this->batchType['name'] == BatchHandler::BATCH_TYPE_CANCELLATIONS) {
       $defaults['title'] = ts('Cancelled Instruction Batch - %1', [1 => $batchNo]);
     }
 

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -24,6 +24,10 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/direct_debit/batch', "reset=1&action=add&type_id=" . $this->batchType['value']));
 
     CRM_Utils_System::setTitle(E::ts('Create %1', [1 => $this->batchType['label']]));
+    if ($this->batchType['name'] === BatchHandler::BATCH_TYPE_CANCELLATIONS) {
+      CRM_Utils_System::setTitle(E::ts('Create Cancelled Instructions Batch'));
+      $this->batchType['label'] .= ' Batch';
+    }
 
     $newBatchID = BatchHandler::getMaxBatchId() + 1;
     $this->assign('batch_id', $newBatchID);

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -108,6 +108,10 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
       $defaults['end_date_filter'] = (new DateTime())->format('Y-m-d');
     }
 
+    if ($this->batchType['name'] == 'cancellations_batch') {
+      $defaults['title'] = ts('Cancelled Instruction Batch - %1', [1 => $batchNo]);
+    }
+
     return $defaults;
   }
 

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -138,6 +138,8 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
    * @return array[]
    */
   private function assignCancellationsSearchProperties() {
+    CRM_Utils_System::setTitle(ts('Cancelled Instructions Batch - %1', [1 => $this->batch->id]));
+
     $this->addElement('hidden', 'entityTable', 'civicrm_value_dd_mandate');
     $this->assign('tableTitle', ts('Available instructions'));
     $this->assign('entityTable', 'civicrm_value_dd_mandate');

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -138,7 +138,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
    * @return array[]
    */
   private function assignCancellationsSearchProperties() {
-    CRM_Utils_System::setTitle(ts('Cancelled Instructions Batch - %1', [1 => $this->batch->id]));
+    CRM_Utils_System::setTitle(ts('Cancelled Instructions'));
 
     $this->addElement('hidden', 'entityTable', 'civicrm_value_dd_mandate');
     $this->assign('tableTitle', ts('Available instructions'));

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -16,7 +16,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
   /**
    * Batch id.
    *
-   * @var integer
+   * @var int
    */
   protected $batchID;
 

--- a/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
@@ -13,7 +13,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
   private $contactID;
   private $params;
   private $mandateStorageManager;
-  private $dd_codes;
+  private $ddCodes;
 
   /**
    * CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker constructor.
@@ -26,7 +26,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
     $this->contactID = $contactID;
     $this->params = $params;
     $this->mandateStorageManager = $mandateStorageManager;
-    $this->dd_codes = $this->getDDCodes();
+    $this->ddCodes = $this->getDDCodes();
   }
 
   /**
@@ -92,7 +92,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
    * @return bool
    */
   private function isCancelledMandate($mandate) {
-    if ($this->dd_codes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
+    if ($this->ddCodes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
       return TRUE;
     }
 

--- a/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
@@ -1,0 +1,161 @@
+<?php
+use CRM_ManualDirectDebit_Common_MandateStorageManager as MandateStorageManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker.
+ *
+ * Checks if the mandate's status has changed vs active cancellations, to remove
+ * it from the batch if need be. MAndates that change their status from '0C' to
+ * anything else should be removed from pending (unsubmitted) batches.
+ */
+class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
+
+  private $contactID;
+  private $params;
+  private $mandateStorageManager;
+  private $dd_codes;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker constructor.
+   *
+   * @param $contactID
+   * @param $params
+   * @param \CRM_ManualDirectDebit_Common_MandateStorageManager $mandateStorageManager
+   */
+  public function __construct($contactID, $params, MandateStorageManager $mandateStorageManager) {
+    $this->contactID = $contactID;
+    $this->params = $params;
+    $this->mandateStorageManager = $mandateStorageManager;
+    $this->dd_codes = $this->getDDCodes();
+  }
+
+  /**
+   * Obtains list of dd codes, mapping their name to their value.
+   *
+   * @return array
+   */
+  private function getDDCodes() {
+    return CRM_Core_OptionGroup::values('direct_debit_codes', FALSE, FALSE, FALSE, NULL, 'name');
+  }
+
+  /**
+   * Runs the check for invalid mandates in cancellations.
+   *
+   * Processes the contact to check for mandates in cancellation batches with
+   * stuats different to '0C'.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function process() {
+    $mandates = $this->getMandates();
+
+    foreach ($mandates as $checkedMandate) {
+      $this->checkMandate($checkedMandate);
+    }
+  }
+
+  /**
+   * Returns array of mandates associated to contact.
+   *
+   * @return array
+   */
+  private function getMandates() {
+    return $this->mandateStorageManager->getMandatesForContact($this->contactID);
+  }
+
+  /**
+   * Checks if the mandate needs to be removed from a cancellations batch.
+   *
+   * @param array $mandate
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function checkMandate($mandate) {
+    if ($this->isCancelledMandate($mandate)) {
+      return;
+    }
+
+    $pendingCancellationBatches = $this->getPendingCancellationBatches();
+    foreach ($pendingCancellationBatches as $batch) {
+      $batchItemID = $this->getPendingCancellationBatchItemID($mandate, $batch);
+      if ($batchItemID) {
+        $this->removeBatchItem($batchItemID);
+      }
+    }
+  }
+
+  /**
+   * Checks if the given mandate has been cancelled.
+   *
+   * @param $mandate
+   *
+   * @return bool
+   */
+  private function isCancelledMandate($mandate) {
+    if ($this->dd_codes[$mandate['dd_code']] === MandateStorageManager::DD_CODE_NAME_CANCELDIRECTDEBIT) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Obtains list of open cancellation batches.
+   *
+   * @return array|mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPendingCancellationBatches() {
+    $result = civicrm_api3('Batch', 'get', [
+      'sequential' => 1,
+      'type_id' => 'cancellations_batch',
+      'status_id' => 'Open',
+    ]);
+
+    if (!empty($result['values'])) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+  /**
+   * Obteins batch item ofr the mandate in the given batch.
+   *
+   * @param array $mandate
+   * @param array $batch
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPendingCancellationBatchItemID($mandate, $batch) {
+    $result = civicrm_api3('EntityBatch', 'get', [
+      'sequential' => 1,
+      'batch_id' => $batch['id'],
+      'entity_id' => $mandate['id'],
+      'entity_table' => MandateStorageManager::DIRECT_DEBIT_TABLE_NAME,
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0]['id'];
+    }
+
+    return 0;
+  }
+
+  /**
+   * Deletes the given batch item.
+   *
+   * @param int $batchItemID
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function removeBatchItem($batchItemID) {
+    civicrm_api3('EntityBatch', 'delete', [
+      'sequential' => 1,
+      'id' => $batchItemID,
+      'options' => ['limit' => 0],
+    ]);
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -20,7 +20,7 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
    * @param $recurringContributionId
    */
   public function alterRecurContributionLinks(&$values, $recurringContributionId) {
-    $contactId =  CRM_Utils_Request::retrieve('cid', 'Integer');
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Integer');
     $contactType = $this->getContactType($contactId);
 
     $this->links[] = [

--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -62,7 +62,7 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
   public function alterBatchLinks($objectId) {
     $batch = CRM_Batch_BAO_Batch::findById($objectId);
 
-    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', 'instructions_batch', 'name', 'String', FALSE);
+    $instructionsBatchTypeId = CRM_Core_OptionGroup::getRowValues('batch_type', CRM_ManualDirectDebit_Batch_BatchHandler::BATCH_TYPE_INSTRUCTIONS, 'name', 'String', FALSE);
     if ($batch->type_id == $instructionsBatchTypeId['value']) {
       foreach ($this->links as &$link) {
         switch ($link['name']) {

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -33,7 +33,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
 
     $batch = (new BatchHandler($entityID));
-    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+    if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $sortMapper[] = 'receive_date';
     }
 
@@ -74,7 +74,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'transaction_type',
     ];
 
-    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
+    if ($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $selectorElements[] = 'receive_date';
     }
     $selectorElements[] = 'action';
@@ -120,10 +120,10 @@ class CRM_ManualDirectDebit_Page_AJAX {
         // since we are using it to quote the field value.
         // str_replace helps to provide a break for new-line
         $sOutput .= '"' . $element . '" :"' . addcslashes(str_replace([
-            "\r\n",
-            "\n",
-            "\r",
-          ], '<br />', $value[$element]), '"\\') . '"';
+          "\r\n",
+          "\n",
+          "\r",
+        ], '<br />', $value[$element]), '"\\') . '"';
 
         // remove extra spaces and tab character that breaks dataTable CRM-12551
         $sOutput = preg_replace("/\s+/", " ", $sOutput);
@@ -218,6 +218,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
               'batch_id' => $entityID,
             ];
             break;
+
           case 'discard':
             $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
             $params['status_id'] = CRM_Utils_Array::key('Discarded', $batchStatus);

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * This class contains all the function that are called using AJAX
@@ -31,8 +32,8 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $entityTable = CRM_Utils_Request::retrieveValue('entityTable', 'String', NULL);
     $notPresent = CRM_Utils_Request::retrieveValue('notPresent', 'String', NULL);
 
-    $batch = (new CRM_ManualDirectDebit_Batch_BatchHandler($entityID));
-    if($batch->getBatchType() == 'dd_payments') {
+    $batch = (new BatchHandler($entityID));
+    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $sortMapper[] = 'receive_date';
     }
 
@@ -73,7 +74,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
       'transaction_type',
     ];
 
-    if($batch->getBatchType() == 'dd_payments') {
+    if($batch->getBatchType() == BatchHandler::BATCH_TYPE_PAYMENTS) {
       $selectorElements[] = 'receive_date';
     }
     $selectorElements[] = 'action';
@@ -250,7 +251,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
    */
   public static function export() {
     $id = CRM_Utils_Request::retrieveValue('id', 'String');
-    $batch = new CRM_ManualDirectDebit_Batch_BatchHandler($id);
+    $batch = new BatchHandler($id);
     $batch->createExportFile();
   }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -55,12 +55,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         CRM_Core_Action::EXPORT => [
           'name' => ts('Export'),
           'title' => ts('Export Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'export' . '\' );"',
+          'extra' => 'onclick = "assignRemove( %%id%%, \'export\' );"',
         ],
         CRM_Core_Action::ENABLE => [
           'name' => ts('Submit'),
           'title' => ts('Submit Transaction'),
-          'extra' => 'onclick = "submitBatch(%%id%%);"',
+          'extra' => 'onclick = "submitBatch(%%id%%, \'%%submitMessage%%\');"',
         ],
         CRM_Core_Action::UPDATE => [
           'name' => ts('Update'),
@@ -71,7 +71,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         CRM_Core_Action::DISABLE => [
           'name' => ts('Discard'),
           'title' => ts('Discard Transaction'),
-          'extra' => 'onclick = "assignRemove( %%id%%,\'' . 'discard' . '\' );"',
+          'extra' => 'onclick = "assignRemove( %%id%%, \'discard\' );"',
         ],
       ];
     }
@@ -205,8 +205,16 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         $action -= CRM_Core_Action::DISABLE;
       }
 
-      $batch['action'] = CRM_Core_Action::formLink(self::links(), $action,
-        ['id' => $id], ts('more'), FALSE, '', 'Batch', $id
+      $submitMessage = base64_encode(BatchHandler::getSubmitAlertMessage($batch['type_id']));
+      $batch['action'] = CRM_Core_Action::formLink(
+        self::links(),
+        $action,
+        ['id' => $id, 'submitMessage' => $submitMessage],
+        ts('more'),
+        FALSE,
+        '',
+        'Batch',
+        $id
       );
 
       $param = [];

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -157,7 +157,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       'context' => '',
     ];
 
-    switch (true) {
+    switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
         $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
         break;

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -150,7 +150,14 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    */
   private function buildSearchParams($typeIdInRequest) {
     $createdDateFrom = CRM_Utils_Request::retrieve('created_date_from', 'String', $this, FALSE, NULL);
+    if (!empty($createdDateFrom)) {
+      $createdDateFrom .= ' 00:00:00';
+    }
+
     $createdDateTo = CRM_Utils_Request::retrieve('created_date_to', 'String', $this, FALSE, NULL);
+    if (!empty($createdDateTo)) {
+      $createdDateTo .= ' 23:59:59';
+    }
 
     $param = [
       'type_id' => $typeIdInRequest,
@@ -159,15 +166,15 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
 
     switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
-        $param['created_date'] = ['BETWEEN' => [$createdDateFrom . ' 00:00:00', $createdDateTo . ' 23:59:59']];
+        $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
         break;
 
       case !empty($createdDateFrom):
-        $param['created_date'] = ['>=' => $createdDateFrom . ' 00:00:00'];
+        $param['created_date'] = ['>=' => $createdDateFrom];
         break;
 
       case !empty($createdDateTo):
-        $param['created_date'] = ['<=' => $createdDateTo . ' 23:59:59'];
+        $param['created_date'] = ['<=' => $createdDateTo];
         break;
     }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -11,7 +11,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    *
    * @var array
    */
-  static $links = NULL;
+  public static $links = NULL;
 
   /**
    * Pager
@@ -79,8 +79,8 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * Finally it calls the parent's run method.
    */
   public function run() {
-    // get the requested action
-    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse'); // default to 'browse'
+    // get the requested action - default to 'browse'
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
     $this->assign('action', $action);
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
@@ -121,10 +121,11 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       $batch['transaction_count'] = $batchTransaction->getTotalNumber();
     }
 
-    if(BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]){
+    if (BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]) {
       $type = 'Payment';
       CRM_Utils_System::setTitle(ts('View Payment Batches'));
-    } else {
+    }
+    else {
       $type = 'Instruction';
       CRM_Utils_System::setTitle(ts('View New Instruction Batches'));
     }

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -236,7 +236,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @return array
    */
   private function getBatchTypeOptions() {
-    $batchTypeNames = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'label');
+    $condition = " AND (
+      v.name = '" . BatchHandler::BATCH_TYPE_INSTRUCTIONS . "'
+      OR v.name = '" . BatchHandler::BATCH_TYPE_PAYMENTS . "'
+      OR v.name = '" . BatchHandler::BATCH_TYPE_CANCELLATIONS . "'
+    )";
+    $batchTypeNames = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, $condition, 'label');
 
     return ['' => 'All'] + $batchTypeNames;
   }

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -159,15 +159,15 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
 
     switch (TRUE) {
       case !empty($createdDateFrom) && !empty($createdDateTo):
-        $param['created_date'] = ['BETWEEN' => [$createdDateFrom, $createdDateTo]];
+        $param['created_date'] = ['BETWEEN' => [$createdDateFrom . ' 00:00:00', $createdDateTo . ' 23:59:59']];
         break;
 
       case !empty($createdDateFrom):
-        $param['created_date'] = ['>=' => $createdDateFrom];
+        $param['created_date'] = ['>=' => $createdDateFrom . ' 00:00:00'];
         break;
 
       case !empty($createdDateTo):
-        $param['created_date'] = ['<=' => $createdDateTo];
+        $param['created_date'] = ['<=' => $createdDateTo . ' 23:59:59'];
         break;
     }
 

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Page for displaying the list of financial batches
@@ -84,7 +85,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     $typeId = CRM_Utils_Request::retrieve('type_id', 'String', $this, FALSE);
-    $typeId = $typeId ?: array_search('instructions_batch', $batchTypes);
+    $typeId = $typeId ?: array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes);
 
     $param = [
       'type_id' => $typeId,
@@ -115,12 +116,12 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
         ['id' => $id], ts('more'), FALSE, '', 'Batch', $id
       );
 
-      $param['entityTable'] = 'dd_payments' == $batchTypes[$batch['type_id']] ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
+      $param['entityTable'] = BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$batch['type_id']] ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
       $batch['transaction_count'] = $batchTransaction->getTotalNumber();
     }
 
-    if('dd_payments' == $batchTypes[$typeId]){
+    if(BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$typeId]){
       $type = 'Payment';
       CRM_Utils_System::setTitle(ts('View Payment Batches'));
     } else {
@@ -128,7 +129,7 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
       CRM_Utils_System::setTitle(ts('View New Instruction Batches'));
     }
 
-    $submittedMessage = CRM_ManualDirectDebit_Batch_BatchHandler::getSubmitAlertMessage($typeId);
+    $submittedMessage = BatchHandler::getSubmitAlertMessage($typeId);
     $this->assign('submittedMessage', $submittedMessage);
     $this->assign('batches', $batchList);
     $this->assign('type', $type);

--- a/CRM/ManualDirectDebit/Page/BatchList.php
+++ b/CRM/ManualDirectDebit/Page/BatchList.php
@@ -114,11 +114,18 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @param int $batchTypeID
    */
   private function setPageTitle($batchTypeID) {
-    if (BatchHandler::BATCH_TYPE_PAYMENTS == $this->getBatchTypeMachineName($batchTypeID)) {
-      CRM_Utils_System::setTitle(ts('View Payment Batches'));
-    }
-    else {
-      CRM_Utils_System::setTitle(ts('Manage Instruction Batches'));
+    switch ($this->getBatchTypeMachineName($batchTypeID)) {
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
+        CRM_Utils_System::setTitle(ts('Manage Payment Batches'));
+        break;
+
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+      case BatchHandler::BATCH_TYPE_CANCELLATIONS:
+        CRM_Utils_System::setTitle(ts('Manage Instruction Batches'));
+        break;
+
+      default:
+        CRM_Utils_System::setTitle(ts('Manage Direct Debit Batches'));
     }
   }
 
@@ -235,11 +242,18 @@ class CRM_ManualDirectDebit_Page_BatchList extends CRM_Core_Page_Basic {
    * @return string
    */
   private function getEntityTypeName($typeId) {
-    if (BatchHandler::BATCH_TYPE_PAYMENTS == $this->getBatchTypeMachineName($typeId)) {
-      $entityTypeName = 'Payment';
-    }
-    else {
-      $entityTypeName = 'Instruction';
+    switch ($this->getBatchTypeMachineName($typeId)) {
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
+        $entityTypeName = 'Payment';
+        break;
+
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
+      case BatchHandler::BATCH_TYPE_CANCELLATIONS:
+        $entityTypeName = 'Instruction';
+        break;
+
+      default:
+        $entityTypeName = '';
     }
 
     return $entityTypeName;

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -14,7 +14,7 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     parent::__construct($title, $mode);
 
     $this->queue = CRM_ManualDirectDebit_Queue_BatchSubmission::getQueue();
-    $this->batchId =  CRM_Utils_Request::retrieveValue('batchId', 'Int');
+    $this->batchId = CRM_Utils_Request::retrieveValue('batchId', 'Int');
   }
 
   public function run() {
@@ -77,7 +77,7 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     $runner = new CRM_Queue_Runner([
       'title' => ts('Submitting the batch, this may take a while depending on how many records are processed ..'),
       'queue' => $this->queue,
-      'errorMode'=> CRM_Queue_Runner::ERROR_ABORT,
+      'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
       'onEnd' => array('CRM_ManualDirectDebit_Page_BatchSubmissionQueue', 'onEnd'),
       'onEndUrl' => CRM_Utils_System::url('civicrm/direct_debit/batch-transaction', ['reset' => 1, 'action' => 'view', 'bid' => $this->batchId]),
     ]);
@@ -89,4 +89,5 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
     $message = ts('Batch Submission Completed');
     CRM_Core_Session::setStatus($message, '', 'success');
   }
+
 }

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -26,7 +26,8 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
       $this->validateBatch();
       $this->addTasksToQueue();
       $this->runQueue();
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       CRM_Core_Session::setStatus($e->getMessage(), 'Error Submitting Batch!', 'error');
       $this->redirectToBatchViewPage();
     }

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -2,6 +2,7 @@
 
 use CRM_ManualDirectDebit_Queue_Build_InstructionsQueueBuilder as InstructionsQueueBuilder;
 use CRM_ManualDirectDebit_Queue_Build_PaymentsQueueBuilder as PaymentsQueueBuilder;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
 
@@ -43,10 +44,11 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
   private function addTasksToQueue() {
     $batchType = $this->getBatchType();
     switch ($batchType) {
-      case 'instructions_batch':
+      case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
         $queueBuilder = new InstructionsQueueBuilder($this->queue, $this->batchId);
         break;
-      case 'dd_payments':
+
+      case BatchHandler::BATCH_TYPE_PAYMENTS:
         $queueBuilder = new PaymentsQueueBuilder($this->queue, $this->batchId);
         break;
     }

--- a/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
+++ b/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
@@ -40,8 +40,6 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
    * @return array
    */
   private static function getPageBatches($filterParams) {
-    $batches = [];
-
     $apiParams['status_id'] = ['NOT IN' => ['Data Entry']];
 
     if (!empty($filterParams['id'])) {
@@ -50,6 +48,10 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
 
     if (!empty($filterParams['type_id'])) {
       $apiParams['type_id'] = $filterParams['type_id'];
+    }
+
+    if (!empty($filterParams['created_date'])) {
+      $apiParams['created_date'] = $filterParams['created_date'];
     }
 
     if (!empty($filterParams['rowCount']) && is_numeric($filterParams['rowCount'])
@@ -77,10 +79,10 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
 
     $result = civicrm_api3('Batch', 'get', $apiParams);
     if (!empty($result['values'])) {
-      $batches = $result['values'];
+      return $result['values'];
     }
 
-    return $batches;
+    return [];
   }
 
   /**

--- a/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
+++ b/CRM/ManualDirectDebit/Page/BatchTableListHandler.php
@@ -103,7 +103,7 @@ class CRM_ManualDirectDebit_Page_BatchTableListHandler {
     $linksMask = array_sum(array_keys($rowLinks));
 
     if ($batchStatuses[$rowValues['status_id']] == 'Closed') {
-      $rowLinks =[];
+      $rowLinks = [];
     }
     $linksValues = ['id' => $rowValues['id'], 'status' => $rowValues['status_id']];
 

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Page for displaying list of Batch Transaction
@@ -30,7 +31,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
       $param = ['id' => $batchID, 'context' => ''];
       $batch = CRM_ManualDirectDebit_Page_BatchTableListHandler::generateRows($param);
       $batch = $batch[$batchID];
-      $param['entityTable'] = $batchTypes[$batch['type_id']] == 'instructions_batch' ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
+      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_INSTRUCTIONS ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
 
       $batchInfo = [
@@ -40,8 +41,8 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
         'created_date' => $batch['created_date'],
         'created_by' => $batch['created_by'],
       ];
-      $type = 'dd_payments' == $batchTypes[$batch['type_id']] ? 'Payment' : 'Instruction';
-      $submittedMessage = CRM_ManualDirectDebit_Batch_BatchHandler::getSubmitAlertMessage($batch['type_id']);
+      $type = BatchHandler::BATCH_TYPE_PAYMENTS == $batchTypes[$batch['type_id']] ? 'Payment' : 'Instruction';
+      $submittedMessage = BatchHandler::getSubmitAlertMessage($batch['type_id']);
 
       $this->assign('batchInfo', $batchInfo);
       $this->assign('submittedMessage', $submittedMessage);

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -31,7 +31,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
       $param = ['id' => $batchID, 'context' => ''];
       $batch = CRM_ManualDirectDebit_Page_BatchTableListHandler::generateRows($param);
       $batch = $batch[$batchID];
-      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_INSTRUCTIONS ? 'civicrm_value_dd_mandate' : 'civicrm_contribution';
+      $param['entityTable'] = $batchTypes[$batch['type_id']] == BatchHandler::BATCH_TYPE_PAYMENTS ? 'civicrm_contribution' : 'civicrm_value_dd_mandate';
       $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($batch['id'], $param);
 
       $batchInfo = [

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -14,7 +14,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
   protected $links = NULL;
 
   /**
-   * @var integer
+   * @var int
    */
   protected $entityID;
 
@@ -22,8 +22,8 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
    * Runs the page.
    */
   public function run() {
-    // get the requested action
-    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse'); // default to 'browse'
+    // get the requested action - default to 'browse'
+    $action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
 
     if ($action == CRM_Core_Action::VIEW) {
       $batchID = CRM_Utils_Request::retrieve('bid', 'Positive') ?: CRM_Utils_Array::value('batch_id', $_POST);

--- a/CRM/ManualDirectDebit/Page/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Page/BatchTransaction.php
@@ -55,6 +55,7 @@ class CRM_ManualDirectDebit_Page_BatchTransaction extends CRM_Core_Page_Basic {
     $this->entityID = CRM_Utils_Request::retrieve('bid', 'Positive');
 
     $this->edit($action, $this->entityID);
+
     return parent::run();
   }
 

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -21,17 +21,17 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "instructions_batch",
+      "searchValue" => BatchHandler::BATCH_TYPE_INSTRUCTIONS,
       "optionGroup" => "batch_type",
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "cancellations_batch",
+      "searchValue" => BatchHandler::BATCH_TYPE_PAYMENTS,
       "optionGroup" => "batch_type",
     ],
     [
       "entityType" => "OptionValue",
-      "searchValue" => "dd_payments",
+      "searchValue" => BatchHandler::BATCH_TYPE_CANCELLATIONS,
       "optionGroup" => "batch_type",
     ],
     [
@@ -182,13 +182,18 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     }
   }
 
+  /**
+   * Builds menu item to create mandate cancellation batches.
+   *
+   * @return array
+   */
   private function buildCreateCancelledInstructionsBatchMenuItem() {
     $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     return [
       'label' => ts('Create Cancelled Instructions Batch'),
       'name' => 'create_cancellation_batch',
-      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('cancellations_batch', $batchTypes),
+      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_CANCELLATIONS, $batchTypes),
       'permission' => 'can manage direct debit batches',
       'operator' => NULL,
       'separator' => NULL,
@@ -491,7 +496,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('Create New Instructions Batch'),
         'name' => 'create_new_instructions_batch',
-        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('instructions_batch', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'separator' => 1,
         'parent_name' => 'direct_debit',
@@ -499,7 +504,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('Create Payment Collection Batch'),
         'name' => 'export_direct_debit_payments',
-        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('dd_payments', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,
@@ -508,7 +513,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('View New Instruction Batches'),
         'name' => 'view_new_instruction_batches',
-        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('instructions_batch', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => 1,
@@ -517,7 +522,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       [
         'label' => ts('View Payment Collection Batches'),
         'name' => 'view_payment_batches',
-        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('dd_payments', $batchTypes),
+        'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -159,9 +159,31 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'description' => 'Direct debit mandates that need to be cancelled.',
     ]);
     $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
+    $this->updateMenuLabelsFromViewToManage();
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
+  }
+
+  /**
+   * Updates menu items for View New Instructions/Payment Batches.
+   *
+   * Changes the labels for 'View New Instruction Batches' to 'Manage
+   * Instruction Batches', and 'View Payment Collection Batches' to 'Manage
+   * Payment Collection Batches'.
+   */
+  private function updateMenuLabelsFromViewToManage() {
+    $viewInstructionsItem = new CRM_Core_BAO_Navigation();
+    $viewInstructionsItem->name = 'view_new_instruction_batches';
+    $viewInstructionsItem->find(TRUE);
+    $viewInstructionsItem->label = 'Manage Instruction Batches';
+    $viewInstructionsItem->save();
+
+    $viewPaymentsItem = new CRM_Core_BAO_Navigation();
+    $viewPaymentsItem->name = 'view_payment_batches';
+    $viewPaymentsItem->find(TRUE);
+    $viewPaymentsItem->label = 'Manage Payment Collection Batches';
+    $viewPaymentsItem->save();
   }
 
   /**
@@ -511,7 +533,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'parent_name' => 'direct_debit',
       ],
       [
-        'label' => ts('View New Instruction Batches'),
+        'label' => ts('Manage Instruction Batches'),
         'name' => 'view_new_instruction_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_INSTRUCTIONS, $batchTypes),
         'permission' => 'can manage direct debit batches',
@@ -520,7 +542,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'parent_name' => 'direct_debit',
       ],
       [
-        'label' => ts('View Payment Collection Batches'),
+        'label' => ts('Manage Payment Collection Batches'),
         'name' => 'view_payment_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search(BatchHandler::BATCH_TYPE_PAYMENTS, $batchTypes),
         'permission' => 'can manage direct debit batches',

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManualDirectDebit_ExtensionUtil as E;
+use CRM_ManualDirectDebit_Batch_BatchHandler as BatchHandler;
 
 /**
  * Collection of upgrade steps.
@@ -152,7 +153,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->addOptionValue([
       'option_group_id' => 'batch_type',
       'name' => 'cancellations_batch',
-      'label' => 'Direct Debit Cancellations',
+      'label' => 'Cancelled Instructions',
       'is_active' => 1,
       'weight' => 6,
       'description' => 'Direct debit mandates that need to be cancelled.',

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -25,6 +25,11 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
     [
       "entityType" => "OptionValue",
+      "searchValue" => "cancellations_batch",
+      "optionGroup" => "batch_type",
+    ],
+    [
+      "entityType" => "OptionValue",
       "searchValue" => "dd_payments",
       "optionGroup" => "batch_type",
     ],
@@ -144,18 +149,50 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   }
 
   public function upgrade_0014() {
-    $this->addNav([
+    $this->addOptionValue([
+      'option_group_id' => 'batch_type',
+      'name' => 'cancellations_batch',
+      'label' => 'Direct Debit Cancellations',
+      'is_active' => 1,
+      'weight' => 6,
+      'description' => 'Direct debit mandates that need to be cancelled.'
+    ]);
+    $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Adds the option value, if it exist.
+   *
+   * @param array $optionValueParams
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function addOptionValue($optionValueParams) {
+    $optionValue = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => $optionValueParams['option_group_id'],
+      'name' => $optionValueParams['name'],
+    ]);
+
+    if (!$optionValue['count']) {
+      civicrm_api3('OptionValue', 'create', $optionValueParams);
+    }
+  }
+
+  private function buildCreateCancelledInstructionsBatchMenuItem() {
+    $batchTypes = CRM_Core_OptionGroup::values('batch_type', FALSE, FALSE, FALSE, NULL, 'name');
+
+    return [
       'label' => ts('Create Cancelled Instructions Batch'),
-      'name' => 'create_cancelled_batches',
-      'url' => 'civicrm/direct_debit/cancelled-batch-list',
+      'name' => 'create_cancellation_batch',
+      'url' => 'civicrm/direct_debit/batch?reset=1&action=add&type_id=' . array_search('cancellations_batch', $batchTypes),
       'permission' => 'can manage direct debit batches',
       'operator' => NULL,
       'separator' => NULL,
       'parent_name' => 'direct_debit',
-    ]);
-    CRM_Core_BAO_Navigation::resetNavigation();
-
-    return TRUE;
+    ];
   }
 
   public function upgrade_0013() {
@@ -255,21 +292,12 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   }
 
   private function addMessageTemplateToCustomGroupEntities() {
-    $optionValueParams = [
+    $this->addOptionValue([
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_msg_template',
       'label' => 'MessageTemplate',
       'value' => 'MessageTemplate',
-    ];
-
-    $cgextendOptionValue = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => $optionValueParams['option_group_id'],
-      'name' => $optionValueParams['name'],
     ]);
-
-    if (!$cgextendOptionValue['count']) {
-      civicrm_api3('OptionValue', 'create', $optionValueParams);
-    }
   }
 
   private function addDDTemplateCustomGroup() {
@@ -494,15 +522,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'separator' => NULL,
         'parent_name' => 'direct_debit',
       ],
-      [
-        'label' => ts('Create Cancelled Instructions Batch'),
-        'name' => 'create_cancelled_batches',
-        'url' => 'civicrm/direct_debit/cancelled-batch-list',
-        'permission' => 'can manage direct debit batches',
-        'operator' => NULL,
-        'separator' => NULL,
-        'parent_name' => 'direct_debit',
-      ],
+      $this->buildCreateCancelledInstructionsBatchMenuItem(),
     ];
 
     foreach ($menuItems as $item) {
@@ -804,7 +824,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'export_direct_debit_payments',
       'view_new_instruction_batches',
       'view_payment_batches',
-      'create_cancelled_batches',
+      'create_cancellation_batch',
     ];
 
     foreach ($menuItems as $item) {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -93,7 +93,6 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     ],
   ];
 
-
   /**
    * List of processor types
    *
@@ -805,6 +804,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'export_direct_debit_payments',
       'view_new_instruction_batches',
       'view_payment_batches',
+      'create_cancelled_batches',
     ];
 
     foreach ($menuItems as $item) {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -144,6 +144,21 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $this->createDirectDebitPaymentProcessor();
   }
 
+  public function upgrade_0014() {
+    $this->addNav([
+      'label' => ts('Create Cancelled Instructions Batch'),
+      'name' => 'create_cancelled_batches',
+      'url' => 'civicrm/direct_debit/cancelled-batch-list',
+      'permission' => 'can manage direct debit batches',
+      'operator' => NULL,
+      'separator' => NULL,
+      'parent_name' => 'direct_debit',
+    ]);
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
   public function upgrade_0013() {
     $this->hideAndReserveDDActivityTypes();
     return TRUE;
@@ -218,7 +233,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function createCollectionReminderFlagRecords() {
     CRM_Core_DAO::executeQuery("
-      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag 
+      INSERT INTO civicrm_value_direct_debit_collectionreminder_sendflag
       (entity_id, is_notification_sent) SELECT id,0 FROM civicrm_contribution
       ");
   }
@@ -472,6 +487,15 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
         'label' => ts('View Payment Collection Batches'),
         'name' => 'view_payment_batches',
         'url' => 'civicrm/direct_debit/batch-list?reset=1&type_id=' . array_search('dd_payments', $batchTypes),
+        'permission' => 'can manage direct debit batches',
+        'operator' => NULL,
+        'separator' => NULL,
+        'parent_name' => 'direct_debit',
+      ],
+      [
+        'label' => ts('Create Cancelled Instructions Batch'),
+        'name' => 'create_cancelled_batches',
+        'url' => 'civicrm/direct_debit/cancelled-batch-list',
         'permission' => 'can manage direct debit batches',
         'operator' => NULL,
         'separator' => NULL,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -316,9 +316,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function setDefaultMinimumMandateReferenceLength() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
     civicrm_api3('setting', 'create', [
-        'manualdirectdebit_minimum_reference_prefix_length' =>
-          $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
-      ]);
+      'manualdirectdebit_minimum_reference_prefix_length' => $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
+    ]);
   }
 
   public function upgrade_0004() {

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -128,7 +128,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     "direct_debit_mandate",
     "direct_debit_information",
     "direct_debit_message_template",
-    "direct_debit_collection_reminder_sendflag"
+    "direct_debit_collection_reminder_sendflag",
   ];
 
   public function install() {
@@ -194,7 +194,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
           'is_reserved' => 1,
         ];
         civicrm_api3('OptionValue', 'create', $updateParams);
-      } else {
+      }
+      else {
         $activityTypeParams['option_group_id'] = 'activity_type';
         $activityTypeParams['filter'] = 1;
         $activityTypeParams['is_reserved'] = 1;
@@ -301,7 +302,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -315,7 +317,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
     civicrm_api3('setting', 'create', [
         'manualdirectdebit_minimum_reference_prefix_length' =>
-        $configFields['manualdirectdebit_minimum_reference_prefix_length']['default']
+          $configFields['manualdirectdebit_minimum_reference_prefix_length']['default'],
       ]);
   }
 
@@ -324,7 +326,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createMessageTemplates();
 
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }
@@ -334,7 +337,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       $this->createScheduledJob();
 
       return TRUE;
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return FALSE;
     }
   }
@@ -408,8 +412,8 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
   private function createScheduledJob() {
     $domainID = CRM_Core_Config::domainID();
 
-    if($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')){
-      $this->alterEntity('Job','Send Direct Debit Payment Collection Reminders','name',FALSE,'uninstall');
+    if ($this->isEntityAlreadyExist("Job", 'Send Direct Debit Payment Collection Reminders', 'name')) {
+      $this->alterEntity('Job', 'Send Direct Debit Payment Collection Reminders', 'name', FALSE, 'uninstall');
     }
 
     $params = [
@@ -595,7 +599,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       ],
     ];
 
-    foreach($paramsPerType as $typeParams) {
+    foreach ($paramsPerType as $typeParams) {
       $params = array_merge($defaultProcessorPrams, $typeParams);
       civicrm_api3('PaymentProcessor', 'create', $params);
     }
@@ -607,7 +611,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
 
   private function setDefaultSettingValues() {
     $configFields = CRM_ManualDirectDebit_Common_SettingsManager::getConfigFields();
-    foreach ($configFields  as $name => $config) {
+    foreach ($configFields as $name => $config) {
       civicrm_api3('setting', 'create', [$name => $config['default']]);
     }
   }
@@ -783,7 +787,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
    * Deletes Direct Debit payment processor
    */
   private function deletePaymentProcessor() {
-    foreach([0, 1] as $isTest) {
+    foreach ([0, 1] as $isTest) {
       civicrm_api3('PaymentProcessor', 'get', [
         'name' => 'Direct Debit',
         'is_test' => $isTest,

--- a/CRM/ManualDirectDebit/Upgrader.php
+++ b/CRM/ManualDirectDebit/Upgrader.php
@@ -155,7 +155,7 @@ class CRM_ManualDirectDebit_Upgrader extends CRM_ManualDirectDebit_Upgrader_Base
       'label' => 'Direct Debit Cancellations',
       'is_active' => 1,
       'weight' => 6,
-      'description' => 'Direct debit mandates that need to be cancelled.'
+      'description' => 'Direct debit mandates that need to be cancelled.',
     ]);
     $this->addNav($this->buildCreateCancelledInstructionsBatchMenuItem());
     CRM_Core_BAO_Navigation::resetNavigation();

--- a/css/batchSearch.css
+++ b/css/batchSearch.css
@@ -1,0 +1,7 @@
+div .batch-create-date-fields label {
+  margin-left: 20px;
+}
+
+div .crm-submit-buttons {
+  margin-bottom: 0 !important;
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -256,6 +256,10 @@ function manualdirectdebit_civicrm_pageRun(&$page) {
       CRM_Core_Resources::singleton()
         ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/paymentMethodMandateSelection.js');
       break;
+
+    case CRM_ManualDirectDebit_Page_BatchList::class:
+      CRM_Core_Resources::singleton()->addStyleFile(E::LONG_NAME, 'css/batchSearch.css');
+      break;
   }
 }
 

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -320,6 +320,7 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
       $form->add('hidden', 'optionContributionId', $openContributionId);
     }
   }
+
   if ($formName == 'CRM_Contact_Form_CustomData') {
     if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'))) {
       $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -268,7 +268,6 @@ function _manualdirectdebit_getContactType($contactId) {
 
 /**
  * Implements hook_civicrm_custom().
- *
  */
 function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
   if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
@@ -281,6 +280,10 @@ function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->generateMandateData();
     }
+
+    $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
+    $cancellationChecker->process();
   }
 }
 
@@ -296,6 +299,11 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
  * Implements hook_civicrm_post().
  */
 function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  if ($op == 'create' && $objectName == 'Contribution') {
+    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
+    $postContributionHook->process();
+  }
+
   if ($op == 'create' && $objectName == 'Contribution') {
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -279,11 +279,11 @@ function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
     if ($op == 'edit' || $op == 'update') {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->generateMandateData();
-    }
 
-    $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
-    $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
-    $cancellationChecker->process();
+      $mandateStorageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+      $cancellationChecker = new CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker($entityID, $params, $mandateStorageManager);
+      $cancellationChecker->process();
+    }
   }
 }
 

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -84,14 +84,12 @@
     order: []
   });
 
-  function submitBatch(batchId) {
+  function submitBatch(batchId, batchMessage) {
     CRM.$("#enableDisableStatusMsg").dialog({
       title: {/literal}'{ts escape="js"}Submit Batch{/ts}'{literal},
       modal: true,
       open: function () {
-        var msg = {/literal}{if $submittedMessage}"{$submittedMessage}"{else}"{ts escape="js"}Are you sure you want to submit this batch? This process is not revertable.{/ts}"{/if}{literal};
-
-        CRM.$('#enableDisableStatusMsg').show().html(msg);
+        CRM.$('#enableDisableStatusMsg').show().html(atob(batchMessage));
       },
       buttons: {
         {/literal}"{ts escape='js'}Cancel{/ts}"{literal}: function () {

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -3,23 +3,23 @@
 <div class="crm-form-block crm-search-form-block">
   <div class="page-civicrm-group">
     <form id="searchForm">
-      <div class="crm-section">
-        <div class="content float-left">
-          Batch Type: {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
+        <div class="float-left">
+          <label for="type_id">Batch Type:</label>
+          {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
         </div>
-        <div class="content float-left">
-          From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+        <div class="batch-create-date-fields float-right">
+          <label for="created_date_from">From:</label>
+          <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
+          <label for="created_date_to">To:</label>
+          <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
-        <div class="float-left">&nbsp;</div>
-        <div>
+        <div class="clear">&nbsp;</div>
+        <div class="crm-submit-buttons">
           <span class="crm-button crm-button-type-refresh crm-button_qf_Basic_refresh crm-i-button">
             <i class="crm-i fa-check" aria-hidden="true"></i>
             <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Basic_refresh" value="Search" type="submit" id="_qf_Basic_refresh">
           </span>
         </div>
-        <div class="clear"></div>
-      </div>
     </form>
   </div>
 </div>

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -1,4 +1,28 @@
 <div id="enableDisableStatusMsg" class="crm-container" style="display:none;"></div>
+
+<div class="crm-form-block crm-search-form-block">
+  <div class="page-civicrm-group">
+    <form id="searchForm">
+      <div class="crm-section">
+        <div class="content float-left">
+          Batch Type: {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
+        </div>
+        <div class="content float-left">
+          From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
+          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_from}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+        </div>
+        <div class="float-left">&nbsp;</div>
+        <div>
+          <span class="crm-button crm-button-type-refresh crm-button_qf_Basic_refresh crm-i-button">
+            <i class="crm-i fa-check" aria-hidden="true"></i>
+            <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Basic_refresh" value="Search" type="submit" id="_qf_Basic_refresh">
+          </span>
+        </div>
+        <div class="clear"></div>
+      </div>
+    </form>
+  </div>
+</div>
 <div class="batch-list crm-results-block">
   {include file="CRM/common/pager.tpl" location="top"}
     {strip}
@@ -6,6 +30,7 @@
     <thead class="sticky">
     <tr>
       <th class="crm-batch-name">{ts}Batch Name{/ts}</th>
+      <th class="crm-batch-name">{ts}Batch Type{/ts}</th>
       <th class="crm-batch-item_count">{ts}{$type} Count{/ts}</th>
       <th class="crm-batch-status">{ts}Status{/ts}</th>
       <th class="crm-batch-created_date">{ts}Created Date{/ts}</th>
@@ -18,6 +43,9 @@
       <tr class="crm-entity" data-entity="batch" data-id="{$batch.id}">
         <td class="crm-batch-name">
           {$batch.name}
+        </td>
+        <td class="crm-batch-item_count">
+          {$batch.batch_type_name}
         </td>
         <td class="crm-batch-item_count">
           {$batch.transaction_count}

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -9,7 +9,7 @@
         </div>
         <div class="content float-left">
           From: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_from}" id="created_date_to" class="crm-form-text crm-hidden-date" />
+          To: <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
         <div class="float-left">&nbsp;</div>
         <div>

--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -4,13 +4,13 @@
   <div class="page-civicrm-group">
     <form id="searchForm">
         <div class="float-left">
-          <label for="type_id">Batch Type:</label>
+          <label for="type_id">{ts}Batch Type:{/ts}</label>
           {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
         </div>
         <div class="batch-create-date-fields float-right">
-          <label for="created_date_from">From:</label>
+          <label for="created_date_from">{ts}From:{/ts}</label>
           <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="From" name="created_date_from" type="text" value="{$created_date_from}" id="created_date_from" class="crm-form-text crm-hidden-date" />
-          <label for="created_date_to">To:</label>
+          <label for="created_date_to">{ts}To:{/ts}</label>
           <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="To" name="created_date_to" type="text" value="{$created_date_to}" id="created_date_to" class="crm-form-text crm-hidden-date" />
         </div>
         <div class="clear">&nbsp;</div>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -401,6 +401,14 @@
       <is_active>1</is_active>
     </OptionValue>
     <OptionValue>
+      <label>Direct Debit Cancellations</label>
+      <name>cancellations_batch</name>
+      <is_active>1</is_active>
+      <weight>6</weight>
+      <description>Direct debit mandates that need to be cancelled.</description>
+      <option_group_name>batch_type</option_group_name>
+    </OptionValue>
+    <OptionValue>
       <label>Submitted</label>
       <name>Submitted</name>
       <is_active>1</is_active>


### PR DESCRIPTION
## Overview
We need to provide functionality such that a user can export mandates that have been cancelled, so that they can import them into their direct debit software and process the cancellations.

**User Story** 
As a CiviCRM user. I would like to be able to create a mandate batch which includes cancelled direct debit mandates. So that I can import them into my Direct Debit management software to have the mandates cancelled.

## Before
No functionality to manage direct debit cancellations existed, save for the possibility to change the status of a mandate to '0C' (Cancelled).

## After
Functionality to create, manage and export cancellations is implemented. This comprises the PR's done for:
- IO-74: #189
- IO-75: #190
- IO-76: #191
- IO-77: #204, #205
- IO-83: #195
- IO-87: #198
- IO-101: #208
- IO-113: #206, #210
- IO-114: #207
- IO-115: #209
