### PR TITLE
BASW-774: Fix the slow loading of "Manage Direct Debit Batches" page

### DIFF
--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -93,6 +93,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $this->notPresent = $notPresent;
     $this->params = $params;
 
+    // The value of $this->params['entityTable'] is 'civicrm_contribution' when
+    // using the "Direct Debit Payments" export search form
     if (empty($this->params['entityTable'])) {
       $this->params['entityTable'] = self::DD_MANDATE_TABLE;
     }
@@ -110,132 +112,159 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   private function setSearchableFields() {
     $this->searchableFields = [
       'entity_id' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.entity_id',
+        'field' => 'entity_id',
       ],
       'bank_name' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.bank_name',
+        'field' => 'bank_name',
       ],
       'bank_street_address' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.bank_street_address',
+        'field' => 'bank_street_address',
       ],
       'bank_city' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.bank_city',
+        'field' => 'bank_city',
       ],
       'bank_county' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.bank_county',
+        'field' => 'bank_county',
       ],
       'bank_postcode' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.bank_postcode',
+        'field' => 'bank_postcode',
       ],
       'account_holder_name' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.account_holder_name',
+        'field' => 'account_holder_name',
       ],
       'ac_number' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.ac_number',
+        'field' => 'ac_number',
       ],
       'sort_code' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.sort_code',
+        'field' => 'sort_code',
       ],
       'dd_code' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => 'IN',
-        'field' => self::DD_MANDATE_TABLE . '.dd_code',
+        'field' => 'dd_code',
       ],
       'dd_ref' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.dd_ref',
+        'field' => 'dd_ref',
       ],
       'start_date' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '<=',
-        'field' => self::DD_MANDATE_TABLE . '.start_date',
+        'field' => 'start_date',
       ],
       'authorisation_date' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.authorisation_date',
-      ],
-      'collection_day' => [
-        'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.collection_day',
+        'field' => 'authorisation_date',
       ],
       'originator_number' => [
+        'table' => self::DD_MANDATE_TABLE,
         'op' => '=',
-        'field' => self::DD_MANDATE_TABLE . '.originator_number',
+        'field' => 'originator_number',
       ],
       'contribution_status_id' => [
+        'table' => 'civicrm_contribution',
         'op' => 'IN',
-        'field' => 'civicrm_contribution.contribution_status_id',
-      ],
-      'recur_status' => [
-        'op' => 'IN',
-        'field' => 'civicrm_contribution_recur.contribution_status_id',
+        'field' => 'contribution_status_id',
       ],
       'financial_type_id' => [
+        'table' => 'civicrm_contribution',
         'op' => 'IN',
-        'field' => 'civicrm_contribution.financial_type_id',
+        'field' => 'financial_type_id',
       ],
       'contribution_currency_type' => [
+        'table' => 'civicrm_contribution',
         'op' => 'IN',
-        'field' => 'civicrm_contribution.currency',
+        'field' => 'currency',
       ],
       'contribution_payment_instrument_id' => [
+        'table' => 'civicrm_contribution',
         'op' => 'IN',
-        'field' => 'civicrm_contribution.payment_instrument_id',
+        'field' => 'payment_instrument_id',
       ],
       'contribution_test' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.is_test',
+        'field' => 'is_test',
       ],
       'contribution_trxn_id' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.trxn_id',
+        'field' => 'trxn_id',
       ],
       'invoice_number' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.invoice_number',
+        'field' => 'invoice_number',
       ],
       'contribution_pay_later' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.is_pay_later',
+        'field' => 'is_pay_later',
       ],
       'cancel_reason' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.cancel_reason',
+        'field' => 'cancel_reason',
       ],
       'contribution_source' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.source',
+        'field' => 'source',
       ],
       'contribution_page_id' => [
+        'table' => 'civicrm_contribution',
         'op' => '=',
-        'field' => 'civicrm_contribution.contribution_page_id',
-      ],
-      'contribution_recur_contribution_status_id' => [
-        'op' => 'IN',
-        'field' => 'civicrm_contribution_recur.contribution_status_id',
-      ],
-      'contact_tags' => [
-        'op' => 'IN',
-        'field' => 'civicrm_entity_tag.tag_id',
-      ],
-      'group' => [
-        'op' => 'IN',
-        'field' => 'civicrm_group_contact.group_id',
+        'field' => 'contribution_page_id',
       ],
       'contribution_amount_low' => [
+        'table' => 'civicrm_contribution',
         'op' => '>=',
-        'field' => 'civicrm_contribution.total_amount',
+        'field' => 'total_amount',
       ],
       'contribution_amount_high' => [
+        'table' => 'civicrm_contribution',
         'op' => '<=',
-        'field' => 'civicrm_contribution.total_amount',
+        'field' => 'total_amount',
+      ],
+      'recur_status' => [
+        'table' => 'civicrm_contribution_recur',
+        'op' => 'IN',
+        'field' => 'contribution_status_id',
+      ],
+      'contribution_recur_contribution_status_id' => [
+        'table' => 'civicrm_contribution_recur',
+        'op' => 'IN',
+        'field' => 'contribution_status_id',
+      ],
+      'contact_tags' => [
+        'table' => 'civicrm_entity_tag',
+        'op' => 'IN',
+        'field' => 'tag_id',
+      ],
+      'group' => [
+        'table' => 'civicrm_group_contact',
+        'op' => 'IN',
+        'field' => 'group_id',
       ],
     ];
   }
@@ -463,10 +492,10 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     foreach ($this->searchableFields as $k => $field) {
       if (isset($this->params[$k])) {
         if ($field['op'] == 'IN') {
-          $query->where($field['field'] . ' ' . $field['op'] . ' (@' . $k . ')', [$k => explode(',', $this->params[$k])]);
+          $query->where("{$field['table']}.{$field['field']} {$field['op']} (@{$k})", [$k => explode(',', $this->params[$k])]);
         }
         else {
-          $query->where($field['field'] . ' ' . $field['op'] . ' @' . $k, [$k => $this->params[$k]]);
+          $query->where("{$field['table']}.{$field['field']} {$field['op']} @{$k}", [$k => $this->params[$k]]);
         }
       }
     }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -504,15 +504,30 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    */
   public function getDDMandateInstructionsQuery() {
     $query = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
-    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . self::DD_MANDATE_TABLE . '.id AND civicrm_entity_batch.entity_table = \'' . self::DD_MANDATE_TABLE . '\'');
-    $query->join('civicrm_option_group', 'LEFT JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
-    $query->join('civicrm_option_value', 'LEFT JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
-    $query->where('civicrm_entity_batch.batch_id = !entityID', ['entityID' => $this->batchID]);
+    $query->join('contact', 'INNER JOIN civicrm_contact ON ' . self::DD_MANDATE_TABLE . '.entity_id = civicrm_contact.id');
+    $query->join('civicrm_option_group', 'INNER JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
+    $query->join('civicrm_option_value', 'INNER JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
+    $query->where('civicrm_contact.is_deleted IS NULL OR civicrm_contact.is_deleted = 0');
+
+    if ($this->notPresent) {
+      $batchStatus = CRM_Core_PseudoConstant::get('CRM_Batch_DAO_Batch', 'status_id', ['labelColumn' => 'name']);
+      $excluded = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
+      $excluded->select($this->params['entityTable'] . '.id');
+      $excluded->join('entity_batch', 'INNER JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
+      $excluded->join('batch', 'INNER JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
+      $excluded->join('current_batch', 'INNER JOIN civicrm_batch current_batch ON current_batch.id = ' . $this->batchID);
+      $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
+      $excluded->where('civicrm_batch.type_id = current_batch.type_id');
+
+      $query->where($this->params['entityTable'] . '.id NOT IN (' . $excluded->toSQL() . ')');
+    }
+    else {
+      $query->join('entity_batch', 'INNER JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . self::DD_MANDATE_TABLE . '.id AND civicrm_entity_batch.entity_table = \'' . self::DD_MANDATE_TABLE . '\'');
+      $query->where('civicrm_entity_batch.batch_id = !entityID', ['entityID' => $this->batchID]);
+    }
 
     //select
     $query->select(implode(' , ', $this->returnValues));
-
-    $query->distinct(TRUE);
 
     foreach ($this->searchableFields as $k => $field) {
       if (isset($this->params[$k])) {

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -394,42 +394,47 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   private function getBatchRows($batch) {
-    $mandateItems = $this->getDDMandateInstructions();
+    if ($batch->getBatchType() === BatchHandler::BATCH_TYPE_PAYMENTS) {
+      $items = $this->getDDPayments();
+    }
+    else {
+      $items = $this->getDDMandateInstructions();
+    }
 
     $rows = [];
-    foreach ($mandateItems as $mandateItem) {
+    foreach ($items as $item) {
       $row = [];
       foreach ($this->columnHeader as $columnKey => $columnValue) {
-        if (isset($mandateItem[$columnKey])) {
-          $row[$columnKey] = $mandateItem[$columnKey];
+        if (isset($item[$columnKey])) {
+          $row[$columnKey] = $item[$columnKey];
         }
         else {
           $row[$columnKey] = NULL;
         }
       }
 
-      $row['check'] = $this->getCheckRow($batch, $mandateItem['id']);
+      $row['check'] = $this->getCheckRow($batch, $item['id']);
 
       switch ($batch->getBatchType()) {
         case BatchHandler::BATCH_TYPE_INSTRUCTIONS:
         case BatchHandler::BATCH_TYPE_CANCELLATIONS:
-          if (!empty($mandateItem['contact_id'])) {
-            $row['action'] = $this->getLinkToMandate($mandateItem['id'], $mandateItem['contact_id']);
+          if (!empty($item['contact_id'])) {
+            $row['action'] = $this->getLinkToMandate($item['id'], $item['contact_id']);
           }
 
-          $rows[$mandateItem['mandate_id']] = $row;
+          $rows[$item['mandate_id']] = $row;
           break;
 
         case BatchHandler::BATCH_TYPE_PAYMENTS:
-          if (isset($mandateItem['contribute_id'])) {
-            $contributionId = $mandateItem['contribute_id'];
+          if (isset($item['contribute_id'])) {
+            $contributionId = $item['contribute_id'];
           }
           else {
-            $contributionId = $mandateItem['id'];
+            $contributionId = $item['id'];
           }
 
-          if (!empty($mandateItem['contact_id'])) {
-            $row['action'] = $this->getLinkToContribution($contributionId, $mandateItem['contact_id']);
+          if (!empty($item['contact_id'])) {
+            $row['action'] = $this->getLinkToContribution($contributionId, $item['contact_id']);
           }
 
           $rows[$contributionId] = $row;
@@ -471,18 +476,11 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    * @return array
    */
   public function getDDMandateInstructions() {
-
     $query = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
-    $query->join('value_dd_information', 'LEFT JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
-    $query->join('contribution', 'LEFT JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
-    $query->join('contact', 'LEFT JOIN civicrm_contact ON civicrm_contribution.contact_id = civicrm_contact.id');
-    $query->join('email', 'LEFT JOIN civicrm_email ON (civicrm_contact.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1)');
-    $query->join('contribution_recur', 'LEFT JOIN civicrm_contribution_recur ON civicrm_contribution.contribution_recur_id = civicrm_contribution_recur.id');
-    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
+    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . self::DD_MANDATE_TABLE . '.id AND civicrm_entity_batch.entity_table = \'' . self::DD_MANDATE_TABLE . '\'');
     $query->join('civicrm_option_group', 'LEFT JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
     $query->join('civicrm_option_value', 'LEFT JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
-    $query->join('civicrm_entity_tag', 'LEFT JOIN civicrm_entity_tag ON civicrm_entity_tag.entity_id = civicrm_contact.id AND civicrm_entity_tag.entity_table = \'civicrm_contact\'');
-    $query->join('civicrm_group_contact', 'LEFT JOIN civicrm_group_contact ON civicrm_group_contact.contact_id = civicrm_contact.id AND civicrm_group_contact.status = \'Added\'');
+    $query->where('civicrm_entity_batch.batch_id = !entityID', ['entityID' => $this->batchID]);
 
     //select
     $query->select(implode(' , ', $this->returnValues));
@@ -500,6 +498,82 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       }
     }
 
+    if (!empty($this->params['sortBy'])) {
+      $query->orderBy($this->params['sortBy']);
+    }
+    else {
+      $query->orderBy(self::DD_MANDATE_TABLE . '.id');
+    }
+
+    if (!$this->total) {
+      if (!empty($this->params['rowCount']) &&
+        $this->params['rowCount'] > 0
+      ) {
+        $query->limit((int) $this->params['rowCount'], (int) $this->params['offset']);
+      }
+    }
+
+    $mandateItems = CRM_Core_DAO::executeQuery($query->toSQL());
+
+    $rows = [];
+    while ($mandateItems->fetch()) {
+      $mandateItem = [];
+      foreach ($this->returnValues as $key => $value) {
+        if (isset($mandateItems->$key)) {
+          $mandateItem[$key] = $mandateItems->$key;
+        }
+        else {
+          $mandateItem[$key] = NULL;
+        }
+      }
+
+      $mandateItem['amount'] = $this->formatAmount($mandateItem['amount']);
+
+      $rows[] = $mandateItem;
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Returns array of Direct Debit payments
+   *
+   * @return array
+   */
+  public function getDDPayments() {
+    $query = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
+    $query->join('value_dd_information', 'INNER JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
+    $query->join('contribution', 'INNER JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
+    $query->join('contact', 'INNER JOIN civicrm_contact ON civicrm_contribution.contact_id = civicrm_contact.id');
+    $query->join('contribution_recur', 'INNER JOIN civicrm_contribution_recur ON civicrm_contribution.contribution_recur_id = civicrm_contribution_recur.id');
+    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
+    $query->join('civicrm_option_group', 'INNER JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
+    $query->join('civicrm_option_value', 'INNER JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
+
+    //select
+    $query->select(implode(' , ', $this->returnValues));
+
+    $query->distinct(TRUE);
+
+    foreach ($this->searchableFields as $k => $field) {
+      if (!isset($this->params[$k])) {
+        continue;
+      }
+      if ($field['table'] === 'civicrm_entity_tag') {
+        $query->join('civicrm_entity_tag', 'INNER JOIN civicrm_entity_tag ON civicrm_entity_tag.entity_id = civicrm_contact.id AND civicrm_entity_tag.entity_table = \'civicrm_contact\'');
+      }
+      if ($field['table'] === 'civicrm_group_contact') {
+        $query->join('civicrm_group_contact', 'INNER JOIN civicrm_group_contact ON civicrm_group_contact.contact_id = civicrm_contact.id AND civicrm_group_contact.status = \'Added\'');
+      }
+
+      if ($field['op'] == 'IN') {
+        $query->where("{$field['table']}.{$field['field']} {$field['op']} (@{$k})", [$k => explode(',', $this->params[$k])]);
+      }
+      else {
+        $query->where("{$field['table']}.{$field['field']} {$field['op']} @{$k}", [$k => $this->params[$k]]);
+      }
+    }
+
     $this->addContributionReceiveDateCondition($query);
     $this->addSortNameCondition($query);
 
@@ -509,8 +583,8 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $excluded->select($this->params['entityTable'] . '.id');
 
       if ($this->params['entityTable'] == 'civicrm_contribution') {
-        $excluded->join('value_dd_information', 'LEFT JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
-        $excluded->join('contribution', 'LEFT JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
+        $excluded->join('value_dd_information', 'INNER JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
+        $excluded->join('contribution', 'INNER JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
       }
       $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
@@ -542,23 +616,23 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $query->where('civicrm_contact.is_deleted IS NULL OR civicrm_contact.is_deleted = 0');
     $query->where('civicrm_contribution.is_test IS NULL OR civicrm_contribution.is_test = 0');
 
-    $mandateItems = CRM_Core_DAO::executeQuery($query->toSQL());
+    $paymentItems = CRM_Core_DAO::executeQuery($query->toSQL());
 
     $rows = [];
-    while ($mandateItems->fetch()) {
-      $mandateItem = [];
+    while ($paymentItems->fetch()) {
+      $paymentItem = [];
       foreach ($this->returnValues as $key => $value) {
-        if (isset($mandateItems->$key)) {
-          $mandateItem[$key] = $mandateItems->$key;
+        if (isset($paymentItems->$key)) {
+          $paymentItem[$key] = $paymentItems->$key;
         }
         else {
-          $mandateItem[$key] = NULL;
+          $paymentItem[$key] = NULL;
         }
       }
 
-      $mandateItem['amount'] = $this->formatAmount($mandateItem['amount']);
+      $paymentItem['amount'] = $this->formatAmount($paymentItem['amount']);
 
-      $rows[] = $mandateItem;
+      $rows[] = $paymentItem;
     }
 
     return $rows;
@@ -578,7 +652,15 @@ class CRM_ManualDirectDebit_Batch_Transaction {
   public function getTotalNumber() {
     $this->total = TRUE;
 
-    return count($this->getDDMandateInstructions());
+    $batch = (new BatchHandler($this->batchID));
+    if ($batch->getBatchType() === BatchHandler::BATCH_TYPE_PAYMENTS) {
+      $items = $this->getDDPayments();
+    }
+    else {
+      $items = $this->getDDMandateInstructions();
+    }
+
+    return count($items);
   }
 
   /**
@@ -703,6 +785,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       if (mb_strpos($sort_name, '%') === FALSE) {
         $sort_name = "%{$sort_name}%";
       }
+      $query->join('email', 'LEFT JOIN civicrm_email ON (civicrm_contact.id = civicrm_email.contact_id AND civicrm_email.is_primary = 1)');
       $query->where('civicrm_contact.sort_name LIKE @sort_name OR civicrm_contact.nick_name LIKE @sort_name OR civicrm_email.email LIKE @sort_name', ['sort_name' => $sort_name]);
     }
   }

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -569,7 +569,6 @@ class CRM_ManualDirectDebit_Batch_Transaction {
     $query->join('contribution', 'INNER JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
     $query->join('contact', 'INNER JOIN civicrm_contact ON civicrm_contribution.contact_id = civicrm_contact.id');
     $query->join('contribution_recur', 'INNER JOIN civicrm_contribution_recur ON civicrm_contribution.contribution_recur_id = civicrm_contribution_recur.id');
-    $query->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
     $query->join('civicrm_option_group', 'INNER JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
     $query->join('civicrm_option_value', 'INNER JOIN civicrm_option_value ON civicrm_option_group.id = civicrm_option_value.option_group_id AND civicrm_option_value.value = ' . self::DD_MANDATE_TABLE . '.dd_code');
 
@@ -609,15 +608,16 @@ class CRM_ManualDirectDebit_Batch_Transaction {
         $excluded->join('value_dd_information', 'INNER JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
         $excluded->join('contribution', 'INNER JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');
       }
-      $excluded->join('entity_batch', 'LEFT JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
-      $excluded->join('batch', 'LEFT JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
-      $excluded->join('current_batch', 'LEFT JOIN civicrm_batch current_batch ON current_batch.id = ' . $this->batchID);
+      $excluded->join('entity_batch', 'INNER JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
+      $excluded->join('batch', 'INNER JOIN civicrm_batch ON civicrm_entity_batch.batch_id = civicrm_batch.id');
+      $excluded->join('current_batch', 'INNER JOIN civicrm_batch current_batch ON current_batch.id = ' . $this->batchID);
       $excluded->where('civicrm_batch.status_id <> ' . CRM_Utils_Array::key('Discarded', $batchStatus));
       $excluded->where('civicrm_batch.type_id = current_batch.type_id');
 
       $query->where($this->params['entityTable'] . '.id NOT IN (' . $excluded->toSQL() . ')');
     }
     else {
+      $query->join('entity_batch', 'INNER JOIN civicrm_entity_batch ON civicrm_entity_batch.entity_id = ' . $this->params['entityTable'] . '.id AND civicrm_entity_batch.entity_table = \'' . $this->params['entityTable'] . '\'');
       $query->where('civicrm_entity_batch.batch_id = !entityID', ['entityID' => $this->batchID]);
     }
 


### PR DESCRIPTION
## Overview
This PR fixes the slow loading of "Manage Direct Debit Batches" page.

## Before
Opening the "Manage Direct Debit Batches" page will **take a lot of time and maybe "Timeout" error** if the table `civicrm_value_dd_information` has so many records (> 100k).

## After
Opening the "Manage Direct Debit Batches" page will **be fast** even if the table `civicrm_value_dd_information` has so many records (> 100k).

## Technical Details
The `getBatchRows` method uses the same query base to search for direct debit payments and instruction batch.

The query will be so slow if the table `civicrm_value_dd_information` has so many records (> 100k) because the MYSQL will load the whole civicrm_value_dd_information to the memory instead of using the indexes.

```sql
EXPLAIN SELECT * FROM civicrm_value_dd_mandate LEFT JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id

| id | select_type | table                        | partitions | type | possible_keys    | key  | key_len | ref  | rows   | filtered | Extra |
|  1 | SIMPLE      | civicrm_value_dd_mandate     | NULL       | ALL  | NULL             | NULL | NULL    | NULL |     55 |   100.00 | NULL |
|  1 | SIMPLE      | civicrm_value_dd_information | NULL       | ALL  | INDEX_mandate_id | NULL | NULL    | NULL | 139824 |   100.00 | Using where; Using join buffer (Block Nested Loop) |
```
`Using join buffer (Block Nested Loop)` means the join is unable to use an index, and it's doing a table-scan on the joined table. The issue is related to MYSQL engine - see https://bugs.mysql.com/bug.php?id=69721.

The `LEFT JOIN` is required so that the query can fetch payments and instruction records. This PR removes the `LEFT JOIN civicrm_value_dd_information` from instruction query and instead creates a separate query that use `INNER JOIN` to fetch the payment records.



