### PR TITLE
IO-177: Revert "Revert "IO-56: Improve Direct Debit payment plan date calculations""

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -4,6 +4,8 @@
  * Class provide information about Direct Debit Mandate Settings
  */
 class CRM_ManualDirectDebit_Common_SettingsManager {
+  const SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER = 'one_month_after';
+  const SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH = 'force_second_month';
 
   public static $minimumDaysToFirstPayment;
 
@@ -15,14 +17,19 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
   public function getManualDirectDebitSettings() {
     $settingValues = $this->getSettingsValues();
 
-    $settings = [];
-    $settings['default_reference_prefix'] = $settingValues['values'][0]['manualdirectdebit_default_reference_prefix'];
-    $settings['minimum_reference_prefix_length'] = $settingValues['values'][0]['manualdirectdebit_minimum_reference_prefix_length'];
+    $settings = [
+      'default_reference_prefix' => CRM_Utils_Array::value('manualdirectdebit_default_reference_prefix', $settingValues),
+      'minimum_reference_prefix_length' => CRM_Utils_Array::value('manualdirectdebit_minimum_reference_prefix_length', $settingValues),
+      'minimum_days_to_first_payment' => CRM_Utils_Array::value('manualdirectdebit_minimum_days_to_first_payment', $settingValues),
+      'second_instalment_date_behaviour' => CRM_Utils_Array::value('manualdirectdebit_second_instalment_date_behaviour', $settingValues),
+    ];
+
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_new_instruction_run_dates']);
+      CRM_Utils_Array::value('manualdirectdebit_new_instruction_run_dates', $settingValues)
+    );
     $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      $settingValues['values'][0]['manualdirectdebit_payment_collection_run_dates']);
-    $settings['minimum_days_to_first_payment'] = $settingValues['values'][0]['manualdirectdebit_minimum_days_to_first_payment'];
+      CRM_Utils_Array::value('manualdirectdebit_payment_collection_run_dates', $settingValues)
+    );
 
     return $settings;
   }
@@ -64,7 +71,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       return self::$minimumDaysToFirstPayment;
     }
     else {
-      throw new CiviCRM_API3_Exception(t("Please, configure minimum days to first payment"), 'required_setting_not_configured');
+      throw new CiviCRM_API3_Exception(ts("Please, configure minimum days to first payment"), 'required_setting_not_configured');
     }
   }
 
@@ -88,7 +95,8 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
         $settingValues = $this->fetchSettingsValues();
       }
     }
-    return $settingValues;
+
+    return $settingValues['values'][0];
   }
 
   /**
@@ -103,6 +111,7 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
       'manualdirectdebit_new_instruction_run_dates',
       'manualdirectdebit_payment_collection_run_dates',
       'manualdirectdebit_minimum_days_to_first_payment',
+      'manualdirectdebit_second_instalment_date_behaviour',
     ];
 
     return civicrm_api3('setting', 'get', [

--- a/CRM/ManualDirectDebit/Form/Configurations.php
+++ b/CRM/ManualDirectDebit/Form/Configurations.php
@@ -16,7 +16,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $mandateConfigs = [];
 
   /**
@@ -25,8 +24,14 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $paymentConfigs = [];
+
+  /**
+   * Contains array of settings' names for Instalment Configs Section.
+   *
+   * @var array
+   */
+  private $instalmentConfigs = [];
 
   /**
    * Contains array of names, which must be displayed
@@ -34,7 +39,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $reminderConfig = [];
 
   /**
@@ -43,7 +47,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    *
    * @var string[]
    */
-
   private $batchConfig = [];
 
   public function buildQuickForm() {
@@ -82,6 +85,7 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
 
     $this->assign('mandateConfigSection', $this->mandateConfigs);
     $this->assign('paymentConfigSection', $this->paymentConfigs);
+    $this->assign('instalmentConfigSection', $this->instalmentConfigs);
     $this->assign('reminderConfigSection', $this->reminderConfig);
     $this->assign('batchConfigSection', $this->batchConfig);
     $this->assign('fieldsWithHelp', $fieldsWithHelp);
@@ -101,12 +105,18 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
    * @see CRM_Core_Form::setDefaultValues()
    */
   public function setDefaultValues() {
-    $currentValues = civicrm_api3('setting', 'get',
-      ['return' => array_keys(SettingsManager::getConfigFields())]);
+    $settingsMetaData = SettingsManager::getConfigFields();
+    $currentValues = civicrm_api3('setting', 'get', [
+      'return' => array_keys($settingsMetaData),
+    ]);
     $defaults = [];
     $domainID = CRM_Core_Config::domainID();
-    foreach ($currentValues['values'][$domainID] as $name => $value) {
-      $defaults[$name] = $value;
+
+    foreach ($settingsMetaData as $settingName => $setting) {
+      $defaults[$settingName] = CRM_Utils_Array::value('default', $setting);
+      if (isset($currentValues['values'][$domainID][$settingName])) {
+        $defaults[$settingName] = $currentValues['values'][$domainID][$settingName];
+      }
     }
 
     return $defaults;
@@ -128,6 +138,10 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
         $this->paymentConfigs[] = $name;
         break;
 
+      case 'instalment_config':
+        $this->instalmentConfigs[] = $name;
+        break;
+
       case 'reminder_config':
         $this->reminderConfig[] = $name;
         break;
@@ -135,7 +149,6 @@ class CRM_ManualDirectDebit_Form_Configurations extends CRM_Core_Form {
       case 'batch_config':
         $this->batchConfig[] = $name;
         break;
-
     }
   }
 

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/Base.php
@@ -1,0 +1,121 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_ContributionBase.
+ *
+ * Holds methods and attributes to all classes that calculate receive dates for
+ * instalments in a payment plan.
+ */
+abstract class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
+  /**
+   * Start date of the payment plan and the receive date of first instalment.
+   *
+   * @var string
+   */
+  protected $receiveDate = '';
+
+  /**
+   * List of parameters being used to create the first instalment.
+   *
+   * @var array
+   */
+  protected $params = [];
+
+  /**
+   * Array with Direct Debit extension settings.
+   *
+   * @var array
+   */
+  protected $ddSettings = [];
+
+  /**
+   * The DirectDebit payment instrument data.
+   *
+   * @var array
+   */
+  protected $directDebitPaymentInstrument = [];
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution constructor.
+   *
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, $params, SettingsManager $settingsManager) {
+    $this->receiveDate =& $receiveDate;
+    $this->params = $params;
+    $this->ddSettings = $settingsManager->getManualDirectDebitSettings();
+    $this->directDebitPaymentInstrument = $this->getDDPaymentMethod();
+  }
+
+  /**
+   * Obtains the data for the Direct Debit payment instrument.
+   *
+   * @return mixed
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getDDPaymentMethod() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => 'direct_debit',
+      'option_group_id' => 'payment_instrument',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0];
+    }
+
+    throw new CRM_Extension_Exception('Could not obtain DD Payment Instrument!');
+  }
+
+  /**
+   * Checks if the contribution is being paid for with direct debit.
+   *
+   * @return bool
+   */
+  protected function isDirectDebit() {
+    if ($this->params['payment_instrument_id'] === 'direct_debit') {
+      return TRUE;
+    }
+
+    if ($this->params['payment_instrument_id'] === $this->directDebitPaymentInstrument['value']) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Obtains recurrring contribution used for the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function getRecurringContribution() {
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['contribution_recur_id'],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Changes the receive date for the instalment, if necessary.
+   *
+   * @return mixed
+   */
+  abstract public function process();
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution.
+ *
+ * Implements hook to calculate the receive date of the first contribution of a
+ * payment plan.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
+
+  /**
+   * Calculates receive date for payment plan if payment method is DD.
+   *
+   * @throws \Exception
+   */
+  public function process() {
+    if (!$this->isDirectDebit()) {
+      return;
+    }
+
+    $receiveDateTime = new DateTime($this->receiveDate);
+    $nextInstructionRunDate = $this->getNextValidDateAfter($receiveDateTime, $this->ddSettings['new_instruction_run_dates']);
+
+    $minimumDaysToFirstPayment = $this->ddSettings['minimum_days_to_first_payment'];
+    if ($minimumDaysToFirstPayment) {
+      $nextInstructionRunDate->add(new DateInterval("P{$minimumDaysToFirstPayment}D"));
+    }
+
+    $nextPaymentCollectionDate = $this->getNextValidDateAfter($nextInstructionRunDate, $this->ddSettings['payment_collection_run_dates']);
+    $this->receiveDate = $nextPaymentCollectionDate->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Returns first date in collection of days that is after given dates.
+   *
+   * @param \DateTime $referenceDate
+   * @param array $validDaysArray
+   *
+   * @return \Date|\DateTime
+   */
+  private function getNextValidDateAfter(\DateTime $referenceDate, array $validDaysArray) {
+    $referenceYear = intval($referenceDate->format('Y'));
+
+    for ($year = $referenceYear; $year < $referenceYear + 2; $year++) {
+      for ($month = 1; $month < 13; $month++) {
+        foreach ($validDaysArray as $paymentCollectionDay) {
+          $paymentCollectionDay = ($paymentCollectionDay < 10 ? '0' . $paymentCollectionDay : $paymentCollectionDay);
+          $paymentCollectionMonth = ($month < 10 ? '0' . $month : $month);
+          $nextAvailableDate = new DateTime("{$year}-{$paymentCollectionMonth}-{$paymentCollectionDay}");
+
+          if ($nextAvailableDate > $referenceDate) {
+            return $nextAvailableDate;
+          }
+        }
+      }
+    }
+
+    return $referenceDate;
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContribution.php
@@ -1,0 +1,73 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+
+/**
+ * Class OtherContribution.
+ *
+ * Calculates receive date for contributions beyond the second instalment.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution {
+
+  /**
+   * Number of instalment in payment plan.
+   *
+   * @var int
+   */
+  private $contributionNumber;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution constructor.
+   *
+   * @param int $contributionNumber
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct($contributionNumber, &$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
+    $this->contributionNumber = $contributionNumber;
+
+    parent::__construct($receiveDate, $params, $settingsManager, $calculator);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  public function process() {
+    $previousInstalmentDate = $this->getPreviousContributionReceiveDate();
+    $receiveDate = new DateTime($previousInstalmentDate);
+
+    $recurringContribution = $this->getRecurringContribution();
+    $numberOfIntervals = $recurringContribution['frequency_interval'];
+    $frequencyUnit = $recurringContribution['frequency_unit'];
+
+    $this->receiveDate = $this->calculateNextInstalmentReceiveDate($receiveDate, $numberOfIntervals, $frequencyUnit);
+  }
+
+  /**
+   * Obtains the receive date of the last contribution in the payment plan.
+   *
+   * @return mixed|string
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPreviousContributionReceiveDate() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id ASC',
+      ],
+    ]);
+
+    return $result['values'][$this->contributionNumber - 2]['receive_date'];
+  }
+
+}

--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -1,0 +1,269 @@
+<?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution.
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution extends CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_Base {
+
+  /**
+   * Helper object used to calculate receive dates.
+   *
+   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   */
+  protected $receiveDateCalculator;
+
+  /**
+   * CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution constructor.
+   *
+   * @param string $receiveDate
+   * @param array $params
+   * @param \CRM_ManualDirectDebit_Common_SettingsManager $settingsManager
+   * @param \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator $calculator
+   *
+   * @throws \CRM_Extension_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function __construct(&$receiveDate, array $params, SettingsManager $settingsManager, ReceiveDateCalculator $calculator) {
+    parent::__construct($receiveDate, $params, $settingsManager);
+
+    $this->receiveDateCalculator = $calculator;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function process() {
+    if (!$this->isDirectDebit() || $this->isRenewal()) {
+      return;
+    }
+
+    if (!$this->isForceOnSecondMonth()) {
+      return;
+    }
+
+    $this->forceSecondInstalmentOnSecondPeriod();
+  }
+
+  /**
+   * Determines if the payment plan is a renewal or if it's being created.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function isRenewal() {
+    $previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
+    $result = civicrm_api3('ContributionRecur', 'get', [
+      'id' => $this->params['contribution_recur_id'],
+      'return' => ['custom_' . $previousPeriodFieldID],
+    ]);
+
+    if ($result['count'] > 0) {
+      $recurringContribution = array_shift($result['values']);
+      $previousPeriodRecurringContributionID = CRM_Utils_Array::value(
+        'custom_' . $previousPeriodFieldID,
+        $recurringContribution
+      );
+      if (!empty($previousPeriodRecurringContributionID)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Obtains ID for custom field name in given group.
+   *
+   * @param $fieldGroup
+   * @param $fieldName
+   *
+   * @return int
+   * @throws \Exception
+   */
+  protected function getCustomFieldID($fieldGroup, $fieldName) {
+    $result = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => $fieldGroup,
+      'name' => $fieldName,
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0]['id'];
+    }
+
+    throw new Exception("Cannot find customfield $fieldName in $fieldGroup group.");
+  }
+
+  /**
+   * Checks if setting to force second payment on second month is active.
+   *
+   * Checks if DD settings are configured to force second instalment to be on
+   * second month of membership.
+   *
+   * @return bool
+   */
+  private function isForceOnSecondMonth() {
+    if ($this->ddSettings['second_instalment_date_behaviour'] === SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Forces second instalment to have the first instalment's receive date.
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  private function forceSecondInstalmentOnSecondPeriod() {
+    $recurringContribution = $this->getRecurringContribution();
+    $firstContribution = $this->getFirstContribution();
+    $membershipsStartDate = $this->getMembershipsStartDate($firstContribution);
+
+    $firstMembershipCycleDate = new DateTime(
+      $membershipsStartDate->format('Y-m-' . $recurringContribution['cycle_day'])
+    );
+
+    $secondInstalmentReceiveDate = $this->calculateNextInstalmentReceiveDate(
+      $firstMembershipCycleDate,
+      $recurringContribution['frequency_interval'],
+      $recurringContribution['frequency_unit']
+    );
+    $this->receiveDate = $secondInstalmentReceiveDate;
+
+    $firstInstalmentDateTime = new DateTime($firstContribution['receive_date']);
+    $secondInstalmentDateTime = new DateTime($secondInstalmentReceiveDate);
+    if ($firstInstalmentDateTime > $secondInstalmentDateTime) {
+      $this->receiveDate = $firstInstalmentDateTime->format('Y-m-d H:i:s');
+    }
+  }
+
+  /**
+   * Obteins the first contribution in the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getFirstContribution() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->params['contribution_recur_id'],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id',
+      ],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Obtains a membership's start date from those related to the payment plan.
+   *
+   * @param array $firstContribution
+   *
+   * @return \DateTime|null
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembershipsStartDate($firstContribution) {
+    $lineItems = $this->getContributionLineItems($firstContribution);
+
+    foreach ($lineItems as $line) {
+      if ($line['entity_table'] != 'civicrm_membership') {
+        continue;
+      }
+
+      $membership = $this->getMembership($line['entity_id']);
+
+      return new DateTime($membership['start_date']);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Obtains the list of line items for the given contribution.
+   *
+   * @param $contribution
+   *
+   * @return array|mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getContributionLineItems($contribution) {
+    $result = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $contribution['id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+  /**
+   * Obtains the given membership's data.
+   *
+   * @param int $membershipID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembership($membershipID) {
+    $result = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'id' => $membershipID,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Calculates the date for the next instalment, given a date and a frequency.
+   *
+   * @param \DateTime $referenceInstalmentDate
+   * @param $numberOfIntervals
+   * @param $frequencyUnit
+   *
+   * @return string
+   * @throws \Exception
+   */
+  protected function calculateNextInstalmentReceiveDate(\DateTime $referenceInstalmentDate, $numberOfIntervals, $frequencyUnit) {
+    switch ($frequencyUnit) {
+      case 'day':
+        $interval = "P{$numberOfIntervals}D";
+        $referenceInstalmentDate->add(new DateInterval($interval));
+        break;
+
+      case 'week':
+        $interval = "P{$numberOfIntervals}W";
+        $referenceInstalmentDate->add(new DateInterval($interval));
+        break;
+
+      case 'month':
+        $referenceInstalmentDate = $this->receiveDateCalculator->getSameDayNextMonth($referenceInstalmentDate, $numberOfIntervals);
+        break;
+
+      case 'year':
+        $interval = "P{$numberOfIntervals}Y";
+        $referenceInstalmentDate->add(new DateInterval($interval));
+        break;
+    }
+
+    return $referenceInstalmentDate->format('Y-m-d H:i:s');
+  }
+
+}

--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -312,11 +312,6 @@ function manualdirectdebit_civicrm_post($op, $objectName, $objectId, &$objectRef
     $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
     $postContributionHook->process();
   }
-
-  if ($op == 'create' && $objectName == 'Contribution') {
-    $postContributionHook = new CRM_ManualDirectDebit_Hook_Post_Contribution($objectId);
-    $postContributionHook->process();
-  }
 }
 
 /**
@@ -400,6 +395,45 @@ function manualdirectdebit_membershipextras_postOfflineAutoRenewal($membershipId
 
   $mandate = new CRM_ManualDirectDebit_Hook_PostOfflineAutoRenewal_Mandate($recurContributionId, $previousRecurContributionId);
   $mandate->process();
+}
+
+/**
+ * Implements hook_membershipextras_calculateContributionReceiveDate().
+ */
+function manualdirectdebit_membershipextras_calculateContributionReceiveDate($contributionNumber, &$receiveDate, $contributionCreationParams) {
+  $settingsManager = new CRM_ManualDirectDebit_Common_SettingsManager();
+  $calculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator();
+
+  switch ($contributionNumber) {
+    case 1:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    case 2:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution(
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager,
+        $calculator
+      );
+      $receiveDateCalculator->process();
+      break;
+
+    default:
+      $receiveDateCalculator = new CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution(
+        $contributionNumber,
+        $receiveDate,
+        $contributionCreationParams,
+        $settingsManager,
+        $calculator
+      );
+      $receiveDateCalculator->process();
+  }
 }
 
 function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {

--- a/settings/ManualDirectDebit.setting.php
+++ b/settings/ManualDirectDebit.setting.php
@@ -1,6 +1,7 @@
 <?php
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
 
-/*
+/**
  * Metadata for Manual Direct Debit Settings
  */
 return [
@@ -23,7 +24,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_reference_prefix_length',
-    'title' => 'Minimum mandate reference length',
+    'title' => 'Minimum Mandate Reference Length',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -38,7 +39,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_new_instruction_run_dates',
-    'title' => 'New instruction run dates',
+    'title' => 'New Instruction Run Dates',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
@@ -57,14 +58,14 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_payment_collection_run_dates',
-    'title' => 'Payment collection run dates ',
+    'title' => 'Payment Collection Run Dates ',
     'type' => 'Integer',
     'html_type' => 'select',
     'quick_form_type' => 'Element',
     'default' => 1,
     'is_required' => TRUE,
     'is_help' => FALSE,
-    'html_attributes' => generateSequenceNumbers(31),
+    'html_attributes' => generateSequenceNumbers(28),
     'extra_data' => [
       'class' => 'crm-select2',
       'multiple' => 'multiple',
@@ -76,7 +77,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_minimum_days_to_first_payment',
-    'title' => 'Minimum days from new instruction to first payment',
+    'title' => 'Minimum Days from New Instruction to First Payment',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -87,11 +88,32 @@ return [
     'extra_data' => '',
     'section' => 'payment_config',
   ],
+  'manualdirectdebit_second_instalment_date_behaviour' => [
+    'group_name' => 'Manual Direct Debit',
+    'group' => 'manualdirectdebit',
+    'name' => 'manualdirectdebit_second_instalment_date_behaviour',
+    'title' => 'Second Instalment Date Behaviour',
+    'type' => 'String',
+    'html_type' => 'select',
+    'quick_form_type' => 'Element',
+    'default' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    'is_required' => TRUE,
+    'is_help' => TRUE,
+    'html_attributes' => [
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER => ts('Take second instalment 1 month after the first instalment'),
+      SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH => ts('Take second instalment in the second month of membership'),
+    ],
+    'extra_data' => [
+      'class' => 'crm-select2',
+      'placeholder' => ts('- select -'),
+    ],
+    'section' => 'instalment_config',
+  ],
   'manualdirectdebit_days_in_advance_for_collection_reminder' => [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_days_in_advance_for_collection_reminder',
-    'title' => 'Days in advance for Collection Reminder',
+    'title' => 'Days in Advance for Collection Reminder',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -106,7 +128,7 @@ return [
     'group_name' => 'Manual Direct Debit',
     'group' => 'manualdirectdebit',
     'name' => 'manualdirectdebit_batch_submission_queue_limit',
-    'title' => 'Number of records to be processed per batch submission queue task',
+    'title' => 'Number of Records to be Processed per Batch Submission Queue Task',
     'type' => 'Integer',
     'html_type' => 'number',
     'quick_form_type' => 'Element',
@@ -116,7 +138,7 @@ return [
     'html_attributes' => '',
     'extra_data' => '',
     'section' => 'batch_config',
-  ]
+  ],
 ];
 
 /**
@@ -125,7 +147,6 @@ return [
  * @param int $limit
  *
  * @return  array
- *
  */
 function generateSequenceNumbers($limit) {
   $sequence = [];

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.hlp
@@ -20,10 +20,43 @@ contribution should the Direct Debit Payment Collection Reminder
 be sent to the user.{/ts}
 {/htxt}
 
+{htxt id="manualdirectdebit_second_instalment_date_behaviour"}
+  <p>
+    {ts}You can specify how you would like the system to calculate the date for the
+    second instalment for memberships paid in monthly instalments. The options
+    are:{/ts}
+  </p>
+  <ol>
+    <li>
+      <b>{ts}Take the second instalment 1 month after the first instalment(Default): {/ts}</b>
+      {ts}
+        Here, the date of the second instalment is relative to the date of the
+        first instalment. If the first instalment is delayed due to the fact that
+        the first instalment payment run date in the first month was missed, the
+        second instalment will be 1 month from that date. All following
+        instalments will be 1 month following the previous. This might be
+        preferable for ensuring that members do not have to pay for multiple
+        instalments in the same month, but it may mean that the final instalment
+        for a membership is taken in the month after the membership has expired,
+        which might be undesirable from your organisations perspective.
+      {/ts}
+    </li>
+    <li>
+      <b>{ts}Take the second instalment in the second month of membership: {/ts}</b>
+      {ts}
+        Here, the system will always take the second instalment in the second
+        month of membership. In some cases this will mean that both the first
+        instalment and the second instalment will be taken in the second month
+        of membership, if for example, the first instalment payment run date in
+        the first month was missed.
+      {/ts}
+    </li>
+  </ol>
+{/htxt}
+
 {htxt id="inactivity_code-title"}
   {ts}Mandates with inactive codes will not be selectable when
 creating a new Direct Debit contribution/ payment plan.
 Mandates and contributions that link to mandates with these
 codes will not be included in the batch.{/ts}
 {/htxt}
-

--- a/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Configurations.tpl
@@ -2,7 +2,7 @@
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  <h3>{ts}Mandate config{/ts}</h3>
+  <h3>{ts}Mandate Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$mandateConfigSection item=elementName}
@@ -15,7 +15,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Payment config{/ts}</h3>
+  <h3>{ts}Payment Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$paymentConfigSection item=elementName}
@@ -28,7 +28,20 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Reminder config{/ts}</h3>
+  <h3>Instalment Config</h3>
+  <table class="form-layout-compressed">
+    <tbody>
+    {foreach from=$instalmentConfigSection item=elementName}
+      <tr>
+        <td class="label">{$form.$elementName.label}</td>
+        <td>{$form.$elementName.html}
+          {if $fieldsWithHelp.$elementName}{help id=$form.$elementName.name}{/if}
+        </td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
+  <h3>{ts}Reminder Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$reminderConfigSection item=elementName}
@@ -41,7 +54,7 @@
       {/foreach}
     </tbody>
   </table>
-  <h3>{ts}Batch config{/ts}</h3>
+  <h3>{ts}Batch Config{/ts}</h3>
   <table class="form-layout-compressed">
     <tbody>
     {foreach from=$batchConfigSection item=elementName}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContributionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContribution as FirstContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_FirstContributionTest extends BaseHeadlessTest {
+
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Sets up a mock settings manager.
+   *
+   * Builds a mock settings manager object, making it return the given settings
+   * array merged with the default settings, when getManualDirectDebitSettings
+   * method is called.
+   *
+   * @param array $settings
+   *
+   * @return \CRM_ManualDirectDebit_Common_SettingsManager
+   */
+  private function setUpMockSettingsManager(array $settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  public function testCalculateReceiveDateOnFirstRunDateWithMinDaysOverFirstPayDateUsesSecondPayDate() {
+    $receiveDate = '2020-01-01';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 4,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->setUpMockSettingsManager($settings);
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateWithMinDaysOverSecondPayDatePushesForNextMonth() {
+    $receiveDate = '2020-01-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->setUpMockSettingsManager($settings);
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-02-01 00:00:00', $receiveDate);
+  }
+
+  public function testCalculateReceiveDateOnSecondRunDateAtEndOfYearIsPushedForNextYear() {
+    $receiveDate = '2020-12-15';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->setUpMockSettingsManager($settings);
+
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2021-01-01 00:00:00', $receiveDate);
+  }
+
+  public function testPaymentPlansNotPaidWithDirectDebitAreNotChanged() {
+    $receiveDate = '2020-01-15 00:00:00';
+    $settings = [
+      'new_instruction_run_dates' => [10, 20],
+      'minimum_days_to_first_payment' => 5,
+      'payment_collection_run_dates' => [1, 15],
+    ];
+    $settingsManager = $this->setUpMockSettingsManager($settings);
+
+    $this->defaultContributionParams['payment_instrument_id'] = 'EFT';
+    $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-01-15 00:00:00', $receiveDate);
+  }
+
+  public function testReceiveDateCalculationScenarios() {
+    $scenarios = [
+      'IO131TestScenario' => ['2020-12-18 00:00:00', 3, [4], [5, 21], '2021-01-21 00:00:00'],
+      'StartDateBeforeNIRD' => ['2020-08-02 00:00:00', 3, [4], [5, 21], '2020-08-21 00:00:00'],
+      'SignUpAfterNIRD' => ['2020-08-04 00:00:00', 3, [4], [5, 21], '2020-09-21 00:00:00'],
+      'OnPaymentRunDate' => ['2020-08-04 00:00:00', 3, [4], [5, 21], '2020-09-21 00:00:00'],
+      'Scenario5' => ['2020-09-09 00:00:00', 10, [5, 10], [5, 25], '2020-09-25 00:00:00'],
+      'Scenario6' => ['2020-09-11 00:00:00', 15, [5], [25], '2020-10-25 00:00:00'],
+      'Sheela#1' => ['2020-09-10 00:00:00', 10, [5, 10], [5, 25], '2020-10-25 00:00:00'],
+      'Sheela#2' => ['2020-08-01 00:00:00', 3, [4], [5, 21], '2020-08-21 00:00:00'],
+      'Sheela#3' => ['2020-08-01 00:00:00', 3, [4], [7, 21], '2020-08-21 00:00:00'],
+      'Sheela#4' => ['2020-08-05 00:00:00', 3, [4, 18], [7, 21], '2020-09-07 00:00:00'],
+      'Sheela#5' => ['2020-08-20 00:00:00', 3, [4, 18], [5, 21], '2020-09-21 00:00:00'],
+      'Sheela#6' => ['2020-02-04 00:00:00', 3, [4], [5, 21], '2020-03-21 00:00:00'],
+    ];
+
+    foreach ($scenarios as $scenarioName => $testData) {
+      $receiveDate = $testData[0];
+      $settings = [
+        'minimum_days_to_first_payment' => $testData[1],
+        'new_instruction_run_dates' => $testData[2],
+        'payment_collection_run_dates' => $testData[3],
+      ];
+      $expectedReceiveDateForFirstContribution = $testData[4];
+
+      $settingsManager = $this->setUpMockSettingsManager($settings);
+      $receiveDateCalculator = new FirstContributionReceiveDateCalculator(
+        $receiveDate,
+        $this->defaultContributionParams,
+        $settingsManager
+      );
+      $receiveDateCalculator->process();
+
+      $this->assertEquals(
+        $expectedReceiveDateForFirstContribution,
+        $receiveDate,
+        "Scenario $scenarioName failed!"
+      );
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/OtherContributionTest.php
@@ -1,0 +1,215 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContribution as OtherContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_OtherContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return \CRM_ManualDirectDebit_Common_SettingsManager
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $dayNextMonth
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($dayNextMonth) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($dayNextMonth));
+
+    return $calculator;
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param int $numberOfContributions
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, $numberOfContributions, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $receiveDateCalculator = new ReceiveDateCalculator($recurringContribution);
+
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+
+    for ($i = 0; $i < $numberOfContributions; $i++) {
+      $receiveDate = $i === 0 ? $firstInstalmentReceiveDate : $receiveDateCalculator->calculate($i + 1);
+      $contribution = ContributionFabricator::fabricate([
+        'currency' => NULL,
+        'source' => NULL,
+        'contact_id' => $contact['id'],
+        'fee_amount' => 0,
+        'net_amount' => $params['amount'] / $params['installments'],
+        'total_amount' => $params['amount'] / $params['installments'],
+        'receive_date' => $receiveDate,
+        'payment_instrument_id' => 'direct_debit',
+        'financial_type_id' => 'Member Dues',
+        'is_test' => 0,
+        'contribution_status_id' => 'Pending',
+        'is_pay_later' => TRUE,
+        'skipLineItem' => 1,
+        'skipCleanMoney' => TRUE,
+        'contribution_recur_id' => $recurringContribution['id'],
+      ]);
+      LineItemFabricator::fabricate([
+        'entity_table' => 'civicrm_membership',
+        'entity_id' => $membership['id'],
+        'contribution_id' => $contribution['id'],
+        'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+        'label' => $mainMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $contribution['total_amount'],
+        'line_total' => $contribution['total_amount'],
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 0,
+      ]);
+    }
+
+    return $recurringContribution;
+  }
+
+  public function testReceiveDateCalculationOfPaymentsAboveSecondInstalment() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2002-12-29';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, 3, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 15,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settingsManager = $this->buildSettingsManagerMock([]);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-04-15');
+    $receiveDateCalculator = new OtherContributionReceiveDateCalculator(
+      4,
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals('2020-04-15 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContributionTest.php
@@ -1,0 +1,390 @@
+<?php
+use CRM_ManualDirectDebit_Test_Fabricator_Contact as ContactFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_ManualDirectDebit_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_ManualDirectDebit_Common_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as ReceiveDateCalculator;
+use CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribution as SecondContributionReceiveDateCalculator;
+
+/**
+ * Class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest.
+ *
+ * @group headless
+ */
+class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContributionTest extends BaseHeadlessTest {
+  /**
+   * Default direct debit settings that will be used for tests.
+   *
+   * @var array
+   */
+  private $defaultDDSettings = [
+    'default_reference_prefix' => 'PRE-',
+    'minimum_reference_prefix_length' => 4,
+    'new_instruction_run_dates' => [1],
+    'payment_collection_run_dates' => [5],
+    'minimum_days_to_first_payment' => 1,
+    'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+  ];
+
+  /**
+   * Default parameters used to create the contribution of a payment plan.
+   *
+   * @var array
+   */
+  private $defaultContributionParams = [
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+    'fee_amount' => 0,
+    'payment_instrument_id' => 'direct_debit',
+  ];
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Builds a mock class to manage DD settings.
+   *
+   * @return mixed
+   */
+  private function buildSettingsManagerMock($settings) {
+    $settingsManager = $this->createMock(SettingsManager::class);
+    $settingsManager
+      ->method('getManualDirectDebitSettings')
+      ->willReturn(array_merge($this->defaultDDSettings, $settings));
+
+    return $settingsManager;
+  }
+
+  /**
+   * Builds mock receive date calculator object.
+   *
+   * @param string $secondInstalmentReceiveDate
+   *
+   * @return \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   * @throws \Exception
+   */
+  private function buildReceiveDateCalculatorMock($secondInstalmentReceiveDate) {
+    $calculator = $this->createMock(ReceiveDateCalculator::class);
+    $calculator
+      ->method('getSameDayNextMonth')
+      ->willReturn(new DateTime($secondInstalmentReceiveDate));
+
+    return $calculator;
+  }
+
+  /**
+   * Configures a payment plan to be used on tests.
+   *
+   * @param string $membershipStartDate
+   * @param string $firstInstalmentReceiveDate
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupPlan($membershipStartDate, $firstInstalmentReceiveDate, array $params) {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => $params['amount'],
+      'duration_interval' => $params['installments'],
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $recurringContribution = RecurringContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'amount' => $params['amount'],
+      'currency' => NULL,
+      'frequency_unit' => $params['frequency_unit'],
+      'frequency_interval' => $params['frequency_interval'],
+      'installments' => $params['installments'],
+      'start_date' => $firstInstalmentReceiveDate,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'cycle_day' => $params['cycle_day'],
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'direct_debit',
+      'campaign_id' => NULL,
+    ]);
+    $contribution = ContributionFabricator::fabricate([
+      'currency' => NULL,
+      'source' => NULL,
+      'contact_id' => $contact['id'],
+      'fee_amount' => 0,
+      'net_amount' => $params['amount'] / $params['installments'],
+      'total_amount' => $params['amount'] / $params['installments'],
+      'receive_date' => $firstInstalmentReceiveDate,
+      'payment_instrument_id' => 'direct_debit',
+      'financial_type_id' => 'Member Dues',
+      'is_test' => 0,
+      'contribution_status_id' => 'Pending',
+      'is_pay_later' => TRUE,
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'contribution_recur_id' => $recurringContribution['id'],
+    ]);
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => $membershipStartDate,
+      'start_date' => $membershipStartDate,
+      'end_date' => NULL,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 1,
+    ]);
+    LineItemFabricator::fabricate([
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'contribution_id' => $contribution['id'],
+      'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+      'label' => $mainMembershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $contribution['total_amount'],
+      'line_total' => $contribution['total_amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 0,
+    ]);
+
+    return $recurringContribution;
+  }
+
+  /**
+   * Obtains the field's ID for the given field name and group name.
+   *
+   * @param string $fieldGroup
+   * @param string $fieldName
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getCustomFieldID($fieldGroup, $fieldName) {
+    $result = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => $fieldGroup,
+      'name' => $fieldName,
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0]['id'];
+    }
+
+    return 0;
+  }
+
+  public function testForceSecondContributionOnSecondMonthWhenStartDateToFirstPaymentIsMoreThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-05');
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($firstInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenStartDateToFirstPaymentIsLessThan30Days() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-01-15 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-02-15 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 120,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-02-15');
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionOneMonthAfterFirstWhenSettingIsSet() {
+    $membershipStartDate = '2020-01-01';
+    $firstInstalmentReceiveDate = '2020-02-05 00:00:00';
+    $programmedSecondInstalmentReceiveDate = $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-03-05 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 1200,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER,
+    ];
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-03-05');
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $this->assertEquals($programmedSecondInstalmentReceiveDate, $receiveDate);
+  }
+
+  public function testSecondContributionIsNotBeforeFirst() {
+    $membershipStartDate = '2020-08-04';
+    $firstInstalmentReceiveDate = '2020-10-05 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-11-05 00:00:00';
+
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 120,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $settings = [
+      'new_instruction_run_dates' => [4],
+      'payment_collection_run_dates' => [5],
+      'minimum_days_to_first_payment' => 3,
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-09-05');
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+
+    $firstInstalmentDateTime = new DateTime($firstInstalmentReceiveDate);
+    $calculatedSecondInstalmentReceiveDateTime = new DateTime($receiveDate);
+    $this->assertFalse($firstInstalmentDateTime > $calculatedSecondInstalmentReceiveDateTime, "First instalment ($firstInstalmentReceiveDate) is after second instalment ($receiveDate)!");
+    $this->assertEquals('2020-10-05 00:00:00', $receiveDate);
+  }
+
+  public function testSecondContributionOnRenewalsIsNotChanged() {
+    $previousPeriod = $this->setupPlan('2019-08-04', '2019-09-21', [
+      'amount' => 120,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+
+    $membershipStartDate = '2019-08-04';
+    $firstInstalmentReceiveDate = '2020-08-21 00:00:00';
+    $receiveDate = $this->defaultContributionParams['receive_date'] = '2020-09-21 00:00:00';
+    $recurringContribution = $this->setupPlan($membershipStartDate, $firstInstalmentReceiveDate, [
+      'amount' => 120,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'cycle_day' => 5,
+    ]);
+    $this->defaultContributionParams['contribution_recur_id'] = $recurringContribution['id'];
+
+    $previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
+    civicrm_api3('ContributionRecur', 'create', [
+      'id' => $recurringContribution['id'],
+      'custom_' . $previousPeriodFieldID => $previousPeriod['id'],
+    ]);
+
+    $settings = [
+      'new_instruction_run_dates' => [4],
+      'payment_collection_run_dates' => [5, 21],
+      'minimum_days_to_first_payment' => 3,
+      'second_instalment_date_behaviour' => SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_FORCE_SECOND_MONTH,
+    ];
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculatorHelper = $this->buildReceiveDateCalculatorMock('2020-09-21');
+
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+    $this->assertEquals('2020-09-21 00:00:00', $receiveDate);
+
+    $settings['second_instalment_date_behaviour'] = SettingsManager::SECOND_INSTALMENT_BEHAVIOUR_ONE_MONTH_AFTER;
+    $settingsManager = $this->buildSettingsManagerMock($settings);
+    $receiveDateCalculator = new SecondContributionReceiveDateCalculator(
+      $receiveDate,
+      $this->defaultContributionParams,
+      $settingsManager,
+      $receiveDateCalculatorHelper
+    );
+    $receiveDateCalculator->process();
+    $this->assertEquals('2020-09-21 00:00:00', $receiveDate);
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -17,6 +17,8 @@ if (CIVICRM_UF === 'UnitTests') {
   Civi\Test::headless()->apply();
 }
 
+require_once 'BaseHeadlessTest.php';
+
 /**
  * Call the "cv" command.
  *


### PR DESCRIPTION
## Overview

This PR reverts the reverted PR https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/229 so the changes on for IO-56-workstream-improve-dd-start-date that were already applied then were reverted on master branch can be merged back to master branch again. 

This PR merges to a newly created branch, IO-56-workstream branch, which was branched off master branch as of today. The reason that I created a new workstream branch instead of reverting the reverted branch back to the master branch as IO-56 are not completed yet, and we would need this branch for QA before we merge the workstream branch to master branch as well as using this branch will use for merging adding new changes from[IO-136 ](https://compucorp.atlassian.net/browse/IO-136). 

Test failings because the changes that the revert revert back branch relies on the old version of membership extras which as related_payment_plan_periods  custom fields which we don't have it now. So, when running tests against membership extras master branch, the tests will always fail.  Fixes are done on this PR https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/236 