### PR TITLE
MAE-495: Fix mandate edit link in batch screen

### DIFF
--- a/CRM/ManualDirectDebit/Hook/PageRun/ViewCustomData.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/ViewCustomData.php
@@ -66,6 +66,9 @@ class CRM_ManualDirectDebit_Hook_PageRun_ViewCustomData {
    * @throws \CRM_Core_Exception
    */
   private function addEditAndDeleteButtons() {
+    $groupId = $this->page->_groupId;
+    $this->page->assign('groupId', $groupId);
+
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.manualdirectdebit', 'js/mandateEdit.js');
 

--- a/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataEditButtons.tpl
@@ -1,8 +1,8 @@
 <div class="crm-submit-buttons">
-  <a href="/civicrm/contact/view/cd/edit?reset=1&amp;type=Individual&amp;groupID=10&amp;entityID={$contactId}&amp;cgcount={$cgcount}&amp;multiRecordDisplay=single&amp;mode=edit&amp;mandateId={$mandate_id}" class="button edit" id="edit_direct_debit_mandate_1" title="Edit Direct Debit Mandate">
+  <a href="/civicrm/contact/view/cd/edit?reset=1&amp;type=Individual&amp;groupID={$groupId}&amp;entityID={$contactId}&amp;cgcount={$cgcount}&amp;multiRecordDisplay=single&amp;mode=edit&amp;mandateId={$mandate_id}" class="button edit" id="edit_direct_debit_mandate_1" title="Edit Direct Debit Mandate">
     <span><i class="crm-i fa-pencil"></i> {ts}Edit{/ts} </span>
   </a>
-  <a href="#" id="mandate_delete_btn" class="button delete" data-post="{ldelim}&quot;valueID&quot;: &quot;{$mandate_id}&quot;, &quot;groupID&quot;: &quot;10&quot;, &quot;contactId&quot;: &quot;{$contactId}&quot;, &quot;key&quot;: &quot;ad6ba0055f16b015e7228c2eba077526&quot;{rdelim}" title="Delete Direct Debit Mandate 1">
+  <a href="#" id="mandate_delete_btn" class="button delete" data-post="{ldelim}&quot;valueID&quot;: &quot;{$mandate_id}&quot;, &quot;groupID&quot;: &quot;{$groupId}&quot;, &quot;contactId&quot;: &quot;{$contactId}&quot;, &quot;key&quot;: &quot;ad6ba0055f16b015e7228c2eba077526&quot;{rdelim}" title="Delete Direct Debit Mandate">
     <i class="crm-i fa-trash" aria-hidden="true"></i>
     {ts}Delete{/ts}
   </a>


### PR DESCRIPTION
## Before

Trying to edit a mandate inside the instructions batch page shows and empty page.
![af](https://user-images.githubusercontent.com/6275540/128865793-b3707005-7514-4bb7-aedc-ab4487556fb6.gif)




## After

Trying to edit a mandate inside the instructions batch page shows the mandate edit form correctly.

![bef1](https://user-images.githubusercontent.com/6275540/128865787-49b2b73d-7493-4ffd-9cb4-5f99e1e58d73.gif)


## Technical Details

The template was hardcoded to use the group id = 10 in the edit URL which is not necessarily the mandate custom group id on all sites, so I changed it to be set dynamically. 