### PR TITLE
IO-125: Fix Issues With Settings Form

### DIFF
--- a/CRM/ManualDirectDebit/Form/Configurations.php
+++ b/CRM/ManualDirectDebit/Form/Configurations.php
@@ -16,7 +16,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $mandateConfigs = [];
 
   /**
@@ -25,8 +24,14 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $paymentConfigs = [];
+
+  /**
+   * Contains array of settings' names for Instalment Configs Section.
+   *
+   * @var array
+   */
+  private $instalmentConfigs = [];
 
   /**
    * Contains array of names, which must be displayed
@@ -34,7 +39,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $reminderConfig = [];
 
   /**
@@ -43,7 +47,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $batchConfig = [];
 
   public function buildQuickForm() {
@@ -51,7 +54,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
 
     $fieldsWithHelp = [];
     $allowedConfigFields  = SettingsManager::getConfigFields();
-    foreach ($allowedConfigFields  as $name => $config) {
+    foreach ($allowedConfigFields as $name => $config) {
       $this->add(
         $config['html_type'],
         $name,
@@ -82,6 +85,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
 
     $this->assign('mandateConfigSection', $this->mandateConfigs);
     $this->assign('paymentConfigSection', $this->paymentConfigs);
+    $this->assign('instalmentConfigSection', $this->instalmentConfigs);
     $this->assign('reminderConfigSection', $this->reminderConfig);
     $this->assign('batchConfigSection', $this->batchConfig);
     $this->assign('fieldsWithHelp', $fieldsWithHelp);
@@ -92,7 +96,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
     $allowedConfigFields = SettingsManager::getConfigFields();
     $submittedValues = $this->exportValues();
     $valuesToSave = array_intersect_key($submittedValues, $allowedConfigFields);
-      civicrm_api3('setting', 'create', $valuesToSave);
+    civicrm_api3('setting', 'create', $valuesToSave);
   }
 
   /**
@@ -101,12 +105,18 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    * @see CRM_Core_Form::setDefaultValues()
    */
   public function setDefaultValues() {
-    $currentValues = civicrm_api3('setting', 'get',
-      ['return' => array_keys(SettingsManager::getConfigFields())]);
+    $settingsMetaData = SettingsManager::getConfigFields();
+    $currentValues = civicrm_api3('setting', 'get', [
+      'return' => array_keys($settingsMetaData),
+    ]);
     $defaults = [];
     $domainID = CRM_Core_Config::domainID();
-    foreach ($currentValues['values'][$domainID] as $name => $value) {
-      $defaults[$name] = $value;
+
+    foreach ($settingsMetaData as $settingName => $setting) {
+      $defaults[$settingName] = CRM_Utils_Array::value('default', $setting);
+      if (isset($currentValues['values'][$domainID][$settingName])) {
+        $defaults[$settingName] = $currentValues['values'][$domainID][$settingName];
+      }
     }
 
     return $defaults;
@@ -128,6 +138,10 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
         $this->paymentConfigs[] = $name;
         break;
 
+      case 'instalment_config':
+        $this->instalmentConfigs[] = $name;
+        break;
+
       case 'reminder_config':
         $this->reminderConfig[] = $name;
         break;
@@ -135,7 +149,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
       case 'batch_config':
         $this->batchConfig[] = $name;
         break;
-
     }
   }
 

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -98,7 +98,7 @@ return [
     'quick_form_type' => 'Element',
     'default' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     'is_required' => TRUE,
-    'is_help' => FALSE,
+    'is_help' => TRUE,
     'html_attributes' => [
       SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER => ts('Take second instalment 1 month after the first instalment'),
       SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH => ts('Take second instalment in the second month of membership'),
@@ -107,7 +107,7 @@ return [
       'class' => 'crm-select2',
       'placeholder' => ts('- select -'),
     ],
-    'section' => 'payment_config',
+    'section' => 'instalment_config',
   ],
   'manualdirectdebit_days_in_advance_for_collection_reminder' => [
     'group_name' => 'Manual Direct Debit',
@@ -147,7 +147,6 @@ return [
  * @param int $limit
  *
  * @return  array
- *
  */
 function generateSequenceNumbers($limit) {
   $sequence = [];

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
@@ -20,10 +20,43 @@ contribution should the Direct Debit Payment Collection Reminder
 be sent to the user.{/ts}
 {/htxt}
 
+{htxt id="manualdirectdebit_second_instalment_date_behaviour"}
+  <p>
+    {ts}You can specify how you would like the system to calculate the date for the
+    second instalment for memberships paid in monthly instalments. The options
+    are:{/ts}
+  </p>
+  <ol>
+    <li>
+      <b>{ts}Take the second instalment 1 month after the first instalment(Default): {/ts}</b>
+      {ts}
+        Here, the date of the second instalment is relative to the date of the
+        first instalment. If the first instalment is delayed due to the fact that
+        the first instalment payment run date in the first month was missed, the
+        second instalment will be 1 month from that date. All following
+        instalments will be 1 month following the previous. This might be
+        preferable for ensuring that members do not have to pay for multiple
+        instalments in the same month, but it may mean that the final instalment
+        for a membership is taken in the month after the membership has expired,
+        which might be undesirable from your organisations perspective.
+      {/ts}
+    </li>
+    <li>
+      <b>{ts}Take the second instalment in the second month of membership: {/ts}</b>
+      {ts}
+        Here, the system will always take the second instalment in the second
+        month of membership. In some cases this will mean that both the first
+        instalment and the second instalment will be taken in the second month
+        of membership, if for example, the first instalment payment run date in
+        the first month was missed.
+      {/ts}
+    </li>
+  </ol>
+{/htxt}
+
 {htxt id="inactivity_code-title"}
   {ts}Mandates with inactive codes will not be selectable when
 creating a new Direct Debit contribution/ payment plan.
 Mandates and contributions that link to mandates with these
 codes will not be included in the batch.{/ts}
 {/htxt}
-

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
@@ -2,7 +2,7 @@
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  <h3>{ts}Mandate config{/ts}</h3>
+  <h3>{ts}Mandate Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$mandateConfigSection item=elementName}
@@ -15,7 +15,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Payment config{/ts}</h3>
+  <h3>{ts}Payment Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$paymentConfigSection item=elementName}
@@ -28,7 +28,20 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Reminder config{/ts}</h3>
+  <h3>Instalment Config</h3>
+  <table class="form-layout-compressed">
+    <tbody>
+    {foreach from=$instalmentConfigSection item=elementName}
+      <tr>
+        <td class="label">{$form.$elementName.label}</td>
+        <td>{$form.$elementName.html}
+          {if $fieldsWithHelp.$elementName}{help id=$form.$elementName.name}{/if}
+        </td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
+  <h3>{ts}Reminder Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$reminderConfigSection item=elementName}
@@ -41,7 +54,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Batch config{/ts}</h3>
+  <h3>{ts}Batch Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
     {foreach from=$batchConfigSection item=elementName}


### PR DESCRIPTION
## Overview
Issues were found on the DD configurations form:

1. Sub heading "Instalment Config' which is given in the ticket screenshot is missing. New setting is displayed under the existing "Payment config' sub heading.
2. Help icon for the new setting is missing. Hence unable to validate the help text given in the ticket description
3. Should we update capitalization for sub headings on the screen? 
4. Drop down option default value should be  "Take second instalment 1 month after the first instalment" , but it is not set and the value is blank at first 

## Before
1. Heading was missing.
2. Help texts were missing for the new setting.
3. Titles of each group were not properly capitalized.
4. Default values were not being taken into account on the whole form. 

![image](https://user-images.githubusercontent.com/21999940/103684395-7e06f180-4f59-11eb-82fe-76a1dbb13894.png)

## After
1. Added new Instalment Config group with the new setting.
2. Added help texts for the setting.
3. Capitalized titles of each heading.
4. Changed the method that calculated form default values so it takes into account those defined in each settings meta-data.

![image](https://user-images.githubusercontent.com/21999940/103684450-91b25800-4f59-11eb-8ef3-4885d73d00b1.png)
