### PR TITLE
BASW-774: Fix regression when exporting batches

### DIFF
--- a/CRM/ManualDirectDebit/Batch/BatchHandler.php
+++ b/CRM/ManualDirectDebit/Batch/BatchHandler.php
@@ -378,7 +378,13 @@ class CRM_ManualDirectDebit_Batch_BatchHandler {
       $returnValues
     );
 
-    $mandateItems = $batchTransaction->getDDMandateInstructions();
+    if ($this->getBatchType() === self::BATCH_TYPE_PAYMENTS) {
+      $mandateItems = $batchTransaction->getDDPayments();
+    }
+    else {
+      $mandateItems = $batchTransaction->getDDMandateInstructions();
+    }
+
     foreach ($mandateItems as $mandateItem) {
       switch ($this->getBatchType()) {
         case self::BATCH_TYPE_INSTRUCTIONS:

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -645,7 +645,7 @@ class CRM_ManualDirectDebit_Batch_Transaction {
       $query->orderBy($this->params['sortBy']);
     }
     else {
-      $query->orderBy(self::DD_MANDATE_TABLE . '.id');
+      $query->orderBy('civicrm_contribution.id');
     }
 
     if (!$this->total) {

--- a/CRM/ManualDirectDebit/Batch/Transaction.php
+++ b/CRM/ManualDirectDebit/Batch/Transaction.php
@@ -393,16 +393,14 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    */
   private function getBatchRows($batch) {
     if ($batch->getBatchType() === BatchHandler::BATCH_TYPE_PAYMENTS) {
-      $query = $this->getDDPaymentsQuery();
+      $items = $this->getDDPayments();
     }
     else {
-      $query = $this->getDDMandateInstructionsQuery();
+      $items = $this->getDDMandateInstructions();
     }
 
-    $dao = CRM_Core_DAO::executeQuery($query);
-
     $rows = [];
-    foreach ($this->fetchRows($dao) as $item) {
+    foreach ($items as $item) {
       $row = [];
       foreach ($this->columnHeader as $columnKey => $columnValue) {
         if (isset($item[$columnKey])) {
@@ -502,7 +500,18 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    *
    * @return array
    */
-  public function getDDMandateInstructionsQuery() {
+  public function getDDMandateInstructions() {
+    $query = $this->getDDMandateInstructionsQuery();
+    $dao = CRM_Core_DAO::executeQuery($query);
+    return $this->fetchRows($dao);
+  }
+
+  /**
+   * Returns a query for Direct Debit mandate instructions
+   *
+   * @return array
+   */
+  private function getDDMandateInstructionsQuery() {
     $query = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
     $query->join('contact', 'INNER JOIN civicrm_contact ON ' . self::DD_MANDATE_TABLE . '.entity_id = civicrm_contact.id');
     $query->join('civicrm_option_group', 'INNER JOIN civicrm_option_group ON civicrm_option_group.name = "direct_debit_codes"');
@@ -563,7 +572,18 @@ class CRM_ManualDirectDebit_Batch_Transaction {
    *
    * @return array
    */
-  public function getDDPaymentsQuery() {
+  public function getDDPayments() {
+    $query = $this->getDDPaymentsQuery();
+    $dao = CRM_Core_DAO::executeQuery($query);
+    return $this->fetchRows($dao);
+  }
+
+  /**
+   * Returns a query for Direct Debit payments
+   *
+   * @return array
+   */
+  private function getDDPaymentsQuery() {
     $query = CRM_Utils_SQL_Select::from(self::DD_MANDATE_TABLE);
     $query->join('value_dd_information', 'INNER JOIN civicrm_value_dd_information ON civicrm_value_dd_information.mandate_id = civicrm_value_dd_mandate.id');
     $query->join('contribution', 'INNER JOIN civicrm_contribution ON civicrm_contribution.id = civicrm_value_dd_information.entity_id');


### PR DESCRIPTION
## Overview
This PR fixes the error when exporting the batches. The regression was introduced by the previous https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/240 PR.

## Before
Clicking on the export button will show error page.
![2021-06-30_11-56](https://user-images.githubusercontent.com/74309109/123932717-5fc6ff00-d99a-11eb-82b6-eff479645daf.png)

![Screenshot from 2021-06-30 11-46-14](https://user-images.githubusercontent.com/74309109/123930886-cfd48580-d998-11eb-9237-875e75a3fb4e.png)

## After
Clicking on the export button will start downloading the batch.
![2021-06-30_11-55](https://user-images.githubusercontent.com/74309109/123932430-1e365400-d99a-11eb-8cb9-3a98b3f841d2.png)


## Technical Details
As you can see from the following error message , the method `getDDMandateInstructions` is not defined anymore.
```php
array(6) {
  ["%type"]=>
  string(5) "Error"
  ["!message"]=>
  string(93) "Call to undefined method CRM_ManualDirectDebit_Batch_Transaction::getDDMandateInstructions()"
  ["%function"]=>
  string(66) "CRM_ManualDirectDebit_Batch_BatchHandler->getMandateCurrentState()"
  ["%file"]=>
  string(158) "CRM/ManualDirectDebit/Batch/BatchHandler.php"
  ["%line"]=>
  int(381)
  ["severity_level"]=>
  int(3)
}
```

This PR recreate the method.

