### PR TITLE
IO-136: Change Instalment Receive Date Calculator class name

### DIFF
--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
@@ -1,6 +1,6 @@
 <?php
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator as ReceiveDateCalculator;
 
 /**
  * Class OtherContribution.
@@ -23,7 +23,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
    * @param string $receiveDate
    * @param array $params
    * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   * @param \CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator $calculator
    *
    * @throws \CRM_Extension_Exception
    * @throws \CiviCRM_API3_Exception

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -1,6 +1,6 @@
 <?php
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator as ReceiveDateCalculator;
 
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
@@ -10,7 +10,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
   /**
    * Helper object used to calculate receive dates.
    *
-   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @var \CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator
    */
   protected $receiveDateCalculator;
 
@@ -20,7 +20,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
    * @param string $receiveDate
    * @param array $params
    * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   * @param \CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator $calculator
    *
    * @throws \CRM_Extension_Exception
    * @throws \CiviCRM_API3_Exception

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -397,7 +397,7 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
   $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-  $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
+  $calculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator();
 
   switch ($contributionNumber) {
     case 1:


### PR DESCRIPTION
## Overview

Membership Extras version 5 refactored InstallmentReceiveDateCalculator to [InstalmentReceiveDateCalculator](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/MAE-376-version5-workstream/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php#L3). In order for Manual direct debit extension to work with membership extras version 5, we must change the class to match with Membership extras version 5. 

 This PR changes the InstalmentReceiveDateCalculator class name to match with Membership Extras version 5. 

## Technical details

The unit tests would fail when running tests on GitHub Action because InstalmentReceiveDateCalculator does not exist in Membership Extras master branch. In order to make it works, we would need to clone Membership Extras work stream branch on GitHub action and I decide not to do that because:

- This branch is mainly to make manual direct debit work then deploy new site with Compuclient.
- When membership extras version 5 is merged to master branch, we do not need to update the GitHub action again, and we can re-run the job to check if unit tests working properly before we merge this PR to master branch.
