### PR TITLE
IO-129: Do not Allow Payment Run Dates Above the 28th

### DIFF
--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -65,7 +65,7 @@ return [
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(31),
+    'html_attributes' => generateSequenceNumbers(28),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',


### PR DESCRIPTION
## Overview
Run dates above the 28th (ie. 29th, 30th and 31st) should not be allowed to be chosen as payment collection run dates.

## Before
Values shown on the DD configuration form for the payment collection run dates showed values from 1 up to the 31st.

## After
Altered the setting's definition so only values up to the 28th are available on the select field of the form.
