### PR TITLE
COMCL-169: Update CiviCRM version in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35.2 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.35.2
+          version: 5.39.1
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update CiviCRM version in tests workflow to match the CiviCRM version on Compuclient 1.29