### PR TITLE
MAE-423: Fix Direct Debit Search options

### DIFF
--- a/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
+++ b/CRM/ManualDirectDebit/BAO/RecurrMandateRef.php
@@ -90,7 +90,8 @@ class CRM_ManualDirectDebit_BAO_RecurrMandateRef extends CRM_ManualDirectDebit_D
 
     if (isset($queryResult->id) && !empty($queryResult->id)) {
       return $queryResult->id;
-    } else {
+    }
+    else {
       return NULL;
     }
   }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -453,7 +453,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     }
 
     $this->addContributionReceiveDateCondition($query);
-    $this->addContributionCancelDateCondition($query);
 
     if ($this->notPresent) {
       $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
@@ -640,30 +639,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     if (!empty($this->params['receive_date_high'])) {
       $query->where('DATE_FORMAT(civicrm_contribution.receive_date, "%Y%m%d") <= @receive_date_end',
                      ['receive_date_end' => date('Ymd', strtotime($this->params['receive_date_high']))]
-                   );
-    }
-  }
-
-  /**
-   * Add query where condition as per relative cancel date.
-   *
-   * @param $query
-   */
-  private function addContributionCancelDateCondition(&$query) {
-    if (!empty($this->params['contribution_cancel_date_relative'])) {
-      $relativeDate = explode('.', $this->params['contribution_cancel_date_relative']);
-      $date = CRM_Utils_Date::relativeToAbsolute($relativeDate[0], $relativeDate[1]);
-      $query->where('civicrm_contribution.cancel_date >= @cancel_date_start', ['cancel_date_start' => $date['from']]);
-      $query->where('civicrm_contribution.cancel_date <= @cancel_date_end', ['cancel_date_end' => $date['to']]);
-    }
-    if (!empty($this->params['contribution_cancel_date_low'])) {
-      $query->where('civicrm_contribution.cancel_date >= @cancel_date_start',
-                     ['cancel_date_start' => date('Ymd', strtotime($this->params['contribution_cancel_date_low']))]
-                   );
-    }
-    if (!empty(!empty($this->params['contribution_cancel_date_high']))) {
-      $query->where('civicrm_contribution.cancel_date <= @cancel_date_end',
-                     ['cancel_date_end' => date('Ymd', strtotime($this->params['contribution_cancel_date_high']))]
                    );
     }
   }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -221,6 +221,22 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'op' => 'IN',
         'field' => 'civicrm_contribution_recur.contribution_status_id',
       ],
+      'contact_tags' => [
+        'op' => 'IN',
+        'field' => 'civicrm_entity_tag.tag_id',
+      ],
+      'group' => [
+        'op' => 'IN',
+        'field' => 'civicrm_group_contact.group_id',
+      ],
+      'contribution_amount_low' => [
+        'op' => '>=',
+        'field' => 'civicrm_contribution.total_amount',
+      ],
+      'contribution_amount_high' => [
+        'op' => '<=',
+        'field' => 'civicrm_contribution.total_amount',
+      ],
     ];
   }
 
@@ -435,6 +451,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
     $query->join('civicrm_option_group', 'LEFT JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
     $query->join('civicrm_option_value', 'LEFT JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
+    $query->join('civicrm_entity_tag', 'LEFT JOIN civicrm_entity_tag ON civicrm_entity_tag.entity_id = civicrm_contact.id AND civicrm_entity_tag.entity_table = \'civicrm_contact\'');
+    $query->join('civicrm_group_contact', 'LEFT JOIN civicrm_group_contact ON civicrm_group_contact.contact_id = civicrm_contact.id AND civicrm_group_contact.status = \'Added\'');
 
     //select
     $query->select(implode(' , ', $this->returnValues));

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -169,7 +169,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         'op' => '=',
         'field' => self::DD_MANDATE_TABLE . '.originator_number',
       ],
-      'contribution_status' => [
+      'contribution_status_id' => [
         'op' => 'IN',
         'field' => 'civicrm_contribution.contribution_status_id',
       ],

--- a/CRM/ManualDirectDebit/Common/Activity.php
+++ b/CRM/ManualDirectDebit/Common/Activity.php
@@ -22,7 +22,7 @@ class CRM_ManualDirectDebit_Common_Activity {
       'activity_type_id' => $activityTypeName,
       'activity_date_time' => date('YmdHis'),
       'target_id' => $withContactId,
-      'source_record_id' => $sourceRecordId
+      'source_record_id' => $sourceRecordId,
     ];
 
     if (!empty($addedByContactId)) {

--- a/CRM/ManualDirectDebit/Common/MessageTemplate.php
+++ b/CRM/ManualDirectDebit/Common/MessageTemplate.php
@@ -15,33 +15,32 @@ class CRM_ManualDirectDebit_Common_MessageTemplate {
 
   const MANDATE_UPDATE_MSG_NAME = 'mandate_update_notification';
 
-
   public static function getDefaultDirectDebitTemplates() {
     return [
         [
           'name' => self::SIGN_UP_MSG_NAME,
           'templateFile' => 'PaymentSignUpNotification.tpl',
-          'title' => 'Direct Debit Payment Sign Up Notification'
+          'title' => 'Direct Debit Payment Sign Up Notification',
         ],
         [
           'name' => self::PAYMENT_UPDATE_MSG_NAME,
           'templateFile' => 'PaymentUpdateNotification.tpl',
-          'title' => 'Direct Debit Payment Update Notification'
+          'title' => 'Direct Debit Payment Update Notification',
         ],
         [
           'name' => self::COLLECTION_REMINDER_MSG_NAME,
           'templateFile' => 'PaymentCollectionReminder.tpl',
-          'title' => 'Direct Debit Payment Collection Reminder'
+          'title' => 'Direct Debit Payment Collection Reminder',
         ],
         [
           'name' => self::AUTO_RENEW_MSG_NAME,
           'templateFile' => 'AutoRenewNotification.tpl',
-          'title' => 'Direct Debit Auto-renew Notification'
+          'title' => 'Direct Debit Auto-renew Notification',
         ],
         [
           'name' => self::MANDATE_UPDATE_MSG_NAME,
           'templateFile' => 'MandateUpdateNotification.tpl',
-          'title' => 'Direct Debit Mandate Update Notification'
+          'title' => 'Direct Debit Mandate Update Notification',
         ],
     ];
   }
@@ -66,10 +65,9 @@ class CRM_ManualDirectDebit_Common_MessageTemplate {
       'custom_' . $isDDTemplateCustomFieldId => 1,
     ]);
 
-    if(empty($template['id'])) {
+    if (empty($template['id'])) {
       return FALSE;
     }
-
 
     return TRUE;
   }
@@ -78,7 +76,7 @@ class CRM_ManualDirectDebit_Common_MessageTemplate {
     $messageTemplate = civicrm_api3('MessageTemplate', 'get', [
       'sequential' => 1,
       'return' => ['id'],
-      'msg_title' => $title
+      'msg_title' => $title,
     ]);
 
     return $messageTemplate['count'] == 1 ? $messageTemplate['values'][0]['id'] : FALSE;

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -49,7 +49,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
    * @return int|null
    */
   public static function getMinimumDayForFirstPayment() {
-    if (isset(self::$minimumDaysToFirstPayment) && !empty(self::$minimumDaysToFirstPayment)){
+    if (isset(self::$minimumDaysToFirstPayment) && !empty(self::$minimumDaysToFirstPayment)) {
       return self::$minimumDaysToFirstPayment;
     }
 
@@ -59,11 +59,12 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'sequential' => 1,
     ]);
 
-    if(isset($settingValues[$settingTitle]) && !empty($settingValues[$settingTitle])){
+    if (isset($settingValues[$settingTitle]) && !empty($settingValues[$settingTitle])) {
       self::$minimumDaysToFirstPayment = $settingValues[$settingTitle];
       return self::$minimumDaysToFirstPayment;
-    } else {
-      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"),'required_setting_not_configured');
+    }
+    else {
+      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"), 'required_setting_not_configured');
     }
   }
 
@@ -83,8 +84,8 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
 
     if (!isset($settingValues) || empty($settingValues)) {
       $result = civicrm_api3('System', 'flush');
-      if ($result['is_error'] == 0){
-        $settingValues =  $this->fetchSettingsValues();
+      if ($result['is_error'] == 0) {
+        $settingValues = $this->fetchSettingsValues();
       }
     }
     return $settingValues;
@@ -120,18 +121,17 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
     if (!isset($allowedConfigFields) || empty($allowedConfigFields)) {
       $result = civicrm_api3('System', 'flush');
 
-      if ($result['is_error'] == 0){
-        $allowedConfigFields =  self::fetchSettingFields();
+      if ($result['is_error'] == 0) {
+        $allowedConfigFields = self::fetchSettingFields();
       }
     }
 
     return $allowedConfigFields;
   }
 
-
   private static function fetchSettingFields() {
-    return civicrm_api3('setting', 'getfields',[
-      'filters' =>[ 'group' => 'manualdirectdebit'],
+    return civicrm_api3('setting', 'getfields', [
+      'filters' => ['group' => 'manualdirectdebit'],
     ])['values'];
   }
 

--- a/CRM/ManualDirectDebit/Common/User.php
+++ b/CRM/ManualDirectDebit/Common/User.php
@@ -39,7 +39,6 @@ class CRM_ManualDirectDebit_Common_User {
     return $contactId;
   }
 
-
   /**
    * Gets drupal admin id
    *
@@ -48,7 +47,7 @@ class CRM_ManualDirectDebit_Common_User {
   private static function getDrupalAdminUserId() {
     $dbSelect = db_select('users', 'users');
     $dbSelect->join('users_roles', 'roles', 'roles.uid = users.uid');
-    $drupalUserList = $dbSelect->fields('users',['uid'])
+    $drupalUserList = $dbSelect->fields('users', ['uid'])
       ->where('roles.rid = ' . variable_get('user_admin_role'))
       ->range(0, 1)
       ->execute()
@@ -60,7 +59,6 @@ class CRM_ManualDirectDebit_Common_User {
 
     return FALSE;
   }
-
 
   /**
    * Gets contact id by drupal contact id
@@ -74,11 +72,12 @@ class CRM_ManualDirectDebit_Common_User {
       $contactId = civicrm_api3('UFMatch', 'getvalue', [
         'return' => "contact_id",
         'uf_id' => $drupalAdminId,
-        'options' => ['limit' => 1]
+        'options' => ['limit' => 1],
       ]);
 
       return (int) $contactId;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       return FALSE;
     }
   }

--- a/CRM/ManualDirectDebit/Event/Listener/TokenRender.php
+++ b/CRM/ManualDirectDebit/Event/Listener/TokenRender.php
@@ -38,15 +38,17 @@ class CRM_ManualDirectDebit_Event_Listener_TokenRender {
       case 'new_direct_debit_recurring_payment':
       case 'update_direct_debit_recurring_payment':
       case 'offline_direct_debit_auto_renewal':
-      $recurringContributionId = $this->event->context['actionSearchResult']->source_record_id;
+        $recurringContributionId = $this->event->context['actionSearchResult']->source_record_id;
         $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution($recurringContributionId);
         break;
+
       case 'direct_debit_payment_reminder':
         $contributionId = $this->event->context['actionSearchResult']->source_record_id;
         $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Contribution($contributionId);
         break;
+
       case 'direct_debit_mandate_update':
-        $mandateId= $this->event->context['actionSearchResult']->source_record_id;
+        $mandateId = $this->event->context['actionSearchResult']->source_record_id;
         $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Mandate($mandateId);
         break;
     }

--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -164,7 +164,6 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
    */
   private function assignDDPaymentsSearchProperties() {
     $ddCodes = CRM_Core_OptionGroup::values('direct_debit_codes');
-    $paymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, NULL, 'name');
     $recurStatus = $contributionStatus = CRM_Core_OptionGroup::values('contribution_status', FALSE, FALSE, FALSE, NULL, 'name');
     unset($recurStatus[array_search('Cancelled', $contributionStatus)]);
 
@@ -193,16 +192,6 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
       [
         'name' => 'recur_status',
         'value' => array_keys($recurStatus),
-      ],
-      [
-        'name' => 'contribution_status',
-        'value' => [
-          array_search('Pending', $contributionStatus),
-        ],
-      ],
-      [
-        'name' => 'payment_instrument',
-        'value' => array_search('direct_debit', $paymentInstrument),
       ],
     ];
   }

--- a/CRM/ManualDirectDebit/Form/Configurations.php
+++ b/CRM/ManualDirectDebit/Form/Configurations.php
@@ -51,7 +51,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
 
     $fieldsWithHelp = [];
     $allowedConfigFields  = SettingsManager::getConfigFields();
-    foreach ($allowedConfigFields  as $name => $config) {
+    foreach ($allowedConfigFields as $name => $config) {
       $this->add(
         $config['html_type'],
         $name,
@@ -92,7 +92,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
     $allowedConfigFields = SettingsManager::getConfigFields();
     $submittedValues = $this->exportValues();
     $valuesToSave = array_intersect_key($submittedValues, $allowedConfigFields);
-      civicrm_api3('setting', 'create', $valuesToSave);
+    civicrm_api3('setting', 'create', $valuesToSave);
   }
 
   /**

--- a/CRM/ManualDirectDebit/Form/Email/Contribution.php
+++ b/CRM/ManualDirectDebit/Form/Email/Contribution.php
@@ -12,7 +12,8 @@ class CRM_ManualDirectDebit_Form_Email_Contribution extends CRM_Contribute_Form_
     $messageTemplateId = $this->getVar('_submitValues')['template'];
     if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId)) {
       CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon::postProcess($this);
-    } else {
+    }
+    else {
       CRM_Contact_Form_Task_EmailCommon::postProcess($this);
     }
   }

--- a/CRM/ManualDirectDebit/Form/Email/Membership.php
+++ b/CRM/ManualDirectDebit/Form/Email/Membership.php
@@ -9,7 +9,8 @@ class CRM_ManualDirectDebit_Form_Email_Membership extends CRM_Member_Form_Task_E
     $messageTemplateId = $this->getVar('_submitValues')['template'];
     if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId)) {
       CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon::postProcess($this);
-    } else {
+    }
+    else {
       CRM_Contact_Form_Task_EmailCommon::postProcess($this);
     }
   }

--- a/CRM/ManualDirectDebit/Form/Mandate/Create.php
+++ b/CRM/ManualDirectDebit/Form/Mandate/Create.php
@@ -195,7 +195,8 @@ class CRM_ManualDirectDebit_Form_Mandate_Create extends CRM_Core_Form {
       $sqlSelectDebitMandateID = "SELECT MAX(id) as id FROM `civicrm_file`";
       $queryResult = CRM_Core_DAO::executeQuery($sqlSelectDebitMandateID);
       $queryResult->fetch();
-    } catch (Exception $exception) {
+    }
+    catch (Exception $exception) {
       $transaction->rollback();
 
       throw $exception;
@@ -234,7 +235,8 @@ class CRM_ManualDirectDebit_Form_Mandate_Create extends CRM_Core_Form {
   private function getMinimumDayForFirstPayment() {
     try {
       $minimumDaysToFirstPayment = CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
-    } catch (CiviCRM_API3_Exception $error) {
+    }
+    catch (CiviCRM_API3_Exception $error) {
       $minimumDaysToFirstPayment = 0;
     }
 

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -85,8 +85,8 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
     $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("dd_ref");
     $ddRefElementNameId = $this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]['element_name'];
     unset($this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]);
-    foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName){
-      if ($requiredFieldsName == $ddRefElementNameId){
+    foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName) {
+      if ($requiredFieldsName == $ddRefElementNameId) {
         unset($this->form->_required[$requiredFieldsId]);
       }
     }

--- a/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/InjectCustomGroup.php
@@ -68,7 +68,8 @@ class CRM_ManualDirectDebit_Hook_BuildForm_InjectCustomGroup {
   private function getMinimumDayForFirstPayment() {
     try {
       $minimumDaysToFirstPayment = CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
-    } catch (CiviCRM_API3_Exception $error) {
+    }
+    catch (CiviCRM_API3_Exception $error) {
       $minimumDaysToFirstPayment = 0;
     }
 

--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -23,7 +23,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
   /**
    * List of DD codes in the system.
    *
-   * @var
+   * @var array
    */
   private static $ddCodes;
 
@@ -83,7 +83,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
     $extraAttributes = [];
     $isEditRecurContributionForm = $this->form->_formName == 'UpdateSubscription';
     if ($isEditRecurContributionForm) {
-      $extraAttributes['disabled'] = true;
+      $extraAttributes['disabled'] = TRUE;
     }
 
     $contactID = CRM_Utils_Request::retrieve('cid', 'Int');
@@ -105,8 +105,8 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
    */
   private function getNewlyCreatedMandateID($contactID) {
     $sqlSelectDebitMandateID = "
-      SELECT MAX(`id`) AS id 
-      FROM " . CRM_ManualDirectDebit_Common_MandateStorageManager::DIRECT_DEBIT_TABLE_NAME . " 
+      SELECT MAX(`id`) AS id
+      FROM " . CRM_ManualDirectDebit_Common_MandateStorageManager::DIRECT_DEBIT_TABLE_NAME . "
       WHERE `entity_id` = %1
       AND id NOT IN (
         SELECT mandate_id
@@ -151,8 +151,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
         $currentMandate['dd_ref'] . ' - ' .
         $this->getMandateCode($currentMandate['dd_code']) . ' - ' .
         $currentMandate['ac_number'] . ' - ' .
-        CRM_Utils_Date::customFormat($currentMandate['start_date'], $config->dateformatFull)
-      ;
+        CRM_Utils_Date::customFormat($currentMandate['start_date'], $config->dateformatFull);
     }
 
     $result[0] = 'Create New Mandate...';

--- a/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/UpdateSubscription.php
@@ -70,7 +70,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_UpdateSubscription {
 
   private function preventChangingDirectDebitPaymentMethod() {
     CRM_Core_Region::instance('page-body')->add([
-      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
+      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl",
     ]);
   }
 

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -71,7 +71,7 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
     $mandateReference = NULL;
     if (!empty($contactLastRecurContribution['values'][0]['id'])) {
       $contributionRecurId = $contactLastRecurContribution['values'][0]['id'];
-      $mandateReference =  CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
+      $mandateReference = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
     }
 
     if (!empty($mandateReference)) {

--- a/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Mandate/MandateDataGenerator.php
@@ -116,7 +116,8 @@ class CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator {
       $date = new DateTime();
       $date->setTimestamp(strtotime($dateString));
       $formattedDate = $date->format('Y-m-d H:i:s');
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $formattedDate = $this->generateCurrentDateAndTime();
     }
 

--- a/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ContributionRecur/DirectDebitFieldsInjector.php
@@ -48,13 +48,13 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
    * @return bool
    */
   public function inject() {
-    if(! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($this->currentPaymentMethodId)){
+    if (!CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($this->currentPaymentMethodId)) {
       return FALSE;
     }
 
     $mandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($this->currentContributionId);
 
-    if (is_null($mandateId)){
+    if (is_null($mandateId)) {
       CRM_Core_Session::setStatus(t("Mandate doesn't exist"), $title = 'Error', $type = 'alert');
 
       return FALSE;
@@ -89,7 +89,6 @@ class CRM_ManualDirectDebit_Hook_PageRun_ContributionRecur_DirectDebitFieldsInje
         ]);
     }
   }
-
 
   /**
    * Gets mandate cgcount

--- a/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
@@ -9,7 +9,7 @@ class CRM_ManualDirectDebit_Hook_PageRun_TabPage {
   /**
    * Contribution Id
    *
-   * @var
+   * @var int
    */
   private $contributionId;
 

--- a/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Activity.php
+++ b/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Activity.php
@@ -3,7 +3,7 @@
 /**
  * Process 'postOfflineAutoRenewal' hook and create activity
  */
-class  CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Activity extends CRM_ManualDirectDebit_Hook_Common_PostActivityBase {
+class CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Activity extends CRM_ManualDirectDebit_Hook_Common_PostActivityBase {
 
   /**
    * Creates activity

--- a/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Mandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostOfflineAutoRenewal/Mandate.php
@@ -2,7 +2,7 @@
 
 use CRM_ManualDirectDebit_BAO_RecurrMandateRef as RecurrMandateRef;
 
-class  CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate {
+class CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate {
 
   private $contributionRecurId;
 

--- a/CRM/ManualDirectDebit/Hook/PostProcess/RecurContribution/DirectDebitMandate.php
+++ b/CRM/ManualDirectDebit/Hook/PostProcess/RecurContribution/DirectDebitMandate.php
@@ -43,4 +43,5 @@ class CRM_ManualDirectDebit_Hook_PostProcess_RecurContribution_DirectDebitMandat
 
     return [];
   }
+
 }

--- a/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
+++ b/CRM/ManualDirectDebit/Hook/PostSave/MembershipPayment/MandateCreator.php
@@ -70,7 +70,7 @@ class CRM_ManualDirectDebit_Hook_PostSave_MembershipPayment_MandateCreator {
    */
   public function assignMandateForContributions() {
 
-    if (! $this->isContributionRecurring() || ! $this->isCurrentPaymentInstrumentDirectDebit()) {
+    if (!$this->isContributionRecurring() || !$this->isCurrentPaymentInstrumentDirectDebit()) {
       return FALSE;
     }
 

--- a/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
+++ b/CRM/ManualDirectDebit/Hook/ValidateForm/MandateValidator.php
@@ -38,9 +38,10 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
   public function checkValidation() {
     $currentPaymentInstrumentId = $this->getCurrentPaymentInstrumentId();
 
-    if ( ! CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrumentId) || $this->isEditForm()) {
+    if (!CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($currentPaymentInstrumentId) || $this->isEditForm()) {
       $this->turnOffDirectDebitValidation();
-    } else {
+    }
+    else {
       $this->checkSettings();
       $this->validateMandateIsNotEmpty();
     }
@@ -82,7 +83,8 @@ class CRM_ManualDirectDebit_Hook_ValidateForm_MandateValidator {
   private function checkSettings() {
     try {
       CRM_ManualDirectDebit_Common_SettingsManager::getMinimumDayForFirstPayment();
-    } catch (CiviCRM_API3_Exception $error) {
+    }
+    catch (CiviCRM_API3_Exception $error) {
       $currentError = $this->form->getVar('_errors');
       $currentError[] = ['directDebitMandate' => "Please, configure minimum days to first payment"];
       $this->form->setVar('_errors', $currentError);

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Contribution.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Contribution.php
@@ -27,4 +27,5 @@ class CRM_ManualDirectDebit_Mail_DataCollector_Contribution extends CRM_ManualDi
   protected function setContributionId() {
     $this->contributionId = $this->enteredContributionId;
   }
+
 }

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Mandate.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Mandate.php
@@ -3,7 +3,7 @@
 /**
  * Collect data for message template by mandate id
  */
-class CRM_ManualDirectDebit_Mail_DataCollector_Mandate extends CRM_ManualDirectDebit_Mail_DataCollector_Base{
+class CRM_ManualDirectDebit_Mail_DataCollector_Mandate extends CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
   /**
    * Entered Mandate id
@@ -32,7 +32,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_Mandate extends CRM_ManualDirectD
       $this->contributionId = $contributionId;
     }
     else {
-      throw new CiviCRM_API3_Exception("Can't find contribution id by mandate id",'dd_1');
+      throw new CiviCRM_API3_Exception("Can't find contribution id by mandate id", 'dd_1');
     }
   }
 
@@ -51,7 +51,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_Mandate extends CRM_ManualDirectD
   ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->enteredMandateId, 'Integer']
+      1 => [$this->enteredMandateId, 'Integer'],
     ]);
 
     while ($dao->fetch()) {

--- a/CRM/ManualDirectDebit/Mail/DataCollector/Membership.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/Membership.php
@@ -3,7 +3,7 @@
 /**
  * Collect data for message template by membership id
  */
-class CRM_ManualDirectDebit_Mail_DataCollector_Membership extends CRM_ManualDirectDebit_Mail_DataCollector_Base{
+class CRM_ManualDirectDebit_Mail_DataCollector_Membership extends CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
   /**
    * Entered membership id
@@ -30,7 +30,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_Membership extends CRM_ManualDire
       $this->contributionId = $contributionId;
     }
     else {
-      throw new CiviCRM_API3_Exception("Can't find contribution id by membership id",'dd_2');
+      throw new CiviCRM_API3_Exception("Can't find contribution id by membership id", 'dd_2');
     }
   }
 
@@ -43,7 +43,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_Membership extends CRM_ManualDire
     $result = civicrm_api3('MembershipPayment', 'get', [
       'sequential' => 1,
       'membership_id' => $this->enteredMembershipId,
-      'options' => ['sort' => 'contribution_id DESC', 'limit' => 1]
+      'options' => ['sort' => 'contribution_id DESC', 'limit' => 1],
     ]);
 
     return $result['count'] == 1 ? $result['values'][0]['contribution_id'] : FALSE;

--- a/CRM/ManualDirectDebit/Mail/DataCollector/RecurringContribution.php
+++ b/CRM/ManualDirectDebit/Mail/DataCollector/RecurringContribution.php
@@ -3,7 +3,7 @@
 /**
  * Collect data for message template by recurring contribution id
  */
-class CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution extends CRM_ManualDirectDebit_Mail_DataCollector_Base{
+class CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution extends CRM_ManualDirectDebit_Mail_DataCollector_Base {
 
   /**
    * Entered recurring contribution id
@@ -30,7 +30,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution extends CRM
       $this->contributionId = $contributionId;
     }
     else {
-      throw new CiviCRM_API3_Exception("Can't find contribution id by recurring contribution id",'dd_3');
+      throw new CiviCRM_API3_Exception("Can't find contribution id by recurring contribution id", 'dd_3');
     }
   }
 
@@ -43,7 +43,7 @@ class CRM_ManualDirectDebit_Mail_DataCollector_RecurringContribution extends CRM
     $result = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
       'contribution_recur_id' => $this->enteredRecurringContributionId,
-      'options' => ['sort' => 'id DESC', 'limit' => 1]
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
     ]);
 
     return $result['count'] == 1 ? $result['values'][0]['id'] : FALSE;

--- a/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/MembershipEmailCommon.php
@@ -168,11 +168,11 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
       SELECT membership.id AS contribution_id 
       FROM civicrm_membership AS membership
       WHERE membership.contact_id = %1
-        AND membership.id IN(". $validatedMembershipIdsImploded .")
+        AND membership.id IN(" . $validatedMembershipIdsImploded . ")
     ";
 
     $dao = CRM_Core_DAO::executeQuery($query, [
-      1 => [(int) $contactId, 'Integer']
+      1 => [(int) $contactId, 'Integer'],
     ]);
 
     $contactMembershipIds = [];

--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -50,7 +50,7 @@ class CRM_ManualDirectDebit_Page_AJAX {
     $params['rp'] = $rowCount;
 
     $params['context'] = $context;
-    $params['offset'] = ($params['page'] - 1) * $params['rp'];
+    $params['offset'] = $offset;
     $params['rowCount'] = $params['rp'];
     $params['sort'] = CRM_Utils_Array::value('sortBy', $params);
     $params['total'] = 0;

--- a/CRM/ManualDirectDebit/Queue/BatchSubmission.php
+++ b/CRM/ManualDirectDebit/Queue/BatchSubmission.php
@@ -7,11 +7,11 @@ class CRM_ManualDirectDebit_Queue_BatchSubmission {
   private static $queue;
 
   public static function getQueue() {
-    if(!self::$queue) {
+    if (!self::$queue) {
       self::$queue = CRM_Queue_Service::singleton()->create([
         'type' => 'Sql',
         'name' => self::QUEUE_NAME,
-        'reset' => false,
+        'reset' => FALSE,
       ]);
     }
 

--- a/CRM/ManualDirectDebit/Queue/Build/BaseBuilder.php
+++ b/CRM/ManualDirectDebit/Queue/Build/BaseBuilder.php
@@ -23,4 +23,5 @@ abstract class CRM_ManualDirectDebit_Queue_Build_BaseBuilder {
   }
 
   abstract public function buildQueue();
+
 }

--- a/CRM/ManualDirectDebit/Queue/Build/InstructionsQueueBuilder.php
+++ b/CRM/ManualDirectDebit/Queue/Build/InstructionsQueueBuilder.php
@@ -41,4 +41,5 @@ class CRM_ManualDirectDebit_Queue_Build_InstructionsQueueBuilder extends CRM_Man
     );
     $this->queue->createItem($task);
   }
+
 }

--- a/CRM/ManualDirectDebit/Queue/Build/PaymentsQueueBuilder.php
+++ b/CRM/ManualDirectDebit/Queue/Build/PaymentsQueueBuilder.php
@@ -39,4 +39,5 @@ class CRM_ManualDirectDebit_Queue_Build_PaymentsQueueBuilder extends CRM_ManualD
     );
     $this->queue->createItem($task);
   }
+
 }

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/Completion.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/Completion.php
@@ -10,7 +10,7 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_Completion {
       'id' => $batchId,
       'status_id' => 'Submitted',
       'modified_date' => date('YmdHis'),
-      'modified_id' => $loggedInUserId
+      'modified_id' => $loggedInUserId,
     ]);
 
     $ctx->log->info('Changing batch with Id : ' . $batchId . ' to Submitted');

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/InstructionItem.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/InstructionItem.php
@@ -15,7 +15,7 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_InstructionItem {
       }
     }
 
-    $totalExecutionTime = (microtime(true) - $processingStartTime);
+    $totalExecutionTime = (microtime(TRUE) - $processingStartTime);
     $endProcessingMessage = 'Finished processing the task In : ' . $totalExecutionTime . 'Seconds';
     $ctx->log->info($endProcessingMessage);
 
@@ -33,4 +33,5 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_InstructionItem {
     $query = 'UPDATE civicrm_value_dd_mandate SET civicrm_value_dd_mandate.dd_code = "' . array_search($codeName, $ddCodes) . '" WHERE civicrm_value_dd_mandate.id = ' . $mandateId;
     CRM_Core_DAO::executeQuery($query);
   }
+
 }

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
@@ -19,7 +19,7 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_PaymentItem {
       }
     }
 
-    $totalExecutionTime = (microtime(true) - $processingStartTime);
+    $totalExecutionTime = (microtime(TRUE) - $processingStartTime);
     $endProcessingMessage = 'Finished processing the task In : ' . $totalExecutionTime . 'Seconds';
     $ctx->log->info($endProcessingMessage);
 

--- a/CRM/ManualDirectDebit/ScheduleJob/ReminderOffsetDays.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/ReminderOffsetDays.php
@@ -7,7 +7,7 @@ class CRM_ManualDirectDebit_ScheduleJob_ReminderOffsetDays {
   /**
    * Reminder offset in days
    *
-   * @var NULL|int|false
+   * @var null|int|false
    */
   private static $reminderOffsetDays = NULL;
 
@@ -34,7 +34,7 @@ class CRM_ManualDirectDebit_ScheduleJob_ReminderOffsetDays {
     $settingName = "manualdirectdebit_days_in_advance_for_collection_reminder";
     try {
       $settings = civicrm_api3('setting', 'get', [
-        'return' => [$settingName]
+        'return' => [$settingName],
       ]);
     }
     catch (CiviCRM_API3_Exception $e) {

--- a/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
+++ b/CRM/ManualDirectDebit/ScheduleJob/TargetContribution.php
@@ -53,7 +53,7 @@ class CRM_ManualDirectDebit_ScheduleJob_TargetContribution {
       $contributionDataList[] = [
         "contributionId" => $dao->contribution_id,
         "email" => $dao->email,
-        "contactId" => $dao->contact_id
+        "contactId" => $dao->contact_id,
       ];
     }
 

--- a/CRM/ManualDirectDebit/Test/Fabricator/Batch.php
+++ b/CRM/ManualDirectDebit/Test/Fabricator/Batch.php
@@ -21,7 +21,7 @@ class CRM_ManualDirectDebit_Test_Fabricator_Batch extends BaseFabricator {
   protected static $defaultParams = [
     'name' => 'Direct_Debit_Batch_1',
     'title'   => 'Direct Debit Batch - 1',
-    'status_id' => 1
+    'status_id' => 1,
   ];
 
   /**

--- a/CRM/ManualDirectDebit/Test/Fabricator/Batch.php
+++ b/CRM/ManualDirectDebit/Test/Fabricator/Batch.php
@@ -1,0 +1,41 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Base as BaseFabricator;
+
+/**
+ * Class CRM_ManualDirectDebit_Test_Fabricator_Batch.
+ */
+class CRM_ManualDirectDebit_Test_Fabricator_Batch extends BaseFabricator {
+
+  /**
+   * Entity's name.
+   *
+   * @var string
+   */
+  protected static $entityName = 'Batch';
+
+  /**
+   * Array if default parameters to be used to create a batch.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [
+    'name' => 'Direct_Debit_Batch_1',
+    'title'   => 'Direct Debit Batch - 1',
+    'status_id' => 1
+  ];
+
+  /**
+   * Fabricates a batch with the given parameters.
+   *
+   * @param array $params
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(static::$defaultParams, $params);
+
+    return parent::fabricate($params);
+  }
+
+}

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -37,9 +37,9 @@
           {ts}Edit Search Criteria{/ts}
         </div>
         <div class="crm-accordion-body">
-          <div id="searchForm" class="crm-block crm-form-block crm-contact-custom-search-activity-search-form-block">
+          <div id="manualDirectDebitSearchForm" class="crm-block crm-form-block crm-manual-direct-debit-search-form-block">
             <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
-            <table class="form-layout-compressed">
+            <table class="form-layout">
               <tr>
                 <td class="font-size12pt" colspan="2">
                   {$form.sort_name.label}<br>
@@ -256,7 +256,7 @@ function buildTransactionSelectorAssign() {
       aoData = aoData.concat(searchData);
 
 
-      CRM.$('#searchForm :input').each(function() {
+      CRM.$('#manualDirectDebitSearchForm :input').each(function() {
         if (CRM.$(this).val()) {
           aoData.push(
             {name:CRM.$(this).attr('id'), value: CRM.$(this).val()}

--- a/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/BatchTransaction.tpl
@@ -63,7 +63,7 @@
                 <td>&nbsp;</td>
               {/if}
               </tr>
-              {include file="CRM/Contribute/Form/Search/Common.tpl"}
+              {include file="CRM/ManualDirectDebit/Form/Search/Common.tpl"}
             </table>
       <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
           </div>

--- a/templates/CRM/ManualDirectDebit/Form/Search/Common.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Search/Common.tpl
@@ -1,0 +1,46 @@
+<tr>
+    {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="receive_date" colspan="2"}
+</tr>
+<tr>
+  <td>
+    <label>{ts}Contribution Amounts{/ts}</label> <br/>
+      {$form.contribution_amount_low.label}
+      {$form.contribution_amount_low.html} &nbsp;&nbsp;
+      {$form.contribution_amount_high.label}
+      {$form.contribution_amount_high.html} </td>
+  <td>
+    <label>{$form.contribution_status_id.label}</label> <br/>
+      {$form.contribution_status_id.html} </td>
+</tr>
+<tr>
+  <td>
+    <label>{ts}Currency{/ts}</label> <br/>
+      {$form.contribution_currency_type.html|crmAddClass:twenty}
+  </td>
+    {if $form.contribution_batch_id.html }
+      <td>
+          {$form.contribution_batch_id.label}<br/>
+          {$form.contribution_batch_id.html}
+      </td>
+    {/if}
+</tr>
+<tr>
+  <td>
+    <div class="float-left">
+      <label>{$form.contribution_payment_instrument_id.label}</label> <br/>
+        {$form.contribution_payment_instrument_id.html|crmAddClass:twenty}
+    </div>
+  </td>
+</tr>
+<tr>
+  <td>
+    <label>{ts}Financial Type{/ts}</label> <br/>
+      {$form.financial_type_id.html|crmAddClass:twenty}
+  </td>
+</tr>
+<tr>
+  <td>
+      {$form.contribution_product_id.label} <br/>
+      {$form.contribution_product_id.html|crmAddClass:twenty}
+  </td>
+</tr>

--- a/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
@@ -1,0 +1,520 @@
+<?php
+
+use CRM_ManualDirectDebit_Test_Fabricator_Mandate as MandateFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Setting as SettingFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Batch as BatchFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_OriginatorNumber as OriginatorNumberFabricator;
+
+require_once __DIR__ . '/../../../BaseHeadlessTest.php';
+
+/**
+ * Runs tests on RecurrMandateRef.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Batch_TransactionTest extends BaseHeadlessTest {
+
+  /**
+   * @var array
+   */
+  protected $recurringContribution;
+  /**
+   * @var array
+   */
+  protected $mandateStorage;
+  protected $batch;
+  protected $batchTypeId = 0;
+  protected $recurringContributionDDCode = 0;
+
+  private $directDebitPaymentInstrumentId = 0;
+  private $memberDuesFinancialTypeId = 0;
+  private $contributionPendingStatusValue = 0;
+  private $testRollingMembershipType = NULL;
+  private $testRollingMembershipTypePriceFieldValue = NULL;
+  private $tag1 = NULL;
+  private $tag2 = NULL;
+  private $group1 = NULL;
+  private $group2 = NULL;
+  private $contact1 = NULL;
+  private $contact2 = NULL;
+  private $mandate1 = NULL;
+  private $mandate2 = NULL;
+
+  public function setUp() {
+    SettingFabricator::fabricate();
+    $this->mandateStorage = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $this->paymentBatchTypeId = $this->getPaymentBatchTypeId();
+    $this->batch = BatchFabricator::fabricate(['type_id' => $this->paymentBatchTypeId]);
+    $this->originatorNumber = OriginatorNumberFabricator::fabricate()['values'][0]['value'];
+    $this->recurringContributionDDCode = $this->getRecurringContributionDDCode();
+    $this->setUpMembershipType();
+
+    $this->tag1 = $this->createTag(['name' => 'tag1']);
+    $this->tag2 = $this->createTag(['name' => 'tag2']);
+
+    $this->group1 = $this->createGroup(['name' => 'group1']);
+    $this->group2 = $this->createGroup(['name' => 'group2']);
+  }
+
+  /**
+   * Prepare Membership Type
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setUpMembershipType() {
+    $this->directDebitPaymentInstrumentId = $this->getDirectDebitPaymentInstrumentId();
+    $this->memberDuesFinancialTypeId = $this->getMemberDuesFinancialTypeId();
+    $this->contributionPendingStatusValue = $this->getPendingContributionStatusValue();
+
+    $this->testRollingMembershipType = CRM_MembershipExtras_Test_Fabricator_MembershipType::fabricate(
+      [
+        'name' => 'Test Rolling Membership',
+        'period_type' => 'rolling',
+        'minimum_fee' => 120,
+        'duration_interval' => 1,
+        'duration_unit' => 'year',
+      ]);
+
+    $this->testRollingMembershipTypePriceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $this->testRollingMembershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+  }
+
+  /**
+   * Obtains value for the 'Payment' batch type option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPaymentBatchTypeId() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'batch_type',
+      'name' => 'dd_payments',
+    ]);
+  }
+
+  /**
+   * Obtains value for the 'Payment' batch type option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContributionDDCode() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'direct_debit_codes',
+      'name' => 'recurring_contribution',
+    ]);
+  }
+
+  /**
+   * Obtains value for the 'Payment' batch type option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getActiveDDCodes() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'return' => 'value',
+      'option_group_id' => 'direct_debit_codes',
+      'name' => ['IN' => ['first_time_payment', 'recurring_contribution']],
+    ]);
+
+    $activeDDCodes = array_map(function ($item) {
+      return $item['value'];
+    }, $result['values']);
+
+    return implode(',', $activeDDCodes);
+  }
+
+  /**
+   * Obtains value for the 'Pending' contribution status option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPendingContributionStatusValue() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'contribution_status',
+      'name' => 'Pending',
+    ]);
+  }
+
+  /**
+   * Obtains value for direct debit payment instrument option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDirectDebitPaymentInstrumentId() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'payment_instrument',
+      'name' => 'direct_debit',
+    ]);
+  }
+
+  /**
+   * Obtains value for direct debit payment instrument option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMemberDuesFinancialTypeId() {
+    return civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Member Dues',
+    ]);
+  }
+
+  /**
+   * create tag
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createTag($params) {
+    return civicrm_api3('Tag', 'create', [
+      'name' => $params['name'],
+    ]);
+  }
+
+  /**
+   * Add tag to a contact
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function addTagToContact($params) {
+    return civicrm_api3('EntityTag', 'create', [
+      'contact_id' => $params['contact_id'],
+      'tag_id' => $params['tag_id'],
+    ]);
+  }
+
+  /**
+   * create group
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createGroup($params) {
+    return civicrm_api3('Group', 'create', [
+      'name' => $params['name'],
+      'title' => $params['name'],
+    ]);
+  }
+
+  /**
+   * Add Group to a contact
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function addContactToGroup($params) {
+    return civicrm_api3('GroupContact', 'create', [
+      'contact_id' => $params['contact_id'],
+      'group_id' => $params['group_id'],
+    ]);
+  }
+
+  /**
+   * Create payment plan order
+   *
+   * @param array $params
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createPaymentPlanOrder($params) {
+    $paymentPlanMembershipOrder = new CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->contactId = $params['contact_id'];
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-01', strtotime('first day of january this year'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
+    $paymentPlanMembershipOrder->paymentPlanStatus = 'Pending';
+    $paymentPlanMembershipOrder->paymentMethod = 'direct_debit';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $this->testRollingMembershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $this->testRollingMembershipTypePriceFieldValue['id'],
+      'label' => $this->testRollingMembershipType['name'],
+      'qty' => 1,
+      'unit_price' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'line_total' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+    ];
+    $paymentPlan = CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder::fabricate($paymentPlanMembershipOrder);
+
+    // workaround to add mandate to contributions
+    $query = "select id from civicrm_contribution_recur where contact_id = %1";
+    $recurringContributionIds = CRM_Core_DAO::executeQuery($query, [1 => [$params['contact_id'], 'Positive']])->fetchAll();
+    foreach ($recurringContributionIds as $recurringContributionId) {
+      $this->relateMandateToExistingContributions($recurringContributionId, $params['mandate_id']);
+    }
+
+    return $paymentPlan;
+  }
+
+  /**
+   * Relates the given mandate to all the contributions under the given
+   * recurring contribution Id. (copied from CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate)
+   *
+   * @param int $recurringContributionId
+   * @param int $mandateId
+   */
+  private function relateMandateToExistingContributions($recurringContributionId, $mandateId) {
+    $contributions = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $recurringContributionId,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($contributions['count'] < 1) {
+      return;
+    }
+
+    foreach ($contributions['values'] as $payment) {
+      $this->mandateStorage->assignContributionMandate($payment['id'], $mandateId);
+    }
+  }
+
+  /**
+   * Create payment plan order
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createContactAndMandate($params = []) {
+    $contact = ContactFabricator::fabricate($params);
+    $mandate = MandateFabricator::fabricate([
+      'entity_id' => $contact['id'],
+      'originator_number' => $this->originatorNumber,
+      'dd_code' => $this->recurringContributionDDCode,
+    ]);
+
+    return [$contact, $mandate];
+  }
+
+  /**
+   * Obtains search params
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function getSearchParams($params = []) {
+    $offset = 0;
+    $rowCount = 25;
+    $defaultParams = [
+      'page' => ($offset / $rowCount) + 1,
+      'rp' => $rowCount,
+      'context' => 'instructionBatch',
+      'offset' => $offset,
+      'rowCount' => $rowCount,
+      'sort' => NULL,
+      'total' => 0,
+      'entityTable' => 'civicrm_contribution',
+      'originator_number' => $this->originatorNumber,
+      'dd_code' => $this->getActiveDDCodes(),
+      'recur_status' => '1,2,4,5,6,7,8,9,10,11',
+      'contribution_payment_instrument_id' => $this->directDebitPaymentInstrumentId,
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+
+  /**
+   * Tests create recurrMandateRef entity
+   */
+  public function testTransactionSearch() {
+    list($this->contact1, $this->mandate1) = $this->createContactAndMandate([
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+    ]);
+    list($this->contact2, $this->mandate2) = $this->createContactAndMandate([
+      'first_name' => 'Bot',
+      'last_name' => 'Compucorp',
+    ]);
+    $this->createPaymentPlanOrder(['contact_id' => $this->contact1['id'], 'mandate_id' => $this->mandate1['id']]);
+    $this->createPaymentPlanOrder(['contact_id' => $this->contact2['id'], 'mandate_id' => $this->mandate2['id']]);
+
+    $this->searchByDefault();
+    $this->searchByContactTags();
+    $this->searchByGroups();
+    $this->searchByFinancialType();
+    $this->searchByContributionAmount();
+    $this->searchByReceiveDate();
+    $this->searchBySortName();
+  }
+
+  /**
+   * Search by default parameters
+   */
+  private function searchByDefault() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+  }
+
+  /**
+   * Search by contact tags
+   */
+  private function searchByContactTags() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search by an empty tag
+    $params['contact_tags'] = $this->tag1['id'];
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+
+    // Search by one tag
+    $params['contact_tags'] = $this->tag1['id'];
+    $this->addTagToContact(['contact_id' => $this->contact1['id'], 'tag_id' => $this->tag1['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+
+    // Search by two tags
+    $params['contact_tags'] = implode(',', [$this->tag1['id'], $this->tag2['id']]);
+    $this->addTagToContact(['contact_id' => $this->contact2['id'], 'tag_id' => $this->tag2['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+  }
+
+  /**
+   * Search by groups
+   */
+  private function searchByGroups() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search by an empty group
+    $params['group'] = $this->group1['id'];
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+
+    // Search by one group
+    $this->addContactToGroup(['contact_id' => $this->contact1['id'], 'group_id' => $this->group1['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+
+    // Search by two groups (one of them is empty)
+    $params['group'] = implode(',', [$this->group1['id'], $this->group2['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+
+    // Search by two groups
+    $this->addContactToGroup(['contact_id' => $this->contact2['id'], 'group_id' => $this->group2['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+
+    // Search by two groups with a contact belong to both of them
+    $this->addContactToGroup(['contact_id' => $this->contact2['id'], 'group_id' => $this->group1['id']]);
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+  }
+
+  /**
+   * Search by financial type
+   */
+  private function searchByFinancialType() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search by financial type
+    $params['financial_type_id'] = $this->memberDuesFinancialTypeId;
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+
+    // Search by a non existatant financial type
+    $params['financial_type_id'] = '9999';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+  }
+
+  /**
+   * Search by contribution amount
+   */
+  private function searchByContributionAmount() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search by contribution amount low
+    $params['contribution_amount_low'] = '100';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+
+    // Search by contribution amount low
+    $params['contribution_amount_low'] = '130';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+
+    // Search by contribution amount high
+    unset($params['contribution_amount_low']);
+    $params['contribution_amount_high'] = '1000';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+
+    // Search by contribution amount high
+    $params['contribution_amount_high'] = '10';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+
+    // Search by contribution amount low and contribution amount high
+    $params['contribution_amount_low'] = '10';
+    $params['contribution_amount_high'] = '130';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+
+    // Search by contribution amount low and contribution amount high
+    $params['contribution_amount_low'] = '130';
+    $params['contribution_amount_high'] = '160';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+  }
+
+  /**
+   * Search by receive date
+   */
+  private function searchByReceiveDate() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search for this month records
+    $params['receive_date_relative'] = 'this.month';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(2, $total);
+
+    // Search for this year records
+    $params['receive_date_relative'] = 'this.year';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(24, $total);
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
@@ -517,4 +517,36 @@ class CRM_ManualDirectDebit_Batch_TransactionTest extends BaseHeadlessTest {
     $this->assertEquals(24, $total);
   }
 
+  /**
+   * Search by sort name
+   */
+  private function searchBySortName() {
+    $notPresent = TRUE;
+    $params = $this->getSearchParams();
+
+    // Search by a non existatant name
+    $params['sort_name'] = 'a_name_shouldn_t_exist';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(0, $total);
+
+    // Search by full name
+    $params['sort_name'] = 'Compucorp, Bot';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+
+    // Search by a name using wildcard implicitly
+    $params['sort_name'] = 'Comp';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+
+    // Search by a name using wildcard explicitly
+    $params['sort_name'] = 'Comp%';
+    $batchTransaction = new CRM_ManualDirectDebit_Batch_Transaction($this->batch['id'], $params, [], [], $notPresent);
+    $total = $batchTransaction->getTotalNumber();
+    $this->assertEquals(12, $total);
+  }
+
 }

--- a/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Batch/TransactionTest.php
@@ -55,6 +55,22 @@ class CRM_ManualDirectDebit_Batch_TransactionTest extends BaseHeadlessTest {
 
     $this->group1 = $this->createGroup(['name' => 'group1']);
     $this->group2 = $this->createGroup(['name' => 'group2']);
+
+    $this->clearMandateContributionConnectorProperties();
+  }
+
+  /**
+   * Clear MandateContributionConnector properties
+   *
+   * Sometimes the object has properties from previous test because its class follow the singlton pattern
+   * we need to clear those properties between tests by accessing its private method
+   */
+  public function clearMandateContributionConnectorProperties() {
+    $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+    $class = new \ReflectionClass($mandateContributionConnector);
+    $method = $class->getMethod("refreshProperties");
+    $method->setAccessible(TRUE);
+    $method->invokeArgs($mandateContributionConnector, []);
   }
 
   /**

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -57,6 +57,21 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
     SettingFabricator::fabricate();
 
     $this->storageManager = new CRM_ManualDirectDebit_Common_MandateStorageManager();
+    $this->clearMandateContributionConnectorProperties();
+  }
+
+  /**
+   * Clear MandateContributionConnector properties
+   *
+   * Sometimes the object has properties from previous test because its class follow the singlton pattern
+   * we need to clear those properties between tests by accessing its private method
+   */
+  public function clearMandateContributionConnectorProperties() {
+    $mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
+    $class = new \ReflectionClass($mandateContributionConnector);
+    $method = $class->getMethod("refreshProperties");
+    $method->setAccessible(TRUE);
+    $method->invokeArgs($mandateContributionConnector, []);
   }
 
   /**


### PR DESCRIPTION
## Overview
When user go through "Create Payment Collection Batch" and start searching for contributions to export will find some search options not working as intended. 

## Before
![Screenshot from 2021-01-07 13-17-03](https://user-images.githubusercontent.com/74309109/103886780-ad009d00-50ea-11eb-9498-6f6807d275d0.png)


## After
![Screenshot from 2021-01-07 13-15-06](https://user-images.githubusercontent.com/74309109/103886794-b2f67e00-50ea-11eb-95b3-4c22b848d1ae.png)


## Technical Details
The changes are sperated by the commits :
- 1st commit just for auto-format the code automatically by using phpcbf (only small edits to variable docs). 
- In the 2nd commit I've removed the unwanted search options according to the ticket.
- In the 3nd commit I fixed the unhandled options.
- In the 4nd commit I removed some repeated form inputs.


