### PR TITLE
MAE-494: Fix payment batch submission after CiviCRM 5.35 upgrade

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -316,11 +316,12 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     ]);
     $contribution = array_shift($result['values']);
 
-    CRM_Contribute_BAO_Contribution::transitionComponentWithReturnMessage($contribution['id'],
-      $contribution['contribution_status_id'],
-      $originalStatusID,
-      $contribution['receive_date']
-    );
+    CRM_Contribute_BAO_Contribution::transitionComponents([
+      'contribution_id' => $contribution['id'],
+      'contribution_status_id' => $contribution['contribution_status_id'],
+      'previous_contribution_status_id' => $originalStatusID,
+      'receive_date' => $contribution['receive_date'],
+    ]);
   }
 
   /**

--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -307,7 +307,7 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
     $originalStatusID = civicrm_api3('Contribution', 'getvalue', [
       'return' => 'contribution_status_id',
       'id' => $contributionId,
-    ])['result'];
+    ]);
 
     $result = civicrm_api3('Contribution', 'create', [
       'id' => $contributionId,

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
@@ -57,11 +57,12 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_PaymentItem {
     ]);
     $contribution = array_shift($result['values']);
 
-    CRM_Contribute_BAO_Contribution::transitionComponentWithReturnMessage($contribution['id'],
-      $contribution['contribution_status_id'],
-      $originalStatusID,
-      $contribution['receive_date']
-    );
+    CRM_Contribute_BAO_Contribution::transitionComponents([
+      'contribution_id' => $contribution['id'],
+      'contribution_status_id' => $contribution['contribution_status_id'],
+      'previous_contribution_status_id' => $originalStatusID,
+      'receive_date' => $contribution['receive_date'],
+    ]);
   }
 
 }

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
@@ -48,7 +48,7 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_PaymentItem {
     $originalStatusID = civicrm_api3('Contribution', 'getvalue', [
       'return' => 'contribution_status_id',
       'id' => $contributionId,
-    ])['result'];
+    ]);
 
     $result = civicrm_api3('Contribution', 'create', [
       'id' => $contributionId,


### PR DESCRIPTION
## Overview
Fixing payment batch submission after CiviCRM 5.35 upgrade

## Technical Details
Manual direct debit is using the core method "transitionComponentWithReturnMessage" that is in the Contribution BAO class, though this method is now removed in CiviCRM core (see https://github.com/civicrm/civicrm-core/pull/18961 for more info), and thus it results in failure when submitting the payment batch.

Here I replaced the calls for this method with "transitionComponents" method, given that the former is basically calling it but just with returning some extra feedback messages, and that these feedback messages are not even used or showed back to the user in this extension, so it is safe to just call "transitionComponents" instead.