### PR TITLE
IO-134: Fix Scenario Where First Instalment is After Second

### DIFF
--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -77,11 +77,18 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       $membershipsStartDate->format('Y-m-' . $recurringContribution['cycle_day'])
     );
 
-    $this->receiveDate = $this->calculateNextInstalmentReceiveDate(
+    $secondInstalmentReceiveDate = $this->calculateNextInstalmentReceiveDate(
       $firstMembershipCycleDate,
       $recurringContribution['frequency_interval'],
       $recurringContribution['frequency_unit']
     );
+    $this->receiveDate = $secondInstalmentReceiveDate;
+
+    $firstInstalmentDateTime = new DateTime($firstContribution['receive_date']);
+    $secondInstalmentDateTime = new DateTime($secondInstalmentReceiveDate);
+    if ($firstInstalmentDateTime > $secondInstalmentDateTime) {
+      $this->receiveDate = $firstInstalmentDateTime->format('Y-m-d H:i:s');
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Second instalment date is before the 1st instalment date for the below scenario.

DD Settings: 
- New instruction run dates: 4
- Payment collection run dates: 5
- Minimum days from new instruction to first payment: 3
- Second Instalment Date Behavior: Option 2 ( Take 2nd instalment in 2nd month of membership)

Scenario:
1. Create a membership effective from 04-Aug-2020 of 12 instalments 
2. 1st instalment is - 5-Oct -2020 (Calculation - 4t Sep 2020 is the next instruction date + 3 days which is 7th Sep 2020. So the next payment collection run date is 5th Oct 2020).
3. Here 2nd instalment is before 1st instalment. 2nd instalment: 5-Sep 2020. 
4. 3rd instalment is 05 Oct 2020

## Before
Under some configurations, if setting to force the second instalment on the second month is enabled, it can happen that the receive date for the second instalment is calculated to be before the first instalment.

## After
Added a check so if the second instalment is before first, the receive date of the second instalment is set equal to the first. Added a test to cover the scenario.