### PR TITLE
MAE-581: Stop updating 'Next contribution date' field

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/Contribution/ContributionDataGenerator.php
@@ -20,13 +20,6 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
   private $start_date;
 
   /**
-   * Next contribution date
-   *
-   * @var object
-   */
-  private $nextContributionDate;
-
-  /**
    * Array of extension settings
    *
    * @var array
@@ -67,7 +60,6 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
   public function generateContributionFieldsValues() {
     $this->generateCycleDate();
     $this->generateRecurringContributionStartDate();
-    $this->generateNextContributionDate();
   }
 
   /**
@@ -114,19 +106,6 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
     $this->start_date = $startDateGenerator->generate();
   }
 
-  private function generateNextContributionDate() {
-    $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'return' => ['id', 'start_date', 'frequency_interval', 'frequency_unit'],
-      'contact_id' => $this->entityID,
-      'options' => ['limit' => 1, 'sort' => 'contribution_recur_id DESC'],
-    ])['values'][0];
-
-    $receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator($contributionRecur);
-    $nextContributionIndex = 2;
-    $this->nextContributionDate = $receiveDateCalculator->calculate($nextContributionIndex);
-  }
-
   /**
    * Saves all generated values
    */
@@ -139,7 +118,6 @@ class CRM_ManualDirectDebit_Hook_Custom_Contribution_ContributionDataGenerator {
         'id' => '$value.id',
         'cycle_day' => $this->cycleDay,
         'start_date' => $this->start_date,
-        'next_sched_contribution_date' => $this->nextContributionDate,
       ],
     ]);
 


### PR DESCRIPTION
## Overview

The code is no longer needed since in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/389
we stop allowing API and DAO calls from updating  'Next contribution date' field value, so rendering all this code useless.

In later PRs I  introduce different way to calculate the value of this field
