### PR TITLE
CIVIPLUS-176: Add administer Manual Direct Debit permission

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -132,6 +132,11 @@ function manualdirectdebit_civicrm_alterSettingsFolders(&$metaDataFolders = NULL
 function manualdirectdebit_civicrm_permission(&$permissions) {
   $permissionsPrefix = 'CiviCRM : ';
   $permissions['can manage direct debit batches'] = $permissionsPrefix . ts('Can manage Direct Debit Batches');
+
+  $permissions['administer ManualDirectDebit'] = [
+    E::ts('MembershipExtras: administer Manual Direct Debit'),
+    E::ts('Perform all Manual Direct Debit administration tasks in CiviCRM'),
+  ];
 }
 
 /**
@@ -142,8 +147,8 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
   $directDebitMenuItem = [
     'name' => ts('Direct Debit'),
     'url' => NULL,
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
+    'permission' => 'administer CiviCRM, administer ManualDirectDebit',
+    'operator' => 'OR',
     'separator' => NULL,
   ];
   _manualdirectdebit_civix_insert_navigation_menu($menu, 'Administer/', $directDebitMenuItem);
@@ -152,22 +157,22 @@ function manualdirectdebit_civicrm_navigationMenu(&$menu) {
     [
       'name' => ts('Direct Debit Codes'),
       'url' => 'civicrm/admin/options/direct_debit_codes',
-      'permission' => 'administer CiviCRM',
-      'operator' => NULL,
+      'permission' => 'administer CiviCRM, administer ManualDirectDebit',
+      'operator' => 'OR',
       'separator' => NULL,
     ],
     [
       'name' => ts('Direct Debit Configuration'),
       'url' => 'civicrm/admin/direct_debit_configuration',
-      'permission' => 'administer CiviCRM',
-      'operator' => NULL,
+      'permission' => 'administer CiviCRM, administer ManualDirectDebit',
+      'operator' => 'OR',
       'separator' => NULL,
     ],
     [
       'name' => ts('Direct Debit Originator Number'),
       'url' => 'civicrm/admin/options/direct_debit_originator_number?reset=1',
-      'permission' => 'administer CiviCRM',
-      'operator' => NULL,
+      'permission' => 'administer CiviCRM, administer ManualDirectDebit',
+      'operator' => 'OR',
       'separator' => NULL,
     ],
   ];

--- a/xml/Menu/manualdirectdebit.xml
+++ b/xml/Menu/manualdirectdebit.xml
@@ -5,7 +5,7 @@
     <title>Direct Debit Configuration</title>
     <path_arguments>reset=1</path_arguments>
     <page_callback>CRM_ManualDirectDebit_Form_Configurations</page_callback>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer ManualDirectDebit</access_arguments>
     <page_type>0</page_type>
   </item>
   <item>


### PR DESCRIPTION
## Overview

Currently, the direct debit configuration can only be accessed with a user that has permission `administer CiviCRM`. In some systems like SaaS platform or even in some organisations, that may not want to give  `administer CiviCRM` to the site administer  but allows access to the certain admin pages and forms.   

This PR adds new `administer Manual Direct Debit` permission and assign this permission to existing configuration pages that  allows a system admin to assign a new permission to other roles, so the user with the role can access the setting pages without having a global `administer CiviCRM` permission.

## Before

Only user that has `administer CiviCRM` permission can access Manual Direct Debit configuration form. 

## After

Either user that has `administer CiviCRM`  or  `administer Manual Direct Debit` permission can access Manual Direct Debit configuration form. 
