### PR TITLE
MAE-457: Bump version to 4.1.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,8 +18,8 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-11-30</releaseDate>
-  <version>4.0.0</version>
+  <releaseDate>2021-01-18</releaseDate>
+  <version>4.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>


### PR DESCRIPTION
Bumping version to 4.1.0 as part of Membershipextras suite version 4.1.0 release.
