### PR TITLE
IO-152: Remove checking no of instalments

### DIFF
--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -238,7 +238,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
   private function getContributionsForMandate($recurContribution, $contactId) {
     $contributionIds = [];
 
-    if ($this->isMembershipExtrasInstalled() && $this->isAmountOfInstallmentsEqualAmountOfContributions($recurContribution)) {
+    if ($this->isMembershipExtrasInstalled()) {
       /**
        * If Membership was installed first, it gets all contributions for last inserted recurring contribution
        * for current contact
@@ -284,24 +284,6 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
     $isMembershipExist = $membershipExtension->id && $membershipExtension->is_active == 1;
 
     return $isMembershipExist ? TRUE : FALSE;
-  }
-
-  /**
-   * Checks if amount of installments equal to amount of contributions
-   *
-   * @param $recurContribution
-   *
-   * @return bool
-   */
-  private function isAmountOfInstallmentsEqualAmountOfContributions($recurContribution) {
-    $contributionRecurDao = CRM_Contribute_BAO_ContributionRecur::findById($recurContribution);
-    $amountOfInstallments = $contributionRecurDao->installments;
-
-    $amountOfContributions = civicrm_api3('Contribution', 'getcount', [
-      'contribution_recur_id' => $recurContribution,
-    ]);
-
-    return $amountOfInstallments == $amountOfContributions ? TRUE : FALSE;
   }
 
   /**


### PR DESCRIPTION
## Overview

This PR fixes the issue that the mandate ID is not assigned to all contributions when creating a new membership with fixed membership type and using direct debit as payment method.

## Before

When sign up with fixed membership type and membership amount is pro-rated, the mandate will ONLY assign to recurring contribution and first contribution.

## After

When sign up with fixed membership type and membership amount is pro-rated, the mandate will ONLY assign to recurring contribution and all contributions.

## Technical Details

This PR removes a function that checks if number of contributions equals to recurring contribution's instalments number. As number of instalment of recurring contributions and number of contributions will not always equal to recurring contribution's instalments, if the membership amount is pro-rated

