### PR TITLE
IO-131: Fix Failing Scenarios on First Receive Date Calculation

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -15,14 +15,18 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
   public function getManualDirectDebitSettings() {
     $settingValues = $this->getSettingsValues();
 
-    $settings = [];
-    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
-    $settings['minimum_reference_prefix_length'] = $settingValues['values'][0]['manualdirectdebit_minimum_reference_prefix_length'];
+    $settings = [
+      'default_reference_prefix' => CRM_Utils_Array::value('manualdirectdebit_default_reference_prefix', $settingValues),
+      'minimum_reference_prefix_length' => CRM_Utils_Array::value('manualdirectdebit_minimum_reference_prefix_length', $settingValues),
+      'minimum_days_to_first_payment' => CRM_Utils_Array::value('manualdirectdebit_minimum_days_to_first_payment', $settingValues),
+    ];
+
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
+      CRM_Utils_Array::value('manualdirectdebit_new_instruction_run_dates', $settingValues)
+    );
     $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
-    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
+      CRM_Utils_Array::value('manualdirectdebit_payment_collection_run_dates', $settingValues)
+    );
 
     return $settings;
   }
@@ -87,7 +91,8 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
         $settingValues =  $this->fetchSettingsValues();
       }
     }
-    return $settingValues;
+
+    return $settingValues['values'][0];
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -86,12 +86,13 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
       return;
     }
 
-    $paddedReceiveDate = new DateTime($this->receiveDate);
+    $receiveDateTime = new DateTime($this->receiveDate);
+    $nextInstructionRunDate = $this->getNextValidDateAfter($receiveDateTime, $this->ddSettings['new_instruction_run_dates']);
+
     if ($this->ddSettings['minimum_days_to_first_payment']) {
-      $paddedReceiveDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+      $nextInstructionRunDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
     }
 
-    $nextInstructionRunDate = $this->getNextValidDateAfter($paddedReceiveDate, $this->ddSettings['new_instruction_run_dates']);
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
     $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
   }
@@ -131,7 +132,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
           $paymentCollectionMonth = ($month < 10 ? '0' . $month : $month);
           $nextAvailableDate = new DateTime("{$year}-{$paymentCollectionMonth}-{$paymentCollectionDay}");
 
-          if ($nextAvailableDate >= $referenceDate) {
+          if ($nextAvailableDate > $referenceDate) {
             return $nextAvailableDate;
           }
         }

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -89,8 +89,9 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
     $receiveDateTime = new DateTime($this->receiveDate);
     $nextInstructionRunDate = $this->getNextValidDateAfter($receiveDateTime, $this->ddSettings['new_instruction_run_dates']);
 
-    if ($this->ddSettings['minimum_days_to_first_payment']) {
-      $nextInstructionRunDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+    $minimumDaysToFirstPayment = $this->ddSettings['minimum_days_to_first_payment'];
+    if ($minimumDaysToFirstPayment) {
+      $nextInstructionRunDate->add(new DateInterval("P{$minimumDaysToFirstPayment}D"));
     }
 
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);


### PR DESCRIPTION
## Overview
First installment is calculated incorrectly and it seems like it does not consider the 2nd value mentioned in "Payment collection run dates" DD configuration for the calculation. 

Consider this example - When the new instruction Run Date and minimum number of days (combined) is after the cycle date the first instalment should be scheduled for the following month. But it is not.

1. Update the DD configurations as below,
   1. New instruction run dates - 4
   1. Payment collection run dates  -5, 21	
   1. Minimum days from new instruction to first payment - 3
2. Create a membership effective from today 18-Dec-2020 with the same payment plan start date
3. Membership is created effective from today . 
4. But 1st installment is displayed as 5th Jan 2021 . It should be 21st Jan 2021 

Calculation -  4th Jan 2020 is the next instruction date + 3 days which is 7th Jan 2020. So the next payment collection run date is 21st Jan 2020.

Scenarios tested documented here:

https://docs.google.com/spreadsheets/d/1Mpn8UF47mqnrEkXGmWrHYfG2c58H-O4Ygt4q5RLRMnM/edit#gid=1556520030

## Before
Padding was used on receive date, instead of next available new instruction date.

## After
Fixed by first obtaining next available instruction date and adding the minimum days before payment collection to it, to finally obtain the next paypemnt collection run date.

Also made only dates strictly more than reference date be available, as per scenario's requirements.

Added tests for documented scenarios.