### PR TITLE
MAE-501: Fix unable to send direct debit notifications.

### DIFF
--- a/CRM/ManualDirectDebit/Form/Email/Contribution.php
+++ b/CRM/ManualDirectDebit/Form/Email/Contribution.php
@@ -10,12 +10,14 @@ class CRM_ManualDirectDebit_Form_Email_Contribution extends CRM_Contribute_Form_
    */
   public function postProcess() {
     $messageTemplateId = $this->getVar('_submitValues')['template'];
-    if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId)) {
-      CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon::postProcess($this);
+    $isDirectDebitTemplate = CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId);
+    if (!$isDirectDebitTemplate) {
+      parent::postProcess();
+      return;
     }
-    else {
-      CRM_Contact_Form_Task_EmailCommon::postProcess($this);
-    }
+
+    $contribuitonEmailCommon = new CRM_ManualDirectDebit_Mail_Task_Email_ContributionEmail();
+    $contribuitonEmailCommon->postProcess($this);
   }
 
 }

--- a/CRM/ManualDirectDebit/Form/Email/Membership.php
+++ b/CRM/ManualDirectDebit/Form/Email/Membership.php
@@ -7,12 +7,15 @@ class CRM_ManualDirectDebit_Form_Email_Membership extends CRM_Member_Form_Task_E
    */
   public function postProcess() {
     $messageTemplateId = $this->getVar('_submitValues')['template'];
-    if (CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId)) {
-      CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon::postProcess($this);
+    $isDirectDebitTemplate = CRM_ManualDirectDebit_Common_MessageTemplate::isDirectDebitTemplate($messageTemplateId);
+    if (!$isDirectDebitTemplate) {
+      parent::postProcess();
+      return;
     }
-    else {
-      CRM_Contact_Form_Task_EmailCommon::postProcess($this);
-    }
+
+    $membershipEmailCommon = new CRM_ManualDirectDebit_Mail_Task_Email_MembershipEmail();
+    $membershipEmailCommon->postProcess($this);
+
   }
 
 }

--- a/CRM/ManualDirectDebit/Mail/Task/Email/AbstractEmailCommon.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Email/AbstractEmailCommon.php
@@ -1,0 +1,46 @@
+<?php
+
+
+abstract class CRM_ManualDirectDebit_Mail_Task_Email_AbstractEmailCommon extends CRM_Contact_Form_Task_EmailCommon {
+
+  use CRM_Contact_Form_Task_EmailTrait;
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function postProcess(&$form) {
+    $this->bounceIfSimpleMailLimitExceeded(count($form->_contactIds));
+
+    // check and ensure that
+    $formValues = $form->controller->exportValues($form->getName());
+
+    $this->submit($form, $formValues);
+  }
+
+  /**
+   * Validates ids
+   *
+   * @param $ids
+   *
+   * @return array
+   */
+  protected static function validateIds($ids) {
+    if (is_array($ids)) {
+      $validatedIds = [];
+      foreach ($ids as $id) {
+        $validatedIds[] = (int) $id;
+      }
+
+      return $validatedIds;
+    }
+
+    return [];
+  }
+
+  abstract protected function submit(&$form, $formValues);
+
+}

--- a/CRM/ManualDirectDebit/Mail/Task/Email/ContributionEmail.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Email/ContributionEmail.php
@@ -151,7 +151,7 @@ class CRM_ManualDirectDebit_Mail_Task_Email_ContributionEmail extends CRM_Manual
       $tplParams = $dataCollector->retrieve();
       $contactDetail = [$formattedContactDetail];
       $subject = $mailDetails->getSubject();
-      CRM_ManualDirectDebit_Mail_Task_Mail::sendEmail(
+      CRM_ManualDirectDebit_Mail_Task_Mail::sendDirectDebitEmail(
         $contactDetail,
         $subject,
         $formValues['text_message'],

--- a/CRM/ManualDirectDebit/Mail/Task/Email/ContributionEmail.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Email/ContributionEmail.php
@@ -1,22 +1,7 @@
 <?php
 use CRM_ManualDirectDebit_Mail_Task_MailDetailsModel as MailDetailsModel;
 
-class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contact_Form_Task_EmailCommon {
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   *
-   * @param CRM_Core_Form $form
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public static function postProcess(&$form) {
-    self::bounceIfSimpleMailLimitExceeded(count($form->_contactIds));
-
-    // check and ensure that
-    $formValues = $form->controller->exportValues($form->getName());
-    self::submit($form, $formValues);
-  }
+class CRM_ManualDirectDebit_Mail_Task_Email_ContributionEmail extends CRM_ManualDirectDebit_Mail_Task_Email_AbstractEmailCommon {
 
   /**
    * Submit the form values.
@@ -28,8 +13,8 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
    *
    * @throws \CRM_Core_Exception
    */
-  public static function submit(&$form, $formValues) {
-    self::saveMessageTemplate($formValues);
+  public function submit(&$form, $formValues) {
+    $this->saveMessageTemplate($formValues);
 
     $from = CRM_Utils_Array::value('from_email_address', $formValues);
     $from = CRM_Utils_Mail::formatFromAddress($from);
@@ -221,26 +206,6 @@ class CRM_ManualDirectDebit_Mail_Task_ContributionEmailCommon extends CRM_Contac
     }
 
     return $contactContributionIds;
-  }
-
-  /**
-   * Validates ids
-   *
-   * @param $ids
-   *
-   * @return array
-   */
-  private static function validateIds($ids) {
-    if (is_array($ids)) {
-      $validatedIds = [];
-      foreach ($ids as $id) {
-        $validatedIds[] = (int) $id;
-      }
-
-      return $validatedIds;
-    }
-
-    return [];
   }
 
 }

--- a/CRM/ManualDirectDebit/Mail/Task/Email/MembershipEmail.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Email/MembershipEmail.php
@@ -107,7 +107,7 @@ class CRM_ManualDirectDebit_Mail_Task_Email_MembershipEmail extends CRM_ManualDi
           $dataCollector = new CRM_ManualDirectDebit_Mail_DataCollector_Membership($membershipId);
           $tplParams = $dataCollector->retrieve();
           $contactDetail = [$formattedContactDetail];
-          CRM_ManualDirectDebit_Mail_Task_Mail::sendEmail(
+          CRM_ManualDirectDebit_Mail_Task_Mail::sendDirectDebitEmail(
             $contactDetail,
             $subject,
             $formValues['text_message'],

--- a/CRM/ManualDirectDebit/Mail/Task/Email/MembershipEmail.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Email/MembershipEmail.php
@@ -1,21 +1,6 @@
 <?php
 
-class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_Form_Task_EmailCommon {
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   *
-   * @param CRM_Core_Form $form
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public static function postProcess(&$form) {
-    self::bounceIfSimpleMailLimitExceeded(count($form->_contactIds));
-
-    // check and ensure that
-    $formValues = $form->controller->exportValues($form->getName());
-    self::submit($form, $formValues);
-  }
+class CRM_ManualDirectDebit_Mail_Task_Email_MembershipEmail extends CRM_ManualDirectDebit_Mail_Task_Email_AbstractEmailCommon {
 
   /**
    * Submit the form values.
@@ -27,8 +12,8 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
    *
    * @throws \CRM_Core_Exception
    */
-  public static function submit(&$form, $formValues) {
-    self::saveMessageTemplate($formValues);
+  public function submit(&$form, $formValues) {
+    $this->saveMessageTemplate($formValues);
 
     $from = CRM_Utils_Array::value('from_email_address', $formValues);
     $from = CRM_Utils_Mail::formatFromAddress($from);
@@ -165,7 +150,7 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
     $validatedMembershipIds = self::validateIds($membershipIds);
     $validatedMembershipIdsImploded = implode(', ', $validatedMembershipIds);
     $query = "
-      SELECT membership.id AS contribution_id 
+      SELECT membership.id AS contribution_id
       FROM civicrm_membership AS membership
       WHERE membership.contact_id = %1
         AND membership.id IN(" . $validatedMembershipIdsImploded . ")
@@ -181,26 +166,6 @@ class CRM_ManualDirectDebit_Mail_Task_MembershipEmailCommon extends CRM_Contact_
     }
 
     return $contactMembershipIds;
-  }
-
-  /**
-   * Validates ids
-   *
-   * @param $ids
-   *
-   * @return array
-   */
-  private static function validateIds($ids) {
-    if (is_array($ids)) {
-      $validatedIds = [];
-      foreach ($ids as $id) {
-        $validatedIds[] = (int) $id;
-      }
-
-      return $validatedIds;
-    }
-
-    return [];
   }
 
 }

--- a/CRM/ManualDirectDebit/Mail/Task/Mail.php
+++ b/CRM/ManualDirectDebit/Mail/Task/Mail.php
@@ -36,7 +36,7 @@ class CRM_ManualDirectDebit_Mail_Task_Mail extends CRM_Activity_BAO_Activity {
    *   ( sent, activityId) if any email is sent and activityId
    * @throws \CRM_Core_Exception
    */
-  public static function sendEmail(
+  public static function sendDirectDebitEmail(
     &$contactDetails,
     &$subject,
     &$text,


### PR DESCRIPTION
## Overview

When using Find contributions / Find memberships to search for contribution or memberships, Manual Direct Debit extensions provide a feature to send direct debit notifications on the actions using Manual Direct Templates. 

The implementation was extended CiviCRM core functions which were moved from the class to traits since CiviCRM 5.34 [here](https://github.com/civicrm/civicrm-core/pull/19214). 

This PR refactors the code in the Manual Direct Debit to align with the changes in the CiviCRM core. 

## Before

Error was present when sending email from "Send Direct Debit Notifications" actions when using Direct Debit templates or CiviCRM templates.

## After

Email can be sent when using Send Direct Debit Notifications when using either

- Direct Debit templates.
- CiviCRM templates. 

## Technical Details

This PR also takes an opportunity to refactor codes to fix or address  as the following: 

-  Decouple the functions by abstracting function onto abstract class
- Fix warning issue on overriding method that have different signature. 