### PR TITLE
MAE-493: Fix search button markup on manage screen

### DIFF
--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -15,10 +15,10 @@
         </div>
         <div class="clear">&nbsp;</div>
         <div class="crm-submit-buttons">
-          <span class="crm-button crm-button-type-refresh crm-button_qf_Basic_refresh crm-i-button">
+          <button class="crm-button crm-form-xbutton crm-form-submit" name="_qf_Basic_refresh" value="Search" id="_qf_Basic_refresh">
             <i class="crm-i fa-check" aria-hidden="true"></i>
-            <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Basic_refresh" value="Search" type="submit" id="_qf_Basic_refresh">
-          </span>
+            {ts}Search{/ts}
+          </button>
         </div>
     </form>
   </div>


### PR DESCRIPTION
## Overview
As part of updating the button markup for [supporting 5.35 on shoreditch](https://github.com/civicrm/org.civicrm.shoreditch/commit/e7986e2327b69d50e57717bc306f9906491a17ff), the search button styles got broken as it is having old classes and markup. This PR fixes the markup for the search button to retain its styles.

## Before
<img width="468" alt="Screenshot 2021-03-16 at 12 35 19 PM" src="https://user-images.githubusercontent.com/3340537/111272544-c842d800-8658-11eb-98c3-a42ef72c321b.png">


## After
<img width="649" alt="Screenshot 2021-03-16 at 12 56 09 PM" src="https://user-images.githubusercontent.com/3340537/111272551-cc6ef580-8658-11eb-89d0-f98a3711646f.png">


## Technical Details
* The idea was to change `input.crm-form-submit` to `button.crm-form-submit` HTML markup and the `<i>` (icon HTML) was added inside of it.