### PR TITLE
IO-56: Improve Direct Debit payment plan date calculations

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -21,6 +21,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'default_reference_prefix' => CRM_Utils_Array::value('manualdirectdebit_default_reference_prefix', $settingValues),
       'minimum_reference_prefix_length' => CRM_Utils_Array::value('manualdirectdebit_minimum_reference_prefix_length', $settingValues),
       'minimum_days_to_first_payment' => CRM_Utils_Array::value('manualdirectdebit_minimum_days_to_first_payment', $settingValues),
+      'second_instalment_date_behaviour' => CRM_Utils_Array::value('manualdirectdebit_second_instalment_date_behaviour', $settingValues),
     ];
 
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
@@ -110,6 +111,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'manualdirectdebit_new_instruction_run_dates',
       'manualdirectdebit_payment_collection_run_dates',
       'manualdirectdebit_minimum_days_to_first_payment',
+      'manualdirectdebit_second_instalment_date_behaviour',
     ];
 
     return civicrm_api3('setting', 'get', [

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -4,6 +4,8 @@
  * Class provide information about Direct Debit Mandate Settings
  */
 class CRM_ManualDirectDebit_Common_SettingsManager {
+  const SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER = 'one_month_after';
+  const SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH = 'force_second_month';
 
   public static $minimumDaysToFirstPayment;
 

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -66,7 +66,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       return self::$minimumDaysToFirstPayment;
     }
     else {
-      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"), 'required_setting_not_configured');
+      throw new CiviCRM_API3_Exception(ts("Please, configure minimum days to first payment"), 'required_setting_not_configured');
     }
   }
 

--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -17,14 +17,18 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
   public function getManualDirectDebitSettings() {
     $settingValues = $this->getSettingsValues();
 
-    $settings = [];
-    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
-    $settings['minimum_reference_prefix_length'] = $settingValues['values'][0]['manualdirectdebit_minimum_reference_prefix_length'];
+    $settings = [
+      'default_reference_prefix' => CRM_Utils_Array::value('manualdirectdebit_default_reference_prefix', $settingValues),
+      'minimum_reference_prefix_length' => CRM_Utils_Array::value('manualdirectdebit_minimum_reference_prefix_length', $settingValues),
+      'minimum_days_to_first_payment' => CRM_Utils_Array::value('manualdirectdebit_minimum_days_to_first_payment', $settingValues),
+    ];
+
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
+      CRM_Utils_Array::value('manualdirectdebit_new_instruction_run_dates', $settingValues)
+    );
     $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
-    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
+      CRM_Utils_Array::value('manualdirectdebit_payment_collection_run_dates', $settingValues)
+    );
 
     return $settings;
   }
@@ -90,7 +94,8 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
         $settingValues = $this->fetchSettingsValues();
       }
     }
-    return $settingValues;
+
+    return $settingValues['values'][0];
   }
 
   /**

--- a/CRM/ManualDirectDebit/Form/Configurations.php
+++ b/CRM/ManualDirectDebit/Form/Configurations.php
@@ -16,7 +16,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $mandateConfigs = [];
 
   /**
@@ -25,8 +24,14 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $paymentConfigs = [];
+
+  /**
+   * Contains array of settings' names for Instalment Configs Section.
+   *
+   * @var array
+   */
+  private $instalmentConfigs = [];
 
   /**
    * Contains array of names, which must be displayed
@@ -34,7 +39,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $reminderConfig = [];
 
   /**
@@ -43,7 +47,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $batchConfig = [];
 
   public function buildQuickForm() {
@@ -82,6 +85,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
 
     $this->assign('mandateConfigSection', $this->mandateConfigs);
     $this->assign('paymentConfigSection', $this->paymentConfigs);
+    $this->assign('instalmentConfigSection', $this->instalmentConfigs);
     $this->assign('reminderConfigSection', $this->reminderConfig);
     $this->assign('batchConfigSection', $this->batchConfig);
     $this->assign('fieldsWithHelp', $fieldsWithHelp);
@@ -101,12 +105,18 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    * @see CRM_Core_Form::setDefaultValues()
    */
   public function setDefaultValues() {
-    $currentValues = civicrm_api3('setting', 'get',
-      ['return' => array_keys(SettingsManager::getConfigFields())]);
+    $settingsMetaData = SettingsManager::getConfigFields();
+    $currentValues = civicrm_api3('setting', 'get', [
+      'return' => array_keys($settingsMetaData),
+    ]);
     $defaults = [];
     $domainID = CRM_Core_Config::domainID();
-    foreach ($currentValues['values'][$domainID] as $name => $value) {
-      $defaults[$name] = $value;
+
+    foreach ($settingsMetaData as $settingName => $setting) {
+      $defaults[$settingName] = CRM_Utils_Array::value('default', $setting);
+      if (isset($currentValues['values'][$domainID][$settingName])) {
+        $defaults[$settingName] = $currentValues['values'][$domainID][$settingName];
+      }
     }
 
     return $defaults;
@@ -128,6 +138,10 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
         $this->paymentConfigs[] = $name;
         break;
 
+      case 'instalment_config':
+        $this->instalmentConfigs[] = $name;
+        break;
+
       case 'reminder_config':
         $this->reminderConfig[] = $name;
         break;
@@ -135,7 +149,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
       case 'batch_config':
         $this->batchConfig[] = $name;
         break;
-
     }
   }
 

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
@@ -7,7 +7,7 @@ use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
  * Holds methods and attributes to all classes that calculate receive dates for
  * instalments in a payment plan.
  */
-abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
   /**
    * Start date of the payment plan and the receive date of first instalment.
    *
@@ -102,11 +102,10 @@ abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Contr
     $result = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $this->params['contribution_recur_id'],
-      'options' => ['limit' => 0],
     ]);
 
     if ($result['count'] > 0) {
-      return $result['values'][0];
+      return array_shift($result['values']);
     }
 
     return [];

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
@@ -93,10 +93,30 @@ abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Contr
   }
 
   /**
+   * Obtains recurrring contribution used for the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function getRecurringContribution() {
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['contribution_recur_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    return [];
+  }
+
+  /**
    * Changes the receive date for the instalment, if necessary.
    *
    * @return mixed
    */
-  public abstract function process();
+  abstract public function process();
 
 }

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/ContributionBase.php
@@ -1,0 +1,102 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase.
+ *
+ * Holds methods and attributes to all classes that calculate receive dates for
+ * instalments in a payment plan.
+ */
+abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+  /**
+   * Start date of the payment plan and the receive date of first instalment.
+   *
+   * @var string
+   */
+  protected $receiveDate = '';
+
+  /**
+   * List of parameters being used to create the first instalment.
+   *
+   * @var array
+   */
+  protected $params = [];
+
+  /**
+   * Array with Direct Debit extension settings.
+   *
+   * @var array
+   */
+  protected $ddSettings = [];
+
+  /**
+   * The DirectDebit payment instrument data.
+   *
+   * @var array
+   */
+  protected $directDebitPaymentInstrument = [];
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
+   *
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, $params, SettingsManager $settingsManager) {
+    $this->receiveDate =& $receiveDate;
+    $this->params = $params;
+    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
+    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
+  }
+
+  /**
+   * Obtains the data for the Direct Debit payment instrument.
+   *
+   * @return mixed
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDDPaymentMethod() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => 'direct_debit',
+      'option_group_id' => 'payment_instrument',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
+  }
+
+  /**
+   * Checks if the contribution is being paid for with direct debit.
+   *
+   * @return bool
+   */
+  protected function isDirectDebit() {
+    if ($this->params['payment_instrument_id'] === 'direct_debit') {
+      return TRUE;
+    }
+
+    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Changes the receive date for the instalment, if necessary.
+   *
+   * @return mixed
+   */
+  public abstract function process();
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
 
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -1,0 +1,144 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution.
+ *
+ * Implements hook to calculate the receive date of the first contribution of a
+ * payment plan.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution {
+
+  /**
+   * Start date of the payment plan and the receive date of first instalment.
+   *
+   * @var string
+   */
+  private $receiveDate = '';
+
+  /**
+   * List of parameters being used to create the first instalment.
+   *
+   * @var array
+   */
+  private $params = [];
+
+  /**
+   * Array with Direct Debit extension settings.
+   *
+   * @var array
+   */
+  private $ddSettings = [];
+
+  /**
+   * The DirectDebit payment instrument data.
+   *
+   * @var array
+   */
+  private $directDebitPaymentInstrument = [];
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
+   *
+   * @param $receiveDate
+   * @param $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, &$params, SettingsManager $settingsManager) {
+    $this->receiveDate =& $receiveDate;
+    $this->params =& $params;
+    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
+    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
+  }
+
+  /**
+   * Obtains the data for the Direct Debit payment instrument.
+   *
+   * @return mixed
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDDPaymentMethod() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => 'direct_debit',
+      'option_group_id' => 'payment_instrument',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
+  }
+
+  /**
+   * Calculates receive date for payment plan if payment method is DD.
+   *
+   * @throws \Exception
+   */
+  public function process() {
+    if (!$this->isDirectDebit()) {
+      return;
+    }
+
+    $paddedReceiveDate = new DateTime($this->receiveDate);
+    if ($this->ddSettings['minimum_days_to_first_payment']) {
+      $paddedReceiveDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+    }
+
+    $nextInstructionRunDate = $this->getNextValidDateAfter($paddedReceiveDate, $this->ddSettings['new_instruction_run_dates']);
+    $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
+    $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Checks if the contribution is being paid for with direct debit.
+   *
+   * @return bool
+   */
+  private function isDirectDebit() {
+    if ($this->params['payment_instrument_id'] === 'direct_debit') {
+      return TRUE;
+    }
+
+    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Returns first date in collection of days that is after given dates.
+   *
+   * @param \DateTime $referenceDate
+   * @param array $validDaysArray
+   *
+   * @return \Date|\DateTime
+   */
+  private function getNextValidDateAfter(\DateTime $referenceDate, array $validDaysArray) {
+    $referenceYear = intval($referenceDate->format('Y'));
+
+    for ($year = $referenceYear; $year < $referenceYear + 2; $year++) {
+      for ($month = 1; $month < 13; $month++) {
+        foreach ($validDaysArray as $paymentCollectionDay) {
+          $paymentCollectionDay = ($paymentCollectionDay < 10 ? '0' . $paymentCollectionDay : $paymentCollectionDay);
+          $paymentCollectionMonth = ($month < 10 ? '0' . $month : $month);
+          $nextAvailableDate = new DateTime("{$year}-{$paymentCollectionMonth}-{$paymentCollectionDay}");
+
+          if ($nextAvailableDate >= $referenceDate) {
+            return $nextAvailableDate;
+          }
+        }
+      }
+    }
+
+    return $referenceDate;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -7,74 +7,7 @@ use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
  * Implements hook to calculate the receive date of the first contribution of a
  * payment plan.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution {
-
-  /**
-   * Start date of the payment plan and the receive date of first instalment.
-   *
-   * @var string
-   */
-  private $receiveDate = '';
-
-  /**
-   * List of parameters being used to create the first instalment.
-   *
-   * @var array
-   */
-  private $params = [];
-
-  /**
-   * Array with Direct Debit extension settings.
-   *
-   * @var array
-   */
-  private $ddSettings = [];
-
-  /**
-   * The DirectDebit payment instrument data.
-   *
-   * @var array
-   */
-  private $directDebitPaymentInstrument = [];
-
-  /**
-   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
-   *
-   * @param $receiveDate
-   * @param $params
-   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   *
-   * @throws \CRM_Extension_Exception
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function __construct(&$receiveDate, &$params, SettingsManager $settingsManager) {
-    $this->receiveDate =& $receiveDate;
-    $this->params =& $params;
-    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
-    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
-  }
-
-  /**
-   * Obtains the data for the Direct Debit payment instrument.
-   *
-   * @return mixed
-   * @throws \CRM_Extension_Exception
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getDDPaymentMethod() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'name' => 'direct_debit',
-      'option_group_id' => 'payment_instrument',
-      'options' => ['limit' => 0],
-    ]);
-
-    if ($result['count'] > 0) {
-      return $result['values'][0];
-    }
-
-    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
-  }
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
 
   /**
    * Calculates receive date for payment plan if payment method is DD.
@@ -96,23 +29,6 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
 
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
     $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
-  }
-
-  /**
-   * Checks if the contribution is being paid for with direct debit.
-   *
-   * @return bool
-   */
-  private function isDirectDebit() {
-    if ($this->params['payment_instrument_id'] === 'direct_debit') {
-      return TRUE;
-    }
-
-    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -6,7 +6,7 @@
  * Implements hook to calculate the receive date of the first contribution of a
  * payment plan.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
 
   /**
    * Calculates receive date for payment plan if payment method is DD.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -86,12 +86,13 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
       return;
     }
 
-    $paddedReceiveDate = new DateTime($this->receiveDate);
+    $receiveDateTime = new DateTime($this->receiveDate);
+    $nextInstructionRunDate = $this->getNextValidDateAfter($receiveDateTime, $this->ddSettings['new_instruction_run_dates']);
+
     if ($this->ddSettings['minimum_days_to_first_payment']) {
-      $paddedReceiveDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+      $nextInstructionRunDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
     }
 
-    $nextInstructionRunDate = $this->getNextValidDateAfter($paddedReceiveDate, $this->ddSettings['new_instruction_run_dates']);
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
     $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
   }
@@ -131,7 +132,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
           $paymentCollectionMonth = ($month < 10 ? '0' . $month : $month);
           $nextAvailableDate = new DateTime("{$year}-{$paymentCollectionMonth}-{$paymentCollectionDay}");
 
-          if ($nextAvailableDate >= $referenceDate) {
+          if ($nextAvailableDate > $referenceDate) {
             return $nextAvailableDate;
           }
         }

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -89,8 +89,9 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
     $receiveDateTime = new DateTime($this->receiveDate);
     $nextInstructionRunDate = $this->getNextValidDateAfter($receiveDateTime, $this->ddSettings['new_instruction_run_dates']);
 
-    if ($this->ddSettings['minimum_days_to_first_payment']) {
-      $nextInstructionRunDate->add(new DateInterval("P{$this->ddSettings['minimum_days_to_first_payment']}D"));
+    $minimumDaysToFirstPayment = $this->ddSettings['minimum_days_to_first_payment'];
+    if ($minimumDaysToFirstPayment) {
+      $nextInstructionRunDate->add(new DateInterval("P{$minimumDaysToFirstPayment}D"));
     }
 
     $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
@@ -1,0 +1,121 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+
+/**
+ * Class OtherContribution.
+ *
+ * Calculates receive date for contributions beyond the second instalment.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+
+  /**
+   * Number of instalment in payment plan.
+   *
+   * @var int
+   */
+  private $contributionNumber;
+
+  /**
+   * Helper object used to calculate receive dates.
+   *
+   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   */
+  private $receiveDateCalculator;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution constructor.
+   *
+   * @param int $contributionNumber
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($contributionNumber, &$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
+    $this->contributionNumber = $contributionNumber;
+    $this->receiveDateCalculator = $calculator;
+
+    parent::__construct($receiveDate, $params, $settingsManager);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function process() {
+    $previousInstalmentDate = $this->getPreviousContributionReceiveDate();
+    $receiveDate = new DateTime($previousInstalmentDate);
+
+    $recurringContribution = $this->getRecurringContribution();
+    $numberOfIntervals = $recurringContribution['frequency_interval'];
+    $frequencyUnit = $recurringContribution['frequency_unit'];
+
+    switch ($frequencyUnit) {
+      case 'day':
+        $interval = "P{$numberOfIntervals}D";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+
+      case 'week':
+        $interval = "P{$numberOfIntervals}W";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+
+      case 'month':
+        $receiveDate = $this->receiveDateCalculator->getSameDayNextMonth($receiveDate, $numberOfIntervals);
+        break;
+
+      case 'year':
+        $interval = "P{$numberOfIntervals}Y";
+        $receiveDate->add(new DateInterval($interval));
+        break;
+    }
+
+    $this->receiveDate = $receiveDate->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Obtains the receive date of the last contribution in the payment plan.
+   *
+   * @return mixed|string
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPreviousContributionReceiveDate() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id ASC',
+      ],
+    ]);
+
+    return $result['values'][$this->contributionNumber - 2]['receive_date'];
+  }
+
+  /**
+   * Obtains recurrring contribution used for the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContribution() {
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['contribution_recur_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    return [];
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -5,7 +5,7 @@ use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDate
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
  */
-class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
 
   /**
    * Helper object used to calculate receive dates.

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -77,11 +77,18 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       $membershipsStartDate->format('Y-m-' . $recurringContribution['cycle_day'])
     );
 
-    $this->receiveDate = $this->calculateNextInstalmentReceiveDate(
+    $secondInstalmentReceiveDate = $this->calculateNextInstalmentReceiveDate(
       $firstMembershipCycleDate,
       $recurringContribution['frequency_interval'],
       $recurringContribution['frequency_unit']
     );
+    $this->receiveDate = $secondInstalmentReceiveDate;
+
+    $firstInstalmentDateTime = new DateTime($firstContribution['receive_date']);
+    $secondInstalmentDateTime = new DateTime($secondInstalmentReceiveDate);
+    if ($firstInstalmentDateTime > $secondInstalmentDateTime) {
+      $this->receiveDate = $firstInstalmentDateTime->format('Y-m-d H:i:s');
+    }
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -1,0 +1,150 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase {
+
+  /**
+   * @inheritDoc
+   */
+  public function process() {
+    if (!$this->isDirectDebit()) {
+      return;
+    }
+
+    if (!$this->isForceOnSecondMonth()) {
+      return;
+    }
+
+    $this->forceSecondInstalmentOnSecondMonth();
+  }
+
+  /**
+   * Checks if setting to force second payment on second month is active.
+   *
+   * Checks if DD settings are configured to force second instalment to be on
+   * second month of membership.
+   *
+   * @return bool
+   */
+  private function isForceOnSecondMonth() {
+    if ($this->ddSettings['second_instalment_date_behaviour'] === SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Forces second instalment to have the first instalment's receive date.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  private function forceSecondInstalmentOnSecondMonth() {
+    $firstContribution = $this->getFirstContribution();
+    $firstContributionReceiveDate = new DateTime($firstContribution['receive_date']);
+    $membershipsStartDate = $this->getMembershipsStartDate($firstContribution);
+
+    $interval = $membershipsStartDate->diff($firstContributionReceiveDate);
+    $dias = $interval->format('%a');
+
+    if ($dias > 30) {
+      $this->receiveDate = $firstContributionReceiveDate->format('Y-m-d H:i:s');
+    }
+  }
+
+  /**
+   * Obteins the first contribution in the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getFirstContribution() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id',
+      ],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Obtains a membership's start date from those related to the payment plan.
+   *
+   * @param array $firstContribution
+   *
+   * @return \DateTime|null
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembershipsStartDate($firstContribution) {
+    $lineItems = $this->getContributionLineItems($firstContribution);
+
+    foreach ($lineItems as $line) {
+      if ($line['entity_table'] != 'civicrm_membership') {
+        continue;
+      }
+
+      $membership = $this->getMembership($line['entity_id']);
+
+      return new DateTime($membership['start_date']);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Obtains the list of line items for the given contribution.
+   *
+   * @param $contribution
+   *
+   * @return array|mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getContributionLineItems($contribution) {
+    $result = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $contribution['id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+     return [];
+  }
+
+  /**
+   * Obtains the given membership's data.
+   *
+   * @param int $membershipID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembership($membershipID) {
+    $result = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'id' => $membershipID,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -395,14 +395,39 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 /**
  * Implements hook_membershipextras_calculateContributionReceiveDate().
  */
-function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
+function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-  $firstReceiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
-    $receiveDate,
-    $contributionCreationParams,
-    $settingsManager
-  );
-  $firstReceiveDateCalculator->process();
+
+  switch ($contributionNumber) {
+    case 1:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    case 2:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    default:
+      $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
+        $contributionNumber,
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager,
+        $calculator
+      );
+      $receiveDateCalculator->process();
+  }
 }
 
 function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -307,11 +307,6 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-// TODO!!
-  if ($op == 'create' && $objectName == 'Contribution') {
-    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
-    $postContributionHook->process();
-  }
 }
 
 /**
@@ -399,9 +394,6 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 
 /**
  * Implements hook_membershipextras_calculateContributionReceiveDate().
- *
- * @param string $receiveDate
- * @param array $contributionCreationParams
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -397,6 +397,7 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
 
   switch ($contributionNumber) {
     case 1:
@@ -412,13 +413,13 @@ function manualdirectdebit_membershipextras_calculateContributionReceiveDate($co
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
         $receiveDate,
         $contributionCreationParams,
-        $settingsManager
+        $settingsManager,
+        $calculator
       );
       $receiveDateCalculator->process();
       break;
 
     default:
-      $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
         $contributionNumber,
         $receiveDate,

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -307,7 +307,7 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-
+// TODO!!
   if ($op == 'create' && $objectName == 'Contribution') {
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
@@ -395,6 +395,22 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 
   $mandate = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate($recurContributionId, $previousRecurContributionId);
   $mandate->process();
+}
+
+/**
+ * Implements hook_membershipextras_calculateContributionReceiveDate().
+ *
+ * @param string $receiveDate
+ * @param array $contributionCreationParams
+ */
+function manualdirectdebit_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
+  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $firstReceiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
+    $receiveDate,
+    $contributionCreationParams,
+    $settingsManager
+  );
+  $firstReceiveDateCalculator->process();
 }
 
 function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -98,7 +98,7 @@ return [
     'quick_form_type' => 'Element',
     'default' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     'is_required' => TRUE,
-    'is_help' => FALSE,
+    'is_help' => TRUE,
     'html_attributes' => [
       SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER => ts('Take second instalment 1 month after the first instalment'),
       SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH => ts('Take second instalment in the second month of membership'),
@@ -107,7 +107,7 @@ return [
       'class' => 'crm-select2',
       'placeholder' => ts('- select -'),
     ],
-    'section' => 'payment_config',
+    'section' => 'instalment_config',
   ],
   'manualdirectdebit_days_in_advance_for_collection_reminder' => [
     'group_name' => 'Manual Direct Debit',
@@ -147,7 +147,6 @@ return [
  * @param int $limit
  *
  * @return  array
- *
  */
 function generateSequenceNumbers($limit) {
   $sequence = [];

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -1,6 +1,7 @@
 <?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
 
-/*
+/**
  * Metadata for Manual Direct Debit Settings
  */
 return [
@@ -23,7 +24,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_reference_prefix_length',
-    'title' => 'Minimum mandate reference length',
+    'title' => 'Minimum Mandate Reference Length',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -38,7 +39,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_new_instruction_run_dates',
-    'title' => 'New instruction run dates',
+    'title' => 'New Instruction Run Dates',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
@@ -57,7 +58,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_payment_collection_run_dates',
-    'title' => 'Payment collection run dates ',
+    'title' => 'Payment Collection Run Dates ',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
@@ -76,7 +77,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_days_to_first_payment',
-    'title' => 'Minimum days from new instruction to first payment',
+    'title' => 'Minimum Days from New Instruction to First Payment',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -87,11 +88,32 @@ return [
     'extra_data' => '',
     'section' => 'payment_config',
   ],
+  'manualdirectdebit_second_instalment_date_behaviour' => [
+    'group_name' => 'Manual Direct Debit',
+    'group' => 'manualdirectdebit',
+    'name' => 'manualdirectdebit_second_instalment_date_behaviour',
+    'title' => 'Second Instalment Date Behaviour',
+    'type' => 'String',
+    'html_type' => 'select',
+    'quick_form_type' => 'Element',
+    'default' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    'is_required' => TRUE,
+    'is_help' => FALSE,
+    'html_attributes' => [
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER => ts('Take second instalment 1 month after the first instalment'),
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH => ts('Take second instalment in the second month of membership'),
+    ],
+    'extra_data' => [
+      'class' => 'crm-select2',
+      'placeholder' => ts('- select -'),
+    ],
+    'section' => 'payment_config',
+  ],
   'manualdirectdebit_days_in_advance_for_collection_reminder' => [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_days_in_advance_for_collection_reminder',
-    'title' => 'Days in advance for Collection Reminder',
+    'title' => 'Days in Advance for Collection Reminder',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -106,7 +128,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_batch_submission_queue_limit',
-    'title' => 'Number of records to be processed per batch submission queue task',
+    'title' => 'Number of Records to be Processed per Batch Submission Queue Task',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -116,7 +138,7 @@ return [
     'html_attributes' => '',
     'extra_data' => '',
     'section' => 'batch_config',
-  ]
+  ],
 ];
 
 /**

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -65,7 +65,7 @@ return [
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(31),
+    'html_attributes' => generateSequenceNumbers(28),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
@@ -20,10 +20,43 @@ contribution should the Direct Debit Payment Collection Reminder
 be sent to the user.{/ts}
 {/htxt}
 
+{htxt id="manualdirectdebit_second_instalment_date_behaviour"}
+  <p>
+    {ts}You can specify how you would like the system to calculate the date for the
+    second instalment for memberships paid in monthly instalments. The options
+    are:{/ts}
+  </p>
+  <ol>
+    <li>
+      <b>{ts}Take the second instalment 1 month after the first instalment(Default): {/ts}</b>
+      {ts}
+        Here, the date of the second instalment is relative to the date of the
+        first instalment. If the first instalment is delayed due to the fact that
+        the first instalment payment run date in the first month was missed, the
+        second instalment will be 1 month from that date. All following
+        instalments will be 1 month following the previous. This might be
+        preferable for ensuring that members do not have to pay for multiple
+        instalments in the same month, but it may mean that the final instalment
+        for a membership is taken in the month after the membership has expired,
+        which might be undesirable from your organisations perspective.
+      {/ts}
+    </li>
+    <li>
+      <b>{ts}Take the second instalment in the second month of membership: {/ts}</b>
+      {ts}
+        Here, the system will always take the second instalment in the second
+        month of membership. In some cases this will mean that both the first
+        instalment and the second instalment will be taken in the second month
+        of membership, if for example, the first instalment payment run date in
+        the first month was missed.
+      {/ts}
+    </li>
+  </ol>
+{/htxt}
+
 {htxt id="inactivity_code-title"}
   {ts}Mandates with inactive codes will not be selectable when
 creating a new Direct Debit contribution/ payment plan.
 Mandates and contributions that link to mandates with these
 codes will not be included in the batch.{/ts}
 {/htxt}
-

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
@@ -2,7 +2,7 @@
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  <h3>{ts}Mandate config{/ts}</h3>
+  <h3>{ts}Mandate Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$mandateConfigSection item=elementName}
@@ -15,7 +15,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Payment config{/ts}</h3>
+  <h3>{ts}Payment Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$paymentConfigSection item=elementName}
@@ -28,7 +28,20 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Reminder config{/ts}</h3>
+  <h3>Instalment Config</h3>
+  <table class="form-layout-compressed">
+    <tbody>
+    {foreach from=$instalmentConfigSection item=elementName}
+      <tr>
+        <td class="label">{$form.$elementName.label}</td>
+        <td>{$form.$elementName.html}
+          {if $fieldsWithHelp.$elementName}{help id=$form.$elementName.name}{/if}
+        </td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
+  <h3>{ts}Reminder Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$reminderConfigSection item=elementName}
@@ -41,7 +54,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Batch config{/ts}</h3>
+  <h3>{ts}Batch Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
     {foreach from=$batchConfigSection item=elementName}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution as FirstContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest extends BaseHeadlessTest {
+
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  public function testCalculateReceiveDateOnFirstRunDateWithMinDaysOverFirstPayDateUsesSecondPayDate() {
+    $receiveDate = '2020-01-01';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateWithMinDaysOverSecondPayDatePushesForNextMonth() {
+    $receiveDate = '2020-01-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-02-01 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateAtEndOfYearIsPushedForNextYear() {
+    $receiveDate = '2020-12-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2021-01-01 00:00:00', $receiveDate);
+  }
+
+  public function testPaymentPlansNotPaidWithDirectDebitAreNotChanged() {
+    $receiveDate = '2020-01-15 00:00:00';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $this->defaultContributionParams['payment_instrument_id'] = 'EFT';
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -1,0 +1,198 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution as OtherContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param int $numberOfContributions
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, $numberOfContributions, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $receiveDateCalculator = new ReceiveDateCalculator($recurringContribution);
+
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+
+    for ($i = 0; $i < $numberOfContributions; $i++) {
+      $receiveDate = $i === 0 ? $firstInstalmentReceiveDate : $receiveDateCalculator->calculate($i + 1);
+      $contribution = ContributionFabricator::fabricate([
+        'currency' => NULL,
+        'source' => NULL,
+        'contact_id' => $contact['id'],
+        'fee_amount' => 0,
+        'net_amount' => $params['amount'] / $params['installments'],
+        'total_amount' => $params['amount'] / $params['installments'],
+        'receive_date' => $receiveDate,
+        'payment_instrument_id' => 'direct_debit',
+        'financial_type_id' => 'Member Dues',
+        'is_test' => 0,
+        'contribution_status_id' => 'Pending',
+        'is_pay_later' => TRUE,
+        'skipLineItem' => 1,
+        'skipCleanMoney' => TRUE,
+        'contribution_recur_id' => $recurringContribution['id'],
+      ]);
+      LineItemFabricator::fabricate([
+        'entity_table' => 'civicrm_membership',
+        'entity_id' => $membership['id'],
+        'contribution_id' => $contribution['id'],
+        'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+        'label' => $mainMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $contribution['total_amount'],
+        'line_total' => $contribution['total_amount'],
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 0,
+      ]);
+    }
+
+    return $recurringContribution;
+  }
+
+  public function testReceiveDateCalculationOfPaymentsAboveSecondInstalment() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2002-12-29';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, 3, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 15,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settingsManager = $this->buildSettingsManagerMock([]);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
+      4,
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-04-15 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -68,7 +68,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
   /**
    * Builds a mock class to manage DD settings.
    *
-   * @return mixed
+   * @return \CRM_ManualDirectDebit_Common_SettingsManager
    */
   private function buildSettingsManagerMock($settings) {
     $settingsManager = $this->createMock(SettingsManager::class);
@@ -77,6 +77,23 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
       ->willReturn(array_merge($this->defaultDDSettings, $settings));
 
     return $settingsManager;
+  }
+
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $dayNextMonth
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($dayNextMonth) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($dayNextMonth));
+
+    return $calculator;
   }
 
   /**
@@ -182,7 +199,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
     $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
 
     $settingsManager = $this->buildSettingsManagerMock([]);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-04-15');
     $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
       4,
       $receiveDate,

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -79,6 +79,23 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     return $settingsManager;
   }
 
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $dayNextMonth
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($dayNextMonth) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($dayNextMonth));
+
+    return $calculator;
+  }
+
   public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
     $membershipStartDate = '2020-01-01';
     $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
@@ -97,7 +114,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
@@ -128,7 +145,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-15');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
@@ -159,7 +176,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-03-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -1,0 +1,244 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($firstInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenStartDateToFirstPaymentIsLessThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenSettingIsSet() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    ];
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $contribution = ContributionFabricator::fabricate([
+      'currency' => NULL,
+      'source' => NULL,
+      'contact_id' => $contact['id'],
+      'fee_amount' => 0,
+      'net_amount' => $params['amount'] / $params['installments'],
+      'total_amount' => $params['amount'] / $params['installments'],
+      'receive_date' => $firstInstalmentReceiveDate,
+      'payment_instrument_id' => 'direct_debit',
+      'financial_type_id' => 'Member Dues',
+      'is_test' => 0,
+      'contribution_status_id' => 'Pending',
+      'is_pay_later' => TRUE,
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'contribution_recur_id' => $recurringContribution['id'],
+    ]);
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+    LineItemFabricator::fabricate([
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'contribution_id' => $contribution['id'],
+      'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+      'label' => $mainMembershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $contribution['total_amount'],
+      'line_total' => $contribution['total_amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 0,
+    ]);
+
+    return $recurringContribution;
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -6,6 +6,7 @@ use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
 use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
 use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
 
 /**
@@ -64,6 +65,20 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     return $result;
   }
 
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
   public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
     $membershipStartDate = '2020-01-01';
     $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
@@ -81,15 +96,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 
@@ -102,7 +116,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
 
     $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
-      'amount' => 1200,
+      'amount' => 120,
       'frequency_unit' => 'month',
       'frequency_interval' => 1,
       'installments' => 12,
@@ -113,15 +127,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 
@@ -145,15 +158,14 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     ];
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = new ReceiveDateCalculator();
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager
+      $settingsManager,
+      $receiveDateCalculatorHelper
     );
     $receiveDateCalculator->process();
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -17,6 +17,8 @@ if (CIVICRM_UF === 'UnitTests') {
   Civi\Test::headless()->apply();
 }
 
+require_once 'BaseHeadlessTest.php';
+
 /**
  * Call the "cv" command.
  *


### PR DESCRIPTION
## Overview
We need to improve the Direct Debit Start Date. The Start date of the DD payment plan should occur in the same month of sign up when possible. When it is not possible, the second and first instalment should be taken in the same month to match the membership and payments duration, though this should be an optional setting.

The is a final release into master of the work done for:
- IO-123: Calculate First Instalment Date
- IO-124: Calculate Cycle Date
- IO-125: Add New Setting
- IO-126: Calculate Second Instalment Date Using New Setting
- IO-129: Add Validation to Payment Run Dates
- IO-132: Autorenewal Job is Failing
- IO-135: Issue wit Second Instalment

## Before
Functionality to calculate first and second instalment dates according to new instruction and payment run dates was not implemented.

## After
1. Added a new setting so the admin can choose the second instalment to wither be:
   - 1 month after first contribution
   - Force on second month of membership 
2. Created new hook that is dispatched in ME extension before creating a contribution for a payment plan, so the hook can be used to alter the calculated receive date of each contribution.
3. Implemented the new hook on DD extension to change the receive date of each contribution, depending on the new setting so:
   1. First contribution: receive date will be first available payment run date after first instruction run date + min days before payment run date.
   2. Second contribution: if setting is force on second month, it will check the start date of the membership and add 1 instalment frequency to calculate the receive date. Other wise it'll be one month after first contribution.
   3. Other contributions: for instalments > 2, receive date will always be 1 month after previous instalment.
