### PR TITLE
MAE-545: Fix Direct debit payment plan webform submissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.35.2 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.28.3
+          version: 5.35.2
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git -b IO-136-v5-contribution-receive-date-calculation
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git -b MAE-376-version5-workstream
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
 
       - name: Run phpunit tests

--- a/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
@@ -122,7 +122,7 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
       'options' => ['limit' => 1, 'sort' => 'contribution_recur_id DESC'],
     ])['values'][0];
 
-    $receiveDateCalculator = new CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator($contributionRecur);
+    $receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator($contributionRecur);
     $nextContributionIndex = 2;
     $this->nextContributionDate = $receiveDateCalculator->calculate($nextContributionIndex);
   }


### PR DESCRIPTION
The class **CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator** was renamed to **CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator** in v5 (which was done as an effort to fix the typo
in the word installment across our Membershipextra extensions) but the reference for it here was not updated,  which resulted in fatal error when trying to submit webforms that have payment plans configured with direct debit. This PR fixes that.