### PR TITLE
IO-125: Add Setting to Alter Behaviour of Second Instalment

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -4,6 +4,8 @@
  * Class provide information about Direct Debit Mandate Settings
  */
 class CRM_ManualDirectDebit_Common_SettingsManager {
+  const SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER = 'one_month_after';
+  const SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH = 'force_second_month';
 
   public static $minimumDaysToFirstPayment;
 
@@ -49,7 +51,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
    * @return int|null
    */
   public static function getMinimumDayForFirstPayment() {
-    if (isset(self::$minimumDaysToFirstPayment) && !empty(self::$minimumDaysToFirstPayment)){
+    if (isset(self::$minimumDaysToFirstPayment) && !empty(self::$minimumDaysToFirstPayment)) {
       return self::$minimumDaysToFirstPayment;
     }
 
@@ -59,11 +61,12 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'sequential' => 1,
     ]);
 
-    if(isset($settingValues[$settingTitle]) && !empty($settingValues[$settingTitle])){
+    if (isset($settingValues[$settingTitle]) && !empty($settingValues[$settingTitle])) {
       self::$minimumDaysToFirstPayment = $settingValues[$settingTitle];
       return self::$minimumDaysToFirstPayment;
-    } else {
-      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"),'required_setting_not_configured');
+    }
+    else {
+      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"), 'required_setting_not_configured');
     }
   }
 
@@ -83,8 +86,8 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
 
     if (!isset($settingValues) || empty($settingValues)) {
       $result = civicrm_api3('System', 'flush');
-      if ($result['is_error'] == 0){
-        $settingValues =  $this->fetchSettingsValues();
+      if ($result['is_error'] == 0) {
+        $settingValues = $this->fetchSettingsValues();
       }
     }
     return $settingValues;
@@ -120,18 +123,17 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
     if (!isset($allowedConfigFields) || empty($allowedConfigFields)) {
       $result = civicrm_api3('System', 'flush');
 
-      if ($result['is_error'] == 0){
-        $allowedConfigFields =  self::fetchSettingFields();
+      if ($result['is_error'] == 0) {
+        $allowedConfigFields = self::fetchSettingFields();
       }
     }
 
     return $allowedConfigFields;
   }
 
-
   private static function fetchSettingFields() {
-    return civicrm_api3('setting', 'getfields',[
-      'filters' =>[ 'group' => 'manualdirectdebit'],
+    return civicrm_api3('setting', 'getfields', [
+      'filters' => ['group' => 'manualdirectdebit'],
     ])['values'];
   }
 

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -66,7 +66,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       return self::$minimumDaysToFirstPayment;
     }
     else {
-      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"), 'required_setting_not_configured');
+      throw new CiviCRM_API3_Exception(ts("Please, configure minimum days to first payment"), 'required_setting_not_configured');
     }
   }
 

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -1,6 +1,7 @@
 <?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
 
-/*
+/**
  * Metadata for Manual Direct Debit Settings
  */
 return [
@@ -23,7 +24,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_reference_prefix_length',
-    'title' => 'Minimum mandate reference length',
+    'title' => 'Minimum Mandate Reference Length',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -38,7 +39,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_new_instruction_run_dates',
-    'title' => 'New instruction run dates',
+    'title' => 'New Instruction Run Dates',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
@@ -57,7 +58,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_payment_collection_run_dates',
-    'title' => 'Payment collection run dates ',
+    'title' => 'Payment Collection Run Dates ',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
@@ -76,7 +77,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_days_to_first_payment',
-    'title' => 'Minimum days from new instruction to first payment',
+    'title' => 'Minimum Days from New Instruction to First Payment',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -87,11 +88,32 @@ return [
     'extra_data' => '',
     'section' => 'payment_config',
   ],
+  'manualdirectdebit_second_instalment_date_behaviour' => [
+    'group_name' => 'Manual Direct Debit',
+    'group' => 'manualdirectdebit',
+    'name' => 'manualdirectdebit_second_instalment_date_behaviour',
+    'title' => 'Second Instalment Date Behaviour',
+    'type' => 'String',
+    'html_type' => 'select',
+    'quick_form_type' => 'Element',
+    'default' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    'is_required' => TRUE,
+    'is_help' => FALSE,
+    'html_attributes' => [
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER => ts('Take second instalment 1 month after the first instalment'),
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH => ts('Take second instalment in the second month of membership'),
+    ],
+    'extra_data' => [
+      'class' => 'crm-select2',
+      'placeholder' => ts('- select -'),
+    ],
+    'section' => 'payment_config',
+  ],
   'manualdirectdebit_days_in_advance_for_collection_reminder' => [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_days_in_advance_for_collection_reminder',
-    'title' => 'Days in advance for Collection Reminder',
+    'title' => 'Days in Advance for Collection Reminder',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -106,7 +128,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_batch_submission_queue_limit',
-    'title' => 'Number of records to be processed per batch submission queue task',
+    'title' => 'Number of Records to be Processed per Batch Submission Queue Task',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -116,7 +138,7 @@ return [
     'html_attributes' => '',
     'extra_data' => '',
     'section' => 'batch_config',
-  ]
+  ],
 ];
 
 /**


### PR DESCRIPTION
## Overview
We need a setting so that users can choose when the second instalment should be for, under specific scenarios. The setting should be named"Second Instalment Date Behaviour", a dropdown with the following options:

- Take second instalment 1 month after the first instalment (Default)
- Take second instalment in the second month of membership

## Before
The setting did not exist.

## After
Added the setting to the payment options block of DD settings form.
