### PR TITLE
BASW-756: Link the DD mandate to the recurring contribution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.35.2 --cms-ver 7.80 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.28.3
+          version: 5.35.2
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -164,7 +164,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
    *
    * @return bool
    */
-  public static function isDirectDebitCustomGroup($currentGroupId) {
+  public static function isDirectDebitMandateCustomGroup($currentGroupId) {
     $directDebitMandateId = civicrm_api3('CustomGroup', 'getvalue', [
       'sequential' => 1,
       'return' => "id",

--- a/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
@@ -47,17 +47,9 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
    */
   private $mandateStartDate;
 
-  public function __construct($entityID, $settings) {
+  public function __construct($entityID, $settings, $mandateStartDate) {
     $this->entityID = $entityID;
     $this->settings = $settings;
-  }
-
-  /**
-   * Sets mandate start date
-   *
-   * @param $mandateStartDate
-   */
-  public function setMandateStartDate($mandateStartDate) {
     $this->mandateStartDate = $mandateStartDate;
   }
 

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator as ContributionDataGenerator;
+
 /**
  * This class launch required fields generator for different entities
  */
@@ -93,8 +95,8 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
    * Generates and saves the Contribution required fields.
    */
   private function generateContributionData() {
-    $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator($this->entityID, $this->settings);
-    $contributionDataGenerator->setMandateStartDate($this->mandateDataGenerator->getMandateStartDate());
+    $mandateStartDate = $this->mandateDataGenerator->getMandateStartDate();
+    $contributionDataGenerator = new ContributionDataGenerator($this->entityID, $this->settings, $mandateStartDate);
     $contributionDataGenerator->generateContributionFieldsValues();
     $contributionDataGenerator->saveGeneratedContributionValues();
   }

--- a/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/DataGenerator.php
@@ -45,40 +45,7 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
    * Generates and saves the required fields values if they are not supplied by the user.
    */
   public function runDataGeneration() {
-    $isThereExistingMandateReference = $this->isThereExistingMandateReference();
     $this->generateMandateData();
-
-    if (!$isThereExistingMandateReference) {
-      $this->generateContributionData();
-    }
-  }
-
-  /**
-   * Checks if the recur contribution
-   * already has a mandate assigned to it
-   * or not.
-   *
-   * @return bool
-   */
-  private function isThereExistingMandateReference() {
-    $contactLastRecurContribution = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'return' => ['id'],
-      'contact_id' => $this->entityID,
-      'options' => ['limit' => 1, 'sort' => 'contribution_recur_id DESC'],
-    ]);
-
-    $mandateReference = NULL;
-    if (!empty($contactLastRecurContribution['values'][0]['id'])) {
-      $contributionRecurId = $contactLastRecurContribution['values'][0]['id'];
-      $mandateReference = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($contributionRecurId);
-    }
-
-    if (!empty($mandateReference)) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**
@@ -87,16 +54,6 @@ class CRM_ManualDirectDebit_Hook_Custom_DataGenerator {
   public function generateMandateData() {
     $this->mandateDataGenerator->generateMandateFieldsValues();
     $this->mandateDataGenerator->saveGeneratedMandateValues();
-  }
-
-  /**
-   * Generates and saves the Contribution required fields.
-   */
-  private function generateContributionData() {
-    $contributionDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator($this->entityID, $this->settings);
-    $contributionDataGenerator->setMandateStartDate($this->mandateDataGenerator->getMandateStartDate());
-    $contributionDataGenerator->generateContributionFieldsValues();
-    $contributionDataGenerator->saveGeneratedContributionValues();
   }
 
 }

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -112,6 +112,15 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
   }
 
   /**
+   * Gets mandate Id property
+   *
+   * @return int mandateId
+   */
+  public function getMandateId() {
+    return $this->mandateId;
+  }
+
+  /**
    * Checks types of dependency
    *
    */

--- a/CRM/ManualDirectDebit/Hook/Post/Contribution.php
+++ b/CRM/ManualDirectDebit/Hook/Post/Contribution.php
@@ -1,21 +1,114 @@
 <?php
 
 use CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager as CollectionReminderSendFlagManager;
+use CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator as ContributionDataGenerator;
+use CRM_ManualDirectDebit_Common_MandateStorageManager as MandateStorageManager;
 
 class CRM_ManualDirectDebit_Hook_Post_Contribution {
 
   private $contributionId;
+  private $contactId;
+  private $contributionRecurId;
+  private $mandateContributionConnector;
 
-  public function __construct($contributionId) {
+  public function __construct($contributionId, $contactId, $contributionRecurId) {
     $this->contributionId = $contributionId;
+    $this->contactId = $contactId;
+    $this->contributionRecurId = $contributionRecurId;
+    $this->mandateContributionConnector = CRM_ManualDirectDebit_Hook_MandateContributionConnector::getInstance();
   }
 
   public function process() {
     $this->createCollectionReminderSendFlag();
+    $this->processTheWebformSubmission();
+  }
+
+  /**
+   * Processes the webform submission.
+   */
+  private function processTheWebformSubmission() {
+    // The module webform_civicrm will load the class
+    // wf_crm_webform_postprocess in the hook_webform_submission_presave hook.
+    // If it is loaded then this is a webform submission.
+    if (!class_exists('wf_crm_webform_postprocess')) {
+      return;
+    }
+
+    $isThereExistingMandateReference = $this->isThereExistingMandateReference();
+    if ($isThereExistingMandateReference) {
+      return;
+    }
+
+    $mandateId = $this->mandateContributionConnector->getMandateId();
+    if (!$mandateId) {
+      $errorMessage = 'Failed to get the mandateId from mandateContributionConnector for the contribution with Id: ' . $this->contributionId;
+      Civi::log()->error($errorMessage);
+      return;
+    }
+
+    $mandateStartDate = $this->getMandateStartDate($mandateId);
+    $manualDirectDebitSettings = $this->getManualDirectDebitSettings();
+    $this->generateContributionData($mandateStartDate);
+    $this->createDependency();
   }
 
   private function createCollectionReminderSendFlag() {
     CollectionReminderSendFlagManager::setIsNotificationSentToUnsent($this->contributionId);
+  }
+
+  /**
+   * Generates and saves the Contribution required fields.
+   */
+  private function generateContributionData($manualDirectDebitSettings, $mandateStartDate) {
+    $contributionDataGenerator = new ContributionDataGenerator($this->contactId, $manualDirectDebitSettings, $mandateStartDate);
+    $contributionDataGenerator->generateContributionFieldsValues();
+    $contributionDataGenerator->saveGeneratedContributionValues();
+  }
+
+  /**
+   * Checks if the recur contribution
+   * already has a mandate assigned to it
+   * or not.
+   *
+   * @return bool
+   */
+  private function isThereExistingMandateReference() {
+    $mandateReference = NULL;
+    if ($this->contributionRecurId) {
+      $mandateReference = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($this->contributionRecurId);
+    }
+
+    return $mandateReference;
+  }
+
+  /**
+   * Creates dependency between mandate and contribution
+   */
+  private function createDependency() {
+    $this->mandateContributionConnector->createDependency();
+  }
+
+  /**
+   * Gets mandate start date.
+   *
+   * @param $mandateId
+   */
+  private function getMandateStartDate($mandateId) {
+    $mandateStorageManager = new MandateStorageManager();
+    $mandate = $mandateStorageManager->getMandate($mandateId);
+    $mandateStartDate = $mandate->start_date;
+
+    return $mandateStartDate;
+  }
+
+  /**
+   * Gets manual direct debit settings.
+   */
+  private function getManualDirectDebitSettings() {
+    $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+    $manualDirectDebitSettings = $settingsManager->getManualDirectDebitSettings();
+
+    return $manualDirectDebitSettings;
   }
 
 }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -216,7 +216,7 @@ function manualdirectdebit_civicrm_postProcess($formName, &$form) {
       break;
 
     case $formName == 'CRM_Contact_Form_CustomData':
-      $isDirectDebitGroup = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'));
+      $isDirectDebitGroup = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitMandateCustomGroup($form->getVar('_groupID'));
       if ($isDirectDebitGroup) {
         $manualDirectDebit = new CRM_ManualDirectDebit_Hook_PostProcess_Contribution_DirectDebitMandate($form);
         $manualDirectDebit->run();
@@ -279,7 +279,7 @@ function _manualdirectdebit_getContactType($contactId) {
  * Implements hook_civicrm_custom().
  */
 function manualdirectdebit_civicrm_custom($op, $groupID, $entityID, &$params) {
-  if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($groupID)) {
+  if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitMandateCustomGroup($groupID)) {
     if ($op == 'create') {
       $mandateDataGenerator = new CRM_ManualDirectDebit_Hook_Custom_DataGenerator($entityID, $params);
       $mandateDataGenerator->runDataGeneration();
@@ -331,7 +331,7 @@ function manualdirectdebit_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName == 'CRM_Contact_Form_CustomData') {
-    if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitCustomGroup($form->getVar('_groupID'))) {
+    if (CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isDirectDebitMandateCustomGroup($form->getVar('_groupID'))) {
       $customData = new CRM_ManualDirectDebit_Hook_BuildForm_CustomData($form);
       $customData->run();
     }

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -312,11 +312,6 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-
-  if ($op == 'create' && $objectName == 'Contribution') {
-    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
-    $postContributionHook->process();
-  }
 }
 
 /**

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -309,7 +309,7 @@ function manualdirectdebit_civicrm_postSave_civicrm_contribution($dao) {
  */
 function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($op == 'create' && $objectName == 'Contribution') {
-    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
+    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId, $objectRef->contact_id, $objectRef->contribution_recur_id);
     $postContributionHook->process();
   }
 }


### PR DESCRIPTION
## Overview
DD mandate is not linked to the recurring contribution any more after updating webform_civicrm to 7.x-4.28-patch8 especially this https://github.com/compucorp/webform_civicrm/pull/36 PR.

## Before
After submitting a webform configured to use direct debit payment method, navigate to contribution tab >> Recurring Contribution  >> View  and **we'll see the “Mandate doesn’t exist” error message**.
![Screenshot from 2021-05-25 18-40-44](https://user-images.githubusercontent.com/74309109/119527205-c7c96a80-bd88-11eb-9246-37ddb84682f7.png)

## After
After submitting a webform configured to use direct debit payment method, navigate to contribution tab >> Recurring Contribution  >> View  and **we'll see the Mandate ID there**.
![Screenshot from 2021-05-25 18-45-18](https://user-images.githubusercontent.com/74309109/119527847-6229ae00-bd89-11eb-8736-e112d7e2b421.png)


## Technical Details
The `webform_civicrm` module was saving the custom fields directly like this:
```php
    $this->saveCustomData($contact, $cid, 'Contact', !empty($this->existing_contacts[$c]), $c);
```

After the update, the module delegates it to the entity to save the custom data and this affects the fired hooks' execution order.

In the past, the execution order was :

```php
manualdirectdebit_civicrm_post("141953", "Individual", $objectRef, "edit")
manualdirectdebit_civicrm_post("14958", "ContributionRecur", $objectRef, "create")
...
...
...
manualdirectdebit_civicrm_custom(141953, "37", "create", $params)
```

In the previous hook, the 37 is ID of the `direct_debit_mandate` custom group which extends the contacts. The relevant back-trace after the previous hook execution was :

```php
MandateContributionConnector.php:109, CRM_ManualDirectDebit_Hook_MandateContributionConnector->setMandateId()
MandateStorageManager.php:199, CRM_ManualDirectDebit_Common_MandateStorageManager->setMandateForCreatingDependency()
MandateStorageManager.php:189, CRM_ManualDirectDebit_Common_MandateStorageManager->updateMandateId()
MandateDataGenerator.php:140, CRM_ManualDirectDebit_Hook_Custom_Mandate_MandateDataGenerator->saveGeneratedMandateValues()
DataGenerator.php:89, CRM_ManualDirectDebit_Hook_Custom_DataGenerator->generateMandateData()
DataGenerator.php:49, CRM_ManualDirectDebit_Hook_Custom_DataGenerator->runDataGeneration()
manualdirectdebit.php:283, manualdirectdebit_civicrm_custom()
```

The `setMandateId` method links the DD mandate to the recurring contribution only if there
is a `contributionId`. Its definition from the file [MandateContributionConnector.php:109](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/4.3.0/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php#L109) is :

```php
  public function setMandateId($mandateId) {
    $this->mandateId = $mandateId;
    if (isset($this->contributionId)) {
      $this->createDependency();
    }
  }
```

After the module update, the fired hook execution order became a bit different. The 'manualdirectdebit_civicrm_custom' hook will be fired first and multiple times before the manualdirectdebit_civicrm_post hook.

```php
manualdirectdebit_civicrm_custom(141953, "37", "create", $params)
```

Because CiviCRM will fire the custom hook before - see [Contact.php:384](https://github.com/civicrm/civicrm-core/blob/5.35.2/CRM/Contact/BAO/Contact.php#L384).

```php
    if (!empty($params['custom']) &&
      is_array($params['custom'])
    ) {
      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_contact', $contact->id);
    }
```

The `setMandateId` method cannot link the DD mandate to recurring contribution because CiviCRM didn't create the recurring contribution or the contributions at this point of time.

--------------

The `setMandateId` method was called during the event of creating the custom fields for the `direct_debit_mandate` custom group for the contact. I started to solve the issue from here and moved any logic related to contributions to the `processTheWebformSubmission` method in the `CRM_ManualDirectDebit_Hook_Post_Contribution` class. It'll link the DD mandate to the recurring contribution if there is a `contributionRecurId`, a `mandateId` and during a webform submission.


