### PR TITLE
IO-136: V5 contribution receive date calculation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git -b IO-136-v5-contribution-receive-date-calculation
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
 
       - name: Run phpunit tests

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
@@ -85,7 +85,7 @@ abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base 
       return TRUE;
     }
 
-    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+    if ($this->params['payment_instrument_id'] == $this->directDebitPaymentInstrument['value']) {
       return TRUE;
     }
 

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 
 /**
  * Class OtherContribution.
@@ -10,28 +9,18 @@ use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDate
 class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution {
 
   /**
-   * Number of instalment in payment plan.
-   *
-   * @var int
-   */
-  private $contributionNumber;
-
-  /**
    * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution constructor.
    *
-   * @param int $contributionNumber
    * @param string $receiveDate
    * @param array $params
    * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
    *
    * @throws \CRM_Extension_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function __construct($contributionNumber, &$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
-    $this->contributionNumber = $contributionNumber;
+  public function __construct(&$receiveDate, array $params, SettingsManager $settingsManager) {
 
-    parent::__construct($receiveDate, $params, $settingsManager, $calculator);
+    parent::__construct($receiveDate, $params, $settingsManager);
   }
 
   /**
@@ -41,33 +30,12 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
    * @throws \Exception
    */
   public function process() {
-    $previousInstalmentDate = $this->getPreviousContributionReceiveDate();
-    $receiveDate = new DateTime($previousInstalmentDate);
+    $receiveDate = new DateTime($this->params['previous_instalment_date']);
 
-    $recurringContribution = $this->getRecurringContribution();
-    $numberOfIntervals = $recurringContribution['frequency_interval'];
-    $frequencyUnit = $recurringContribution['frequency_unit'];
+    $numberOfIntervals = $this->params['frequency_interval'];
+    $frequencyUnit = $this->params['frequency_unit'];
 
     $this->receiveDate = $this->calculateNextInstalmentReceiveDate($receiveDate, $numberOfIntervals, $frequencyUnit);
-  }
-
-  /**
-   * Obtains the receive date of the last contribution in the payment plan.
-   *
-   * @return mixed|string
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getPreviousContributionReceiveDate() {
-    $result = civicrm_api3('Contribution', 'get', [
-      'sequential' => 1,
-      'contribution_recur_id' => $this->params['contribution_recur_id'],
-      'options' => [
-        'limit' => 0,
-        'sort' => 'id ASC',
-      ],
-    ]);
-
-    return $result['values'][$this->contributionNumber - 2]['receive_date'];
   }
 
 }

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -77,11 +77,18 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       $membershipsStartDate->format('Y-m-' . $recurringContribution['cycle_day'])
     );
 
-    $this->receiveDate = $this->calculateNextInstalmentReceiveDate(
+    $secondInstalmentReceiveDate = $this->calculateNextInstalmentReceiveDate(
       $firstMembershipCycleDate,
       $recurringContribution['frequency_interval'],
       $recurringContribution['frequency_unit']
     );
+    $this->receiveDate = $secondInstalmentReceiveDate;
+
+    $firstInstalmentDateTime = new DateTime($firstContribution['receive_date']);
+    $secondInstalmentDateTime = new DateTime($secondInstalmentReceiveDate);
+    if ($firstInstalmentDateTime > $secondInstalmentDateTime) {
+      $this->receiveDate = $firstInstalmentDateTime->format('Y-m-d H:i:s');
+    }
   }
 
   /**

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 
 /**
  * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
@@ -10,7 +9,7 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
   /**
    * Helper object used to calculate receive dates.
    *
-   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @var \CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator
    */
   protected $receiveDateCalculator;
 
@@ -20,15 +19,15 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
    * @param string $receiveDate
    * @param array $params
    * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
-   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
    *
    * @throws \CRM_Extension_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  public function __construct(&$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
+  public function __construct(&$receiveDate, array $params, SettingsManager $settingsManager) {
+
     parent::__construct($receiveDate, $params, $settingsManager);
 
-    $this->receiveDateCalculator = $calculator;
+    $this->receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator();
   }
 
   /**
@@ -49,50 +48,40 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
   /**
    * Determines if the payment plan is a renewal or if it's being created.
    *
-   * @throws \CiviCRM_API3_Exception
+   * To detect whether the payment plan is being renewed, we check if membership
+   * has more than one recurring contributions attached to the membership or not
+   * if the membership has more than one recurring contribution, this means that
+   * the payment plan is being renewed.
+   *
+   * @return bool
    */
   private function isRenewal() {
-    $previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
-    $result = civicrm_api3('ContributionRecur', 'get', [
-      'id' => $this->params['contribution_recur_id'],
-      'return' => ['custom_' . $previousPeriodFieldID],
+    if (is_null($this->params['contribution_recur_id']) && is_null($this->params['membership_id'])) {
+      return FALSE;
+    }
+
+    $query = "
+        SELECT DISTINCT civicrm_contribution.contribution_recur_id
+        FROM civicrm_contribution
+        INNER JOIN civicrm_membership_payment
+            ON civicrm_contribution.id = civicrm_membership_payment.contribution_id
+        WHERE  civicrm_membership_payment.membership_id = %1
+        GROUP BY civicrm_contribution.contribution_recur_id";
+
+    $result = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->params['membership_id'], 'Integer'],
     ]);
 
-    if ($result['count'] > 0) {
-      $recurringContribution = array_shift($result['values']);
-      $previousPeriodRecurringContributionID = CRM_Utils_Array::value(
-        'custom_' . $previousPeriodFieldID,
-        $recurringContribution
-      );
-      if (!empty($previousPeriodRecurringContributionID)) {
-        return TRUE;
-      }
+    $paymentPlanIds = [];
+    while ($result->fetch()) {
+      $paymentPlanIds[] = $result->contribution_recur_id;
+    }
+
+    if (count($paymentPlanIds) > 1) {
+      return TRUE;
     }
 
     return FALSE;
-  }
-
-  /**
-   * Obtains ID for custom field name in given group.
-   *
-   * @param $fieldGroup
-   * @param $fieldName
-   *
-   * @return int
-   * @throws \Exception
-   */
-  protected function getCustomFieldID($fieldGroup, $fieldName) {
-    $result = civicrm_api3('CustomField', 'get', [
-      'sequential' => 1,
-      'custom_group_id' => $fieldGroup,
-      'name' => $fieldName,
-    ]);
-
-    if ($result['count'] > 0) {
-      return $result['values'][0]['id'];
-    }
-
-    throw new Exception("Cannot find customfield $fieldName in $fieldGroup group.");
   }
 
   /**
@@ -118,117 +107,21 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
    * @throws \Exception
    */
   private function forceSecondInstalmentOnSecondPeriod() {
-    $recurringContribution = $this->getRecurringContribution();
-    $firstContribution = $this->getFirstContribution();
-    $membershipsStartDate = $this->getMembershipsStartDate($firstContribution);
-
-    $firstMembershipCycleDate = new DateTime(
-      $membershipsStartDate->format('Y-m-' . $recurringContribution['cycle_day'])
-    );
-
+    $membershipsStartDate = new DateTime($this->params['membership_start_date']);
+    $firstInstalmentDateTime = new DateTime($this->params['previous_instalment_date']);
+    $cycleDay = $firstInstalmentDateTime->format('d');
+    $firstMembershipCycleDate = new DateTime($membershipsStartDate->format('Y-m-' . $cycleDay));
     $secondInstalmentReceiveDate = $this->calculateNextInstalmentReceiveDate(
       $firstMembershipCycleDate,
-      $recurringContribution['frequency_interval'],
-      $recurringContribution['frequency_unit']
+      $this->params['frequency_interval'],
+      $this->params['frequency_unit']
     );
     $this->receiveDate = $secondInstalmentReceiveDate;
 
-    $firstInstalmentDateTime = new DateTime($firstContribution['receive_date']);
     $secondInstalmentDateTime = new DateTime($secondInstalmentReceiveDate);
     if ($firstInstalmentDateTime > $secondInstalmentDateTime) {
       $this->receiveDate = $firstInstalmentDateTime->format('Y-m-d H:i:s');
     }
-  }
-
-  /**
-   * Obteins the first contribution in the payment plan.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getFirstContribution() {
-    $result = civicrm_api3('Contribution', 'get', [
-      'sequential' => 1,
-      'contribution_recur_id' => $this->params['contribution_recur_id'],
-      'options' => [
-        'limit' => 0,
-        'sort' => 'id',
-      ],
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
-  }
-
-  /**
-   * Obtains a membership's start date from those related to the payment plan.
-   *
-   * @param array $firstContribution
-   *
-   * @return \DateTime|null
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getMembershipsStartDate($firstContribution) {
-    $lineItems = $this->getContributionLineItems($firstContribution);
-
-    foreach ($lineItems as $line) {
-      if ($line['entity_table'] != 'civicrm_membership') {
-        continue;
-      }
-
-      $membership = $this->getMembership($line['entity_id']);
-
-      return new DateTime($membership['start_date']);
-    }
-
-    return NULL;
-  }
-
-  /**
-   * Obtains the list of line items for the given contribution.
-   *
-   * @param $contribution
-   *
-   * @return array|mixed
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getContributionLineItems($contribution) {
-    $result = civicrm_api3('LineItem', 'get', [
-      'sequential' => 1,
-      'contribution_id' => $contribution['id'],
-      'options' => ['limit' => 0],
-    ]);
-
-    if ($result['count'] > 0) {
-      return $result['values'];
-    }
-
-    return [];
-  }
-
-  /**
-   * Obtains the given membership's data.
-   *
-   * @param int $membershipID
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getMembership($membershipID) {
-    $result = civicrm_api3('Membership', 'get', [
-      'sequential' => 1,
-      'id' => $membershipID,
-      'options' => ['limit' => 0],
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
   }
 
   /**

--- a/CRM/ManualDirectDebit/Test/Helper/PaymentPlanTrait.php
+++ b/CRM/ManualDirectDebit/Test/Helper/PaymentPlanTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+
+trait CRM_ManualDirectDebit_Test_Helper_PaymentPlanTrait {
+
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  /**
+   * A helper funcitons that configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate) {
+    $testMembershipType = MembershipTypeFabricator::fabricate(
+      [
+        'name' => 'Test Rolling Membership',
+        'period_type' => 'rolling',
+        'minimum_fee' => 120,
+        'duration_interval' => 1,
+        'duration_unit' => 'year',
+      ]);
+
+    $testMembershipTypePriceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $testMembershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $paymentPlanEntity = new CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder();
+    $paymentPlanEntity->membershipStartDate = $membershipStartDate;
+    $paymentPlanEntity->paymentPlanStartDate = $firstInstalmentReceiveDate;
+    $paymentPlanEntity->paymentMethod = 'direct_debit';
+    $paymentPlanEntity->paymentPlanFrequency = 'Monthly';
+    $paymentPlanEntity->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $testMembershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $testMembershipTypePriceFieldValue['id'],
+      'label' => $testMembershipType['name'],
+      'qty' => 1,
+      'unit_price' => $testMembershipTypePriceFieldValue['amount'],
+      'line_total' => $testMembershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+    ];;
+
+    $recurringContribution = CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder::fabricate($paymentPlanEntity);
+
+    $membership = civicrm_api3('Membership', 'get', [
+      'sequential'   => 1,
+      'membership_type_id' => $testMembershipType['id'],
+      'contact_id' => $recurringContribution['contact_id'],
+    ]);
+
+    //Passing membership ID along with recurring recurring contribution for testing.
+    $recurringContribution['membership_id'] = $membership['id'];
+
+    return $recurringContribution;
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -396,9 +396,11 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
  * Implements hook_membershipextras_calculateContributionReceiveDate().
  */
 function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
-  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
-  $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
+  if ($contributionCreationParams['payment_schedule'] != CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
+    return;
+  }
 
+  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
   switch ($contributionNumber) {
     case 1:
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
@@ -413,19 +415,16 @@ function manualdirectdebit_membershipextras_calculateContributionReceiveDate($co
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
         $receiveDate,
         $contributionCreationParams,
-        $settingsManager,
-        $calculator
+        $settingsManager
       );
       $receiveDateCalculator->process();
       break;
 
     default:
       $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
-        $contributionNumber,
         $receiveDate,
         $contributionCreationParams,
-        $settingsManager,
-        $calculator
+        $settingsManager
       );
       $receiveDateCalculator->process();
   }

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -65,7 +65,7 @@ return [
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(31),
+    'html_attributes' => generateSequenceNumbers(28),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
@@ -29,10 +29,6 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribut
    * @var array
    */
   private $defaultContributionParams = [
-    'is_pay_later' => TRUE,
-    'skipLineItem' => 1,
-    'skipCleanMoney' => TRUE,
-    'fee_amount' => 0,
     'payment_instrument_id' => 'direct_debit',
   ];
 

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -1,12 +1,5 @@
 <?php
-use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
-use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
-use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
-use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
-use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
-use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution as OtherContributionReceiveDateCalculator;
 
 /**
@@ -15,6 +8,9 @@ use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributio
  * @group headless
  */
 class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest extends BaseHeadlessTest {
+
+  use CRM_ManualDirectDebit_Test_Helper_PaymentPlanTrait;
+
   /**
    * Default direct debit settings that will be used for tests.
    *
@@ -35,181 +31,33 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribut
    * @var array
    */
   private $defaultContributionParams = [
-    'is_pay_later' => TRUE,
-    'skipLineItem' => 1,
-    'skipCleanMoney' => TRUE,
-    'fee_amount' => 0,
     'payment_instrument_id' => 'direct_debit',
   ];
 
-  /**
-   * Helper function to create memberships and its default price field value.
-   *
-   * @param array $params
-   *
-   * @return \stdClass
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function createMembershipType($params) {
-    $membershipType = MembershipTypeFabricator::fabricate($params);
-    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
-      'sequential' => 1,
-      'membership_type_id' => $membershipType['id'],
-      'options' => ['limit' => 1],
-    ])['values'][0];
-
-    $result = new stdClass();
-    $result->membershipType = $membershipType;
-    $result->priceFieldValue = $priceFieldValue;
-
-    return $result;
-  }
-
-  /**
-   * Builds a mock class to manage DD settings.
-   *
-   * @return \CRM_ManualDirectDebit_Common_SettingsManager
-   */
-  private function buildSettingsManagerMock($settings) {
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
-
-    return $settingsManager;
-  }
-
-  /**
-   * Builds mock receive date calculator object.
-   *
-   * @param string $dayNextMonth
-   *
-   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
-   * @throws \Exception
-   */
-  private function buildReceiveDateCalculatorMock($dayNextMonth) {
-    $calculator = $this->createMock(ReceiveDateCalculator::class);
-    $calculator
-      ->method('getSameDayNextMonth')
-      ->willReturn(new DateTime($dayNextMonth));
-
-    return $calculator;
-  }
-
-  /**
-   * Configures a payment plan to be used on tests.
-   *
-   * @param string $membershipStartDate
-   * @param string $firstInstalmentReceiveDate
-   * @param int $numberOfContributions
-   * @param array $params
-   *
-   * @return mixed
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, $numberOfContributions, array $params) {
-    $mainMembershipType = $this->createMembershipType([
-      'name' => 'Main Rolling Membership',
-      'period_type' => 'rolling',
-      'minimum_fee' => $params['amount'],
-      'duration_interval' => $params['installments'],
-      'duration_unit' => 'month',
-    ]);
-
-    $contact = ContactFabricator::fabricate();
-    $recurringContribution = RecurringContributionFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'amount' => $params['amount'],
-      'currency' => NULL,
-      'frequency_unit' => $params['frequency_unit'],
-      'frequency_interval' => $params['frequency_interval'],
-      'installments' => $params['installments'],
-      'start_date' => $firstInstalmentReceiveDate,
-      'contribution_status_id' => 'Pending',
-      'is_test' => 0,
-      'cycle_day' => $params['cycle_day'],
-      'payment_processor_id' => 'Offline Recurring Contribution',
-      'financial_type_id' => 'Member Dues',
-      'payment_instrument_id' => 'direct_debit',
-      'campaign_id' => NULL,
-    ]);
-    $receiveDateCalculator = new ReceiveDateCalculator($recurringContribution);
-
-    $membership = MembershipFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'membership_type_id' => $mainMembershipType->membershipType['id'],
-      'join_date' => $membershipStartDate,
-      'start_date' => $membershipStartDate,
-      'end_date' => NULL,
-      'contribution_recur_id' => $recurringContribution['id'],
-      'financial_type_id' => 'Member Dues',
-      'skipLineItem' => 1,
-    ]);
-
-    for ($i = 0; $i < $numberOfContributions; $i++) {
-      $receiveDate = $i === 0 ? $firstInstalmentReceiveDate : $receiveDateCalculator->calculate($i + 1);
-      $contribution = ContributionFabricator::fabricate([
-        'currency' => NULL,
-        'source' => NULL,
-        'contact_id' => $contact['id'],
-        'fee_amount' => 0,
-        'net_amount' => $params['amount'] / $params['installments'],
-        'total_amount' => $params['amount'] / $params['installments'],
-        'receive_date' => $receiveDate,
-        'payment_instrument_id' => 'direct_debit',
-        'financial_type_id' => 'Member Dues',
-        'is_test' => 0,
-        'contribution_status_id' => 'Pending',
-        'is_pay_later' => TRUE,
-        'skipLineItem' => 1,
-        'skipCleanMoney' => TRUE,
-        'contribution_recur_id' => $recurringContribution['id'],
-      ]);
-      LineItemFabricator::fabricate([
-        'entity_table' => 'civicrm_membership',
-        'entity_id' => $membership['id'],
-        'contribution_id' => $contribution['id'],
-        'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
-        'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
-        'label' => $mainMembershipType->membershipType['name'],
-        'qty' => 1,
-        'unit_price' => $contribution['total_amount'],
-        'line_total' => $contribution['total_amount'],
-        'financial_type_id' => 'Member Dues',
-        'non_deductible_amount' => 0,
-        'auto_renew' => 0,
-      ]);
-    }
-
-    return $recurringContribution;
-  }
-
-  public function testReceiveDateCalculationOfPaymentsAboveSecondInstalment() {
-    $membershipStartDate = '2020-01-01';
+  public function testReceiveDateCalculationOfPaymentsFollowSecondInstalment() {
+    $membershipStartDate = '2020-01-15';
     $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
-    $receiveDate = $this->defaultContributionParams['receive_date'] = '2002-12-29';
 
-    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, 3, [
-      'amount' => 1200,
-      'frequency_unit' => 'month',
-      'frequency_interval' => 1,
-      'installments' => 12,
-      'cycle_day' => 15,
-    ]);
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate);
+
+    $secondInstalmentReceiveDate = '2020-02-15 00:00:00';
+
+    //$this->defaultContributionParams['membership_id'] = $testRollingMembershipType;
     $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+    $this->defaultContributionParams['previous_instalment_date'] = $secondInstalmentReceiveDate;
+    $this->defaultContributionParams['membership_start_date'] = $membershipStartDate;
+    $this->defaultContributionParams['frequency_interval'] = $recurringContribution['frequency_interval'];
+    $this->defaultContributionParams['frequency_unit'] = $recurringContribution['frequency_unit'];
 
     $settingsManager = $this->buildSettingsManagerMock([]);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-04-15');
     $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
-      4,
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
+      $settingsManager
     );
     $receiveDateCalculator->process();
 
-    $this->assertEquals('2020-04-15 00:00:00', $receiveDate);
+    $this->assertEquals('2020-03-15 00:00:00', $receiveDate);
   }
 
 }

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -1,12 +1,6 @@
 <?php
-use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
-use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
-use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
-use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
-use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
-use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+
 use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
-use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
 use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
 
 /**
@@ -15,6 +9,8 @@ use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributi
  * @group headless
  */
 class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest extends BaseHeadlessTest {
+
+  use CRM_ManualDirectDebit_Test_Helper_PaymentPlanTrait;
   /**
    * Default direct debit settings that will be used for tests.
    *
@@ -35,258 +31,33 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
    * @var array
    */
   private $defaultContributionParams = [
-    'is_pay_later' => TRUE,
-    'skipLineItem' => 1,
-    'skipCleanMoney' => TRUE,
-    'fee_amount' => 0,
+    'payment_schedule' => 'monthly',
     'payment_instrument_id' => 'direct_debit',
   ];
-
-  /**
-   * Helper function to create memberships and its default price field value.
-   *
-   * @param array $params
-   *
-   * @return \stdClass
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function createMembershipType($params) {
-    $membershipType = MembershipTypeFabricator::fabricate($params);
-    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
-      'sequential' => 1,
-      'membership_type_id' => $membershipType['id'],
-      'options' => ['limit' => 1],
-    ])['values'][0];
-
-    $result = new stdClass();
-    $result->membershipType = $membershipType;
-    $result->priceFieldValue = $priceFieldValue;
-
-    return $result;
-  }
-
-  /**
-   * Builds a mock class to manage DD settings.
-   *
-   * @return mixed
-   */
-  private function buildSettingsManagerMock($settings) {
-    $settingsManager = $this->createMock(SettingsManager::class);
-    $settingsManager
-      ->method('getManualDirectDebitSettings')
-      ->willReturn(array_merge($this->defaultDDSettings, $settings));
-
-    return $settingsManager;
-  }
-
-  /**
-   * Builds mock receive date calculator object.
-   *
-   * @param string $secondInstalmentReceiveDate
-   *
-   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
-   * @throws \Exception
-   */
-  private function buildReceiveDateCalculatorMock($secondInstalmentReceiveDate) {
-    $calculator = $this->createMock(ReceiveDateCalculator::class);
-    $calculator
-      ->method('getSameDayNextMonth')
-      ->willReturn(new DateTime($secondInstalmentReceiveDate));
-
-    return $calculator;
-  }
-
-  /**
-   * Configures a payment plan to be used on tests.
-   *
-   * @param string $membershipStartDate
-   * @param string $firstInstalmentReceiveDate
-   * @param array $params
-   *
-   * @return mixed
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, array $params) {
-    $mainMembershipType = $this->createMembershipType([
-      'name' => 'Main Rolling Membership',
-      'period_type' => 'rolling',
-      'minimum_fee' => $params['amount'],
-      'duration_interval' => $params['installments'],
-      'duration_unit' => 'month',
-    ]);
-
-    $contact = ContactFabricator::fabricate();
-    $recurringContribution = RecurringContributionFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'amount' => $params['amount'],
-      'currency' => NULL,
-      'frequency_unit' => $params['frequency_unit'],
-      'frequency_interval' => $params['frequency_interval'],
-      'installments' => $params['installments'],
-      'start_date' => $firstInstalmentReceiveDate,
-      'contribution_status_id' => 'Pending',
-      'is_test' => 0,
-      'cycle_day' => $params['cycle_day'],
-      'payment_processor_id' => 'Offline Recurring Contribution',
-      'financial_type_id' => 'Member Dues',
-      'payment_instrument_id' => 'direct_debit',
-      'campaign_id' => NULL,
-    ]);
-    $contribution = ContributionFabricator::fabricate([
-      'currency' => NULL,
-      'source' => NULL,
-      'contact_id' => $contact['id'],
-      'fee_amount' => 0,
-      'net_amount' => $params['amount'] / $params['installments'],
-      'total_amount' => $params['amount'] / $params['installments'],
-      'receive_date' => $firstInstalmentReceiveDate,
-      'payment_instrument_id' => 'direct_debit',
-      'financial_type_id' => 'Member Dues',
-      'is_test' => 0,
-      'contribution_status_id' => 'Pending',
-      'is_pay_later' => TRUE,
-      'skipLineItem' => 1,
-      'skipCleanMoney' => TRUE,
-      'contribution_recur_id' => $recurringContribution['id'],
-    ]);
-    $membership = MembershipFabricator::fabricate([
-      'contact_id' => $contact['id'],
-      'membership_type_id' => $mainMembershipType->membershipType['id'],
-      'join_date' => $membershipStartDate,
-      'start_date' => $membershipStartDate,
-      'end_date' => NULL,
-      'contribution_recur_id' => $recurringContribution['id'],
-      'financial_type_id' => 'Member Dues',
-      'skipLineItem' => 1,
-    ]);
-    LineItemFabricator::fabricate([
-      'entity_table' => 'civicrm_membership',
-      'entity_id' => $membership['id'],
-      'contribution_id' => $contribution['id'],
-      'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
-      'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
-      'label' => $mainMembershipType->membershipType['name'],
-      'qty' => 1,
-      'unit_price' => $contribution['total_amount'],
-      'line_total' => $contribution['total_amount'],
-      'financial_type_id' => 'Member Dues',
-      'non_deductible_amount' => 0,
-      'auto_renew' => 0,
-    ]);
-
-    return $recurringContribution;
-  }
-
-  /**
-   * Obtains the field's ID for the given field name and group name.
-   *
-   * @param string $fieldGroup
-   * @param string $fieldName
-   *
-   * @return int
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getCustomFieldID($fieldGroup, $fieldName) {
-    $result = civicrm_api3('CustomField', 'get', [
-      'sequential' => 1,
-      'custom_group_id' => $fieldGroup,
-      'name' => $fieldName,
-    ]);
-
-    if ($result['count'] > 0) {
-      return $result['values'][0]['id'];
-    }
-
-    return 0;
-  }
-
-  public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
-    $membershipStartDate = '2020-01-01';
-    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
-    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05';
-
-    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
-      'amount' => 1200,
-      'frequency_unit' => 'month',
-      'frequency_interval' => 1,
-      'installments' => 12,
-      'cycle_day' => 5,
-    ]);
-    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
-
-    $settings = [
-      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
-    ];
-    $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-05');
-
-    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
-      $receiveDate,
-      $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
-    );
-    $receiveDateCalculator->process();
-
-    $this->assertEquals($firstInstalmentReceiveDate, $receiveDate);
-  }
-
-  public function testSecondContributionOneMonthAfterFirstWhenStartDateToFirstPaymentIsLessThan30Days() {
-    $membershipStartDate = '2020-01-01';
-    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
-    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
-
-    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
-      'amount' => 120,
-      'frequency_unit' => 'month',
-      'frequency_interval' => 1,
-      'installments' => 12,
-      'cycle_day' => 5,
-    ]);
-    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
-
-    $settings = [
-      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
-    ];
-    $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-15');
-
-    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
-      $receiveDate,
-      $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
-    );
-    $receiveDateCalculator->process();
-
-    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
-  }
 
   public function testSecondContributionOneMonthAfterFirstWhenSettingIsSet() {
     $membershipStartDate = '2020-01-01';
     $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
     $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05 00:00:00';
 
-    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
-      'amount' => 1200,
-      'frequency_unit' => 'month',
-      'frequency_interval' => 1,
-      'installments' => 12,
-      'cycle_day' => 5,
-    ]);
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate);
+
+    $this->defaultContributionParams['membership_id'] = $recurringContribution['membership_id'];
+    $this->defaultContributionParams['previous_instalment_date'] = $firstInstalmentReceiveDate;
     $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+    $this->defaultContributionParams['membership_start_date'] = $membershipStartDate;
+    $this->defaultContributionParams['frequency_interval'] = $recurringContribution['frequency_interval'];
+    $this->defaultContributionParams['frequency_unit'] = $recurringContribution['frequency_unit'];
 
     $settings = [
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-03-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
+      $settingsManager
     );
     $receiveDateCalculator->process();
 
@@ -294,9 +65,8 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
   }
 
   public function testSecondContributionIsNotBeforeFirst() {
-    $membershipStartDate = '2020-08-04';
-    $firstInstalmentReceiveDate = '2020-10-05 00:00:00';
-    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-11-05 00:00:00';
+    $membershipStartDate = '2020-10-05 00:00:00';
+    $firstInstalmentReceiveDate = $membershipStartDate;
 
     $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
       'amount' => 120,
@@ -305,7 +75,13 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'installments' => 12,
       'cycle_day' => 5,
     ]);
+
+    $this->defaultContributionParams['membership_id'] = $recurringContribution['membership_id'];
+    $this->defaultContributionParams['previous_instalment_date'] = $firstInstalmentReceiveDate;
     $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+    $this->defaultContributionParams['membership_start_date'] = $membershipStartDate;
+    $this->defaultContributionParams['frequency_interval'] = $recurringContribution['frequency_interval'];
+    $this->defaultContributionParams['frequency_unit'] = $recurringContribution['frequency_unit'];
 
     $settings = [
       'new_instruction_run_dates' => [4],
@@ -314,24 +90,27 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-09-05');
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
+      $settingsManager
     );
     $receiveDateCalculator->process();
 
     $firstInstalmentDateTime = new DateTime($firstInstalmentReceiveDate);
     $calculatedSecondInstalmentReceiveDateTime = new DateTime($receiveDate);
-    $this->assertFalse($firstInstalmentDateTime > $calculatedSecondInstalmentReceiveDateTime, "First instalment ($firstInstalmentReceiveDate) is after second instalment ($receiveDate)!");
-    $this->assertEquals('2020-10-05 00:00:00', $receiveDate);
+    $this->assertFalse(
+      $firstInstalmentDateTime > $calculatedSecondInstalmentReceiveDateTime,
+      "First instalment ($firstInstalmentReceiveDate) is after second instalment ($receiveDate)!"
+    );
+    $this->assertEquals('2020-11-05 00:00:00', $receiveDate);
   }
 
   public function testSecondContributionOnRenewalsIsNotChanged() {
-    $previousPeriod = $this->setupPlan('2019-08-04', '2019-09-21', [
+    $membershipStartDate = '2019-09-21';
+    $firstPreviousInstalmentReceiveDate = $membershipStartDate;
+    $previousPeriod = $this->setupPlan($membershipStartDate, $firstPreviousInstalmentReceiveDate, [
       'amount' => 120,
       'frequency_unit' => 'month',
       'frequency_interval' => 1,
@@ -339,23 +118,40 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'cycle_day' => 5,
     ]);
 
-    $membershipStartDate = '2019-08-04';
-    $firstInstalmentReceiveDate = '2020-08-21 00:00:00';
-    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-09-21 00:00:00';
-    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+    $membershipId = $previousPeriod['membership_id'];
+
+    $previousContributions = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $previousPeriod['id'],
+    ])['values'];
+
+    foreach ($previousContributions as $contribution) {
+      CRM_Member_BAO_MembershipPayment::create([
+        'membership_id' => $membershipId,
+        'contribution_id' => $contribution['id'],
+      ]);
+    }
+
+    $firstRenewalInstalmentReceiveDate = '2020-08-21 00:00:00';
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstRenewalInstalmentReceiveDate, [
       'amount' => 120,
       'frequency_unit' => 'month',
       'frequency_interval' => 1,
       'installments' => 12,
       'cycle_day' => 5,
     ]);
-    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
 
-    $previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
-    civicrm_api3('ContributionRecur', 'create', [
-      'id' => $recurringContribution['id'],
-      'custom_' . $previousPeriodFieldID => $previousPeriod['id'],
-    ]);
+    $currentContributions = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $recurringContribution['id'],
+    ])['values'];
+
+    foreach ($currentContributions as $contribution) {
+      CRM_Member_BAO_MembershipPayment::create([
+        'membership_id' => $membershipId,
+        'contribution_id' => $contribution['id'],
+      ]);
+    }
 
     $settings = [
       'new_instruction_run_dates' => [4],
@@ -364,27 +160,34 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
     ];
     $settingsManager = $this->buildSettingsManagerMock($settings);
-    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-09-21');
+
+    $this->defaultContributionParams['membership_id'] = $membershipId;
+    $this->defaultContributionParams['previous_instalment_date'] = $firstRenewalInstalmentReceiveDate;
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+    $this->defaultContributionParams['membership_start_date'] = $membershipStartDate;
+    $this->defaultContributionParams['frequency_interval'] = $recurringContribution['frequency_interval'];
+    $this->defaultContributionParams['frequency_unit'] = $recurringContribution['frequency_unit'];
+
+    $preprocessReceiveDate = '2020-09-21 00:00:00';
+    $receiveDate = $preprocessReceiveDate;
 
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
+      $settingsManager
     );
     $receiveDateCalculator->process();
-    $this->assertEquals('2020-09-21 00:00:00', $receiveDate);
+    $this->assertEquals($preprocessReceiveDate, $receiveDate);
 
     $settings['second_instalment_date_behaviour'] = SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER;
     $settingsManager = $this->buildSettingsManagerMock($settings);
     $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
       $receiveDate,
       $this->defaultContributionParams,
-      $settingsManager,
-      $receiveDateCalculatorHelper
+      $settingsManager
     );
     $receiveDateCalculator->process();
-    $this->assertEquals('2020-09-21 00:00:00', $receiveDate);
+    $this->assertEquals($preprocessReceiveDate, $receiveDate);
   }
 
 }


### PR DESCRIPTION
## Overview

This PR depends on this [PR](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/380)

This PR updates the logic that the calculation contribution received date as the hook parameters has been changed from contribution array object to a new set of parameters.

## Before

CalculateContribuitonRecieveDate was implemented based on the contribution object.

## After
CalculateContribuitonRecieveDate implementation is implemented as per new parameters passing from the hook. 

The new parameters are: 

```
    $params = [
      'membership_id' => NULL,
      'contribution_recur_id' => NULL,
      'previous_instalment_date' => NULL,
      'payment_schedule' => $this->schedule,
      'payment_instrument_id' => $paymentMethod,
      'membership_start_date' => $firstInstalmentDate,
      'frequency_interval' => $instalmentFrequencyInterval,
      'frequency_unit' => $instalmentFrequencyUnit,
    ];`
```

The calculations for the dates remains the same except the values are taking from new parameters. 

### Technical details

- This [commit](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/236/commits/e79186ea06eee6a2e9613543402de76b5ce50cd7) is a temporary update, which will be updated when the branch is merged to work stream, the reason that this was done because Manual Direct Debit Tests required the code on the Membership v5 branch. 
- There is also changes in Membership Extras that affects the functionality for Manual Direct Debit to check whether, payment plan is being renewed or not so we could determine if we enforce calculation on the second instalments.

The SQL snippet below is used to get a list of recurring contributions by membership ID, if the result is more than one, we would need to ignore the second instalment calculation even though we 

```
        SELECT DISTINCT civicrm_contribution.contribution_recur_id
        FROM civicrm_contribution
        INNER JOIN civicrm_membership_payment
            ON civicrm_contribution.id = civicrm_membership_payment.contribution_id
        WHERE  civicrm_membership_payment.membership_id = %1
        GROUP BY civicrm_contribution.contribution_recur_id";
```

 