### PR TITLE
MAE-411: Bump version to 4.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.24.6
+          version: 5.28.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/info.xml
+++ b/info.xml
@@ -18,8 +18,8 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-10-07</releaseDate>
-  <version>3.0.0</version>
+  <releaseDate>2020-11-30</releaseDate>
+  <version>4.0.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>


### PR DESCRIPTION
## Overview
Bumping version to 4.0.0 as part of Membershipextras suite version 4.0.0 release.

Also as part of this PR I've updated the tests workflow file to use Civicrm and drupal versions specified in Compuclient 