### PR TITLE
IO-126: Alter Receive Date of Other Instalments Based on DD Settings

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -21,6 +21,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'default_reference_prefix' => CRM_Utils_Array::value('manualdirectdebit_default_reference_prefix', $settingValues),
       'minimum_reference_prefix_length' => CRM_Utils_Array::value('manualdirectdebit_minimum_reference_prefix_length', $settingValues),
       'minimum_days_to_first_payment' => CRM_Utils_Array::value('manualdirectdebit_minimum_days_to_first_payment', $settingValues),
+      'second_instalment_date_behaviour' => CRM_Utils_Array::value('manualdirectdebit_second_instalment_date_behaviour', $settingValues),
     ];
 
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
@@ -110,6 +111,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'manualdirectdebit_new_instruction_run_dates',
       'manualdirectdebit_payment_collection_run_dates',
       'manualdirectdebit_minimum_days_to_first_payment',
+      'manualdirectdebit_second_instalment_date_behaviour',
     ];
 
     return civicrm_api3('setting', 'get', [

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
@@ -7,7 +7,7 @@ use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
  * Holds methods and attributes to all classes that calculate receive dates for
  * instalments in a payment plan.
  */
-abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
   /**
    * Start date of the payment plan and the receive date of first instalment.
    *
@@ -102,11 +102,10 @@ abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Contr
     $result = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $this->params['contribution_recur_id'],
-      'options' => ['limit' => 0],
     ]);
 
     if ($result['count'] > 0) {
-      return $result['values'][0];
+      return array_shift($result['values']);
     }
 
     return [];

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
@@ -93,10 +93,30 @@ abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Contr
   }
 
   /**
+   * Obtains recurrring contribution used for the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function getRecurringContribution() {
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['contribution_recur_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    return [];
+  }
+
+  /**
    * Changes the receive date for the instalment, if necessary.
    *
    * @return mixed
    */
-  public abstract function process();
+  abstract public function process();
 
 }

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
@@ -1,0 +1,102 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase.
+ *
+ * Holds methods and attributes to all classes that calculate receive dates for
+ * instalments in a payment plan.
+ */
+abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+  /**
+   * Start date of the payment plan and the receive date of first instalment.
+   *
+   * @var string
+   */
+  protected $receiveDate = '';
+
+  /**
+   * List of parameters being used to create the first instalment.
+   *
+   * @var array
+   */
+  protected $params = [];
+
+  /**
+   * Array with Direct Debit extension settings.
+   *
+   * @var array
+   */
+  protected $ddSettings = [];
+
+  /**
+   * The DirectDebit payment instrument data.
+   *
+   * @var array
+   */
+  protected $directDebitPaymentInstrument = [];
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
+   *
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, $params, SettingsManager $settingsManager) {
+    $this->receiveDate =& $receiveDate;
+    $this->params = $params;
+    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
+    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
+  }
+
+  /**
+   * Obtains the data for the Direct Debit payment instrument.
+   *
+   * @return mixed
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDDPaymentMethod() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => 'direct_debit',
+      'option_group_id' => 'payment_instrument',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
+  }
+
+  /**
+   * Checks if the contribution is being paid for with direct debit.
+   *
+   * @return bool
+   */
+  protected function isDirectDebit() {
+    if ($this->params['payment_instrument_id'] === 'direct_debit') {
+      return TRUE;
+    }
+
+    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Changes the receive date for the instalment, if necessary.
+   *
+   * @return mixed
+   */
+  public abstract function process();
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
 
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -7,74 +7,7 @@ use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
  * Implements hook to calculate the receive date of the first contribution of a
  * payment plan.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution {
-
-  /**
-   * Start date of the payment plan and the receive date of first instalment.
-   *
-   * @var string
-   */
-  private $receiveDate = '';
-
-  /**
-   * List of parameters being used to create the first instalment.
-   *
-   * @var array
-   */
-  private $params = [];
-
-  /**
-   * Array with Direct Debit extension settings.
-   *
-   * @var array
-   */
-  private $ddSettings = [];
-
-  /**
-   * The DirectDebit payment instrument data.
-   *
-   * @var array
-   */
-  private $directDebitPaymentInstrument = [];
-
-  /**
-   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
-   *
-   * @param $receiveDate
-   * @param $params
-   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   *
-   * @throws \CRM_Extension_Exception
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function __construct(&$receiveDate, &$params, SettingsManager $settingsManager) {
-    $this->receiveDate =& $receiveDate;
-    $this->params =& $params;
-    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
-    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
-  }
-
-  /**
-   * Obtains the data for the Direct Debit payment instrument.
-   *
-   * @return mixed
-   * @throws \CRM_Extension_Exception
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getDDPaymentMethod() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'name' => 'direct_debit',
-      'option_group_id' => 'payment_instrument',
-      'options' => ['limit' => 0],
-    ]);
-
-    if ($result['count'] > 0) {
-      return $result['values'][0];
-    }
-
-    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
-  }
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
 
   /**
    * Calculates receive date for payment plan if payment method is DD.
@@ -96,23 +29,6 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
 
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
     $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
-  }
-
-  /**
-   * Checks if the contribution is being paid for with direct debit.
-   *
-   * @return bool
-   */
-  private function isDirectDebit() {
-    if ($this->params['payment_instrument_id'] === 'direct_debit') {
-      return TRUE;
-    }
-
-    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -6,7 +6,7 @@
  * Implements hook to calculate the receive date of the first contribution of a
  * payment plan.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
 
   /**
    * Calculates receive date for payment plan if payment method is DD.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
@@ -1,0 +1,121 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+
+/**
+ * Class OtherContribution.
+ *
+ * Calculates receive date for contributions beyond the second instalment.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+
+  /**
+   * Number of instalment in payment plan.
+   *
+   * @var int
+   */
+  private $contributionNumber;
+
+  /**
+   * Helper object used to calculate receive dates.
+   *
+   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   */
+  private $receiveDateCalculator;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution constructor.
+   *
+   * @param int $contributionNumber
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($contributionNumber, &$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
+    $this->contributionNumber = $contributionNumber;
+    $this->receiveDateCalculator = $calculator;
+
+    parent::__construct($receiveDate, $params, $settingsManager);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function process() {
+    $previousInstalmentDate = $this->getPreviousContributionReceiveDate();
+    $receiveDate = new DateTime($previousInstalmentDate);
+
+    $recurringContribution = $this->getRecurringContribution();
+    $numberOfIntervals = $recurringContribution['frequency_interval'];
+    $frequencyUnit = $recurringContribution['frequency_unit'];
+
+    switch ($frequencyUnit) {
+      case 'day':
+        $interval = "P{$numberOfIntervals}D";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+
+      case 'week':
+        $interval = "P{$numberOfIntervals}W";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+
+      case 'month':
+        $receiveDate = $this->receiveDateCalculator->getSameDayNextMonth($receiveDate, $numberOfIntervals);
+        break;
+
+      case 'year':
+        $interval = "P{$numberOfIntervals}Y";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+    }
+
+    $this->receiveDate = $receiveDate->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Obtains the receive date of the last contribution in the payment plan.
+   *
+   * @return mixed|string
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPreviousContributionReceiveDate() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id ASC',
+      ],
+    ]);
+
+    return $result['values'][$this->contributionNumber - 2]['receive_date'];
+  }
+
+  /**
+   * Obtains recurrring contribution used for the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContribution() {
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['contribution_recur_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    return [];
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -5,7 +5,7 @@ use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDate
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
 
   /**
    * Helper object used to calculate receive dates.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -1,0 +1,150 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+
+  /**
+   * @inheritDoc
+   */
+  public function process() {
+    if (!$this->isDirectDebit()) {
+      return;
+    }
+
+    if (!$this->isForceOnSecondMonth()) {
+      return;
+    }
+
+    $this->forceSecondInstalmentOnSecondMonth();
+  }
+
+  /**
+   * Checks if setting to force second payment on second month is active.
+   *
+   * Checks if DD settings are configured to force second instalment to be on
+   * second month of membership.
+   *
+   * @return bool
+   */
+  private function isForceOnSecondMonth() {
+    if ($this->ddSettings['second_instalment_date_behaviour'] === SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Forces second instalment to have the first instalment's receive date.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  private function forceSecondInstalmentOnSecondMonth() {
+    $firstContribution = $this->getFirstContribution();
+    $firstContributionReceiveDate = new DateTime($firstContribution['receive_date']);
+    $membershipsStartDate = $this->getMembershipsStartDate($firstContribution);
+
+    $interval = $membershipsStartDate->diff($firstContributionReceiveDate);
+    $dias = $interval->format('%a');
+
+    if ($dias > 30) {
+      $this->receiveDate = $firstContributionReceiveDate->format('Y-m-d H:i:s');
+    }
+  }
+
+  /**
+   * Obteins the first contribution in the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getFirstContribution() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id',
+      ],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Obtains a membership's start date from those related to the payment plan.
+   *
+   * @param array $firstContribution
+   *
+   * @return \DateTime|null
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembershipsStartDate($firstContribution) {
+    $lineItems = $this->getContributionLineItems($firstContribution);
+
+    foreach ($lineItems as $line) {
+      if ($line['entity_table'] != 'civicrm_membership') {
+        continue;
+      }
+
+      $membership = $this->getMembership($line['entity_id']);
+
+      return new DateTime($membership['start_date']);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Obtains the list of line items for the given contribution.
+   *
+   * @param $contribution
+   *
+   * @return array|mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getContributionLineItems($contribution) {
+    $result = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $contribution['id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+     return [];
+  }
+
+  /**
+   * Obtains the given membership's data.
+   *
+   * @param int $membershipID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembership($membershipID) {
+    $result = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'id' => $membershipID,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -395,14 +395,39 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 /**
  * Implements hook_membershipextras_calculateContributionReceiveDate().
  */
-function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
+function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-  $firstReceiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
-    $receiveDate,
-    $contributionCreationParams,
-    $settingsManager
-  );
-  $firstReceiveDateCalculator->process();
+
+  switch ($contributionNumber) {
+    case 1:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    case 2:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    default:
+      $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
+        $contributionNumber,
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager,
+        $calculator
+      );
+      $receiveDateCalculator->process();
+  }
 }
 
 function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -397,6 +397,7 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
 
   switch ($contributionNumber) {
     case 1:
@@ -412,13 +413,13 @@ function manualdirectdebit_membershipextras_calculateContributionReceiveDate($co
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
         $receiveDate,
         $contributionCreationParams,
-        $settingsManager
+        $settingsManager,
+        $calculator
       );
       $receiveDateCalculator->process();
       break;
 
     default:
-      $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
         $contributionNumber,
         $receiveDate,

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -1,0 +1,198 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution as OtherContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param int $numberOfContributions
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, $numberOfContributions, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $receiveDateCalculator = new ReceiveDateCalculator($recurringContribution);
+
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+
+    for ($i = 0; $i < $numberOfContributions; $i++) {
+      $receiveDate = $i === 0 ? $firstInstalmentReceiveDate : $receiveDateCalculator->calculate($i + 1);
+      $contribution = ContributionFabricator::fabricate([
+        'currency' => NULL,
+        'source' => NULL,
+        'contact_id' => $contact['id'],
+        'fee_amount' => 0,
+        'net_amount' => $params['amount'] / $params['installments'],
+        'total_amount' => $params['amount'] / $params['installments'],
+        'receive_date' => $receiveDate,
+        'payment_instrument_id' => 'direct_debit',
+        'financial_type_id' => 'Member Dues',
+        'is_test' => 0,
+        'contribution_status_id' => 'Pending',
+        'is_pay_later' => TRUE,
+        'skipLineItem' => 1,
+        'skipCleanMoney' => TRUE,
+        'contribution_recur_id' => $recurringContribution['id'],
+      ]);
+      LineItemFabricator::fabricate([
+        'entity_table' => 'civicrm_membership',
+        'entity_id' => $membership['id'],
+        'contribution_id' => $contribution['id'],
+        'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+        'label' => $mainMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $contribution['total_amount'],
+        'line_total' => $contribution['total_amount'],
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 0,
+      ]);
+    }
+
+    return $recurringContribution;
+  }
+
+  public function testReceiveDateCalculationOfPaymentsAboveSecondInstalment() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2002-12-29';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, 3, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 15,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settingsManager = $this->buildSettingsManagerMock([]);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
+      4,
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-04-15 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -68,7 +68,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
   /**
    * Builds a mock class to manage DD settings.
    *
-   * @return mixed
+   * @return \CRM_ManualDirectDebit_Common_SettingsManager
    */
   private function buildSettingsManagerMock($settings) {
     $settingsManager = $this->createMock(SettingsManager::class);
@@ -77,6 +77,23 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
       ->willReturn(array_merge($this->defaultDDSettings, $settings));
 
     return $settingsManager;
+  }
+
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $dayNextMonth
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($dayNextMonth) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($dayNextMonth));
+
+    return $calculator;
   }
 
   /**
@@ -182,7 +199,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
     $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
 
     $settingsManager = $this->buildSettingsManagerMock([]);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-04-15');
     $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
       4,
       $receiveDate,

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -79,6 +79,23 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     return $settingsManager;
   }
 
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $dayNextMonth
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($dayNextMonth) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($dayNextMonth));
+
+    return $calculator;
+  }
+
   public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
     $membershipStartDate = '2020-01-01';
     $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
@@ -97,7 +114,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
@@ -128,7 +145,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-15');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
@@ -159,7 +176,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-03-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -1,0 +1,244 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($firstInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenStartDateToFirstPaymentIsLessThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenSettingIsSet() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $contribution = ContributionFabricator::fabricate([
+      'currency' => NULL,
+      'source' => NULL,
+      'contact_id' => $contact['id'],
+      'fee_amount' => 0,
+      'net_amount' => $params['amount'] / $params['installments'],
+      'total_amount' => $params['amount'] / $params['installments'],
+      'receive_date' => $firstInstalmentReceiveDate,
+      'payment_instrument_id' => 'direct_debit',
+      'financial_type_id' => 'Member Dues',
+      'is_test' => 0,
+      'contribution_status_id' => 'Pending',
+      'is_pay_later' => TRUE,
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'contribution_recur_id' => $recurringContribution['id'],
+    ]);
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+    LineItemFabricator::fabricate([
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'contribution_id' => $contribution['id'],
+      'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+      'label' => $mainMembershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $contribution['total_amount'],
+      'line_total' => $contribution['total_amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 0,
+    ]);
+
+    return $recurringContribution;
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -6,6 +6,7 @@ use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
 use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
 use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
 
 /**
@@ -64,6 +65,20 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     return $result;
   }
 
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
   public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
     $membershipStartDate = '2020-01-01';
     $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
@@ -81,15 +96,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 
@@ -102,7 +116,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
 
     $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
-      'amount' => 1200,
+      'amount' => 120,
       'frequency_unit' => 'month',
       'frequency_interval' => 1,
       'installments' => 12,
@@ -113,15 +127,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 
@@ -145,15 +158,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 


### PR DESCRIPTION
## Overview
Using the "Second Instalment Date Behaviour" setting, we need to implement the logic for each option:
- Take second instalment 1 month after the first instalment (Default): Here, the date of the second instalment is relative to the date of the first instalment. If the first instalment is delayed due to the fact that the first instalment payment run date in the first month was missed, the second instalment will be 1 month from that date. All following instalments will be 1 month following the previous. This might be preferable for ensuring that members do not have to pay for multiple instalments in the same month, but it may mean that the final instalment for a membership is taken in the month after the membership has expired, which might be undesirable from your organisations perspective.
- Take second instalment in the second month of membership: Here, the system will always take the second instalment in the second month of membership. In some cases this will mean that both the first instalment and the second instalment will be taken in the second month of membership, if for example, the first instalment payment run date in the first month was missed. 

## Before
Only the receive date of the first instalment was changed, according to available first instruction and payment collection dates.

## After
Implemented CalculateContributionReceiveDate hook to alter the receive date of instalments > 1, following the logic needed by checking the "Second Instalment Date Behaviour" setting. Basically, receive dates will only neeed to be altered if the setting is set to **Take second instalment in the second month of membership**. In that case, the second instalment receive date will be the second cycle date period.
