### PR TITLE
IO-123: Implement calculateContributionReceiveDate Hook

### DIFF
--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -1,0 +1,144 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution.
+ *
+ * Implements hook to calculate the receive date of the first contribution of a
+ * payment plan.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution {
+
+  /**
+   * Start date of the payment plan and the receive date of first instalment.
+   *
+   * @var string
+   */
+  private $receiveDate = '';
+
+  /**
+   * List of parameters being used to create the first instalment.
+   *
+   * @var array
+   */
+  private $params = [];
+
+  /**
+   * Array with Direct Debit extension settings.
+   *
+   * @var array
+   */
+  private $ddSettings = [];
+
+  /**
+   * The DirectDebit payment instrument data.
+   *
+   * @var array
+   */
+  private $directDebitPaymentInstrument = [];
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
+   *
+   * @param $receiveDate
+   * @param $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, &$params, SettingsManager $settingsManager) {
+    $this->receiveDate =& $receiveDate;
+    $this->params =& $params;
+    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
+    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
+  }
+
+  /**
+   * Obtains the data for the Direct Debit payment instrument.
+   *
+   * @return mixed
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDDPaymentMethod() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => 'direct_debit',
+      'option_group_id' => 'payment_instrument',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
+  }
+
+  /**
+   * Calculates receive date for payment plan if payment method is DD.
+   *
+   * @throws \Exception
+   */
+  public function process() {
+    if (!$this->isDirectDebit()) {
+      return;
+    }
+
+    $paddedReceiveDate = new DateTime($this->receiveDate);
+    if ($this->ddSettings['minimum_days_to_first_payment']) {
+      $paddedReceiveDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+    }
+
+    $nextInstructionRunDate = $this->getNextValidDateAfter($paddedReceiveDate, $this->ddSettings['new_instruction_run_dates']);
+    $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
+    $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Checks if the contribution is being paid for with direct debit.
+   *
+   * @return bool
+   */
+  private function isDirectDebit() {
+    if ($this->params['payment_instrument_id'] === 'direct_debit') {
+      return TRUE;
+    }
+
+    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Returns first date in collection of days that is after given dates.
+   *
+   * @param \DateTime $referenceDate
+   * @param array $validDaysArray
+   *
+   * @return \Date|\DateTime
+   */
+  private function getNextValidDateAfter(\DateTime $referenceDate, array $validDaysArray) {
+    $referenceYear = intval($referenceDate->format('Y'));
+
+    for ($year = $referenceYear; $year < $referenceYear + 2; $year++) {
+      for ($month = 1; $month < 13; $month++) {
+        foreach ($validDaysArray as $paymentCollectionDay) {
+          $paymentCollectionDay = ($paymentCollectionDay < 10 ? '0' . $paymentCollectionDay : $paymentCollectionDay);
+          $paymentCollectionMonth = ($month < 10 ? '0' . $month : $month);
+          $nextAvailableDate = new DateTime("{$year}-{$paymentCollectionMonth}-{$paymentCollectionDay}");
+
+          if ($nextAvailableDate >= $referenceDate) {
+            return $nextAvailableDate;
+          }
+        }
+      }
+    }
+
+    return $referenceDate;
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -307,11 +307,6 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-// TODO!!
-  if ($op == 'create' && $objectName == 'Contribution') {
-    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
-    $postContributionHook->process();
-  }
 }
 
 /**
@@ -399,9 +394,6 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 
 /**
  * Implements hook_membershipextras_calculateContributionReceiveDate().
- *
- * @param string $receiveDate
- * @param array $contributionCreationParams
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -307,7 +307,7 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-
+// TODO!!
   if ($op == 'create' && $objectName == 'Contribution') {
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
@@ -395,6 +395,22 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 
   $mandate = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate($recurContributionId, $previousRecurContributionId);
   $mandate->process();
+}
+
+/**
+ * Implements hook_membershipextras_calculateContributionReceiveDate().
+ *
+ * @param string $receiveDate
+ * @param array $contributionCreationParams
+ */
+function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
+  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $firstReceiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
+    $receiveDate,
+    $contributionCreationParams,
+    $settingsManager
+  );
+  $firstReceiveDateCalculator->process();
 }
 
 function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution as FirstContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest extends BaseHeadlessTest {
+
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  public function testCalculateReceiveDateOnFirstRunDateWithMinDaysOverFirstPayDateUsesSecondPayDate() {
+    $receiveDate = '2020-01-01';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateWithMinDaysOverSecondPayDatePushesForNextMonth() {
+    $receiveDate = '2020-01-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-02-01 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateAtEndOfYearIsPushedForNextYear() {
+    $receiveDate = '2020-12-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2021-01-01 00:00:00', $receiveDate);
+  }
+
+  public function testPaymentPlansNotPaidWithDirectDebitAreNotChanged() {
+    $receiveDate = '2020-01-15 00:00:00';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $this->defaultContributionParams['payment_instrument_id'] = 'EFT';
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -17,6 +17,8 @@ if (CIVICRM_UF === 'UnitTests') {
   Civi\Test::headless()->apply();
 }
 
+require_once 'BaseHeadlessTest.php';
+
 /**
  * Call the "cv" command.
  *


### PR DESCRIPTION
## Overview
We need to calculate first instalment receive date in such a way that:
- Takes membership start date
- Finds the next NIRD (New instruction run date) and adds MDFNI (Min days for New instruction to First payment) 
- Finds the next payment collection run date available after the padded next instruction run date.

Thus, first instalment receive date should be first available payment collection run date after the the first padded instruction run date, which in turn should be after the membership start date.

## Before
There was no way to change the first instalment's receive date.

## After
Implemented the membership extras calculateContributionReceiveDate hook to change the first instalment's receive date.

## Technical Details
Hook is dispatched from membership extras extension, implemented in this PR:
https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/322
