### PR TITLE
MAE-579: Remove transitionComponents() method call

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.0.0
+    container: compucorp/civicrm-buildkit:1.1.1-php7.2
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.35.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.28.3
+          version: 5.35.1
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
+++ b/CRM/ManualDirectDebit/Queue/Task/BatchSubmission/PaymentItem.php
@@ -38,30 +38,11 @@ class CRM_ManualDirectDebit_Queue_Task_BatchSubmission_PaymentItem {
     CRM_Core_DAO::executeQuery($query);
   }
 
-  /**
-   * Updates Contribution status and calls transition components to update
-   * related entities (like memberships).
-   *
-   * @param int $contributionId
-   */
   private static function recordContributionPayment($contributionId) {
-    $originalStatusID = civicrm_api3('Contribution', 'getvalue', [
-      'return' => 'contribution_status_id',
-      'id' => $contributionId,
-    ]);
-
-    $result = civicrm_api3('Contribution', 'create', [
+    civicrm_api3('Contribution', 'create', [
       'id' => $contributionId,
       'contribution_status_id' => 'Completed',
       'payment_instrument_id' => 'direct_debit',
-    ]);
-    $contribution = array_shift($result['values']);
-
-    CRM_Contribute_BAO_Contribution::transitionComponents([
-      'contribution_id' => $contribution['id'],
-      'contribution_status_id' => $contribution['contribution_status_id'],
-      'previous_contribution_status_id' => $originalStatusID,
-      'receive_date' => $contribution['receive_date'],
     ]);
   }
 


### PR DESCRIPTION
## Overview

I am here applying the commit in which I removed transitionComponents method (https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/253) to the master branch (the original PR targeted v5 branch), the reason is related to an issue I found during my investigating on BASW-897 which is:

1- Create a membership with monthly direct debit payment plan, chose the start date of the membership to something a bit far in the past (like 6 months ago).
2- Use "Manage installments" screen on the recurring contribution and add new membership line item to the current period, and while staying on the current period tab, delete the line item for the membership created in step 1.
3- Refresh the page and go back to the memberships tab, you will find that first now is no longer renewable (the one we deleted) and that there is new membership (the one added).
4- Update the non-renewable (the one we deleted)  status to be permanently "Expired".
5- Create A direct debit instructions batch that has the contact that has the memberships in it then submit the batch.
6- Create a direct debit payment collection batch and select the contributions (picking just one should enough) that belong to the contact that has these memberships, then submit the batch.
7- After submitting the direct debit payment collection batch created in step 6, the membership with permanent "Expired" status (the one we deleted) will change to Current.

This happen because transitionComponents method will check all the memberships that are linked to the contribution by checking the MembershipPayment entity, and after recording the payment for the contribution it will update all the memberships that are linked to it (which includes both memberships the deleted and the new) which force the status to change where it should not.