### PR TITLE
MAE-733: Fix condition for processing Hook_CalculateContributionReceiveDate_OtherContribution

### DIFF
--- a/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
+++ b/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/SecondContribution.php
@@ -38,10 +38,6 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
       return;
     }
 
-    if (!$this->isDirectDebit() || $this->isRenewal()) {
-      return;
-    }
-
     if (!$this->isForceOnSecondMonth()) {
       return;
     }
@@ -169,11 +165,15 @@ class CRM_ManualDirectDebit_Hook_CalculateContributionReceiveDate_SecondContribu
    * Only proceses if payment schedule is MONTHLY
    */
   protected function shouldProcess() {
-    if ($this->params['payment_schedule'] == CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
-      return TRUE;
+    if ($this->params['payment_schedule'] != CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
+      return FALSE;
     }
 
-    return FALSE;
+    if (!$this->isDirectDebit() || $this->isRenewal()) {
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
## Overview
In this PR we ensure that Hook_CalculateContributionReceiveDate_OtherContribution class only runs when the payment method is direct debit and the contribution is for a new membership. 

## Before
Hook_CalculateContributionReceiveDate_OtherContribution is processed and the contribution date for the 3rd instalment onward uses the date from the 2nd instalment date as its base, even though this is an intended logic for direct debit contributions only.
![image](https://user-images.githubusercontent.com/85277674/172193927-865f6584-34e4-401d-9533-70e7b97b9bca.png)


## After
Hook_CalculateContributionReceiveDate_OtherContribution is not processed since the payment method is not direct debit, therefore, the contribution for the 3rd instalment and above uses the date from the 1st instalment as its base.
![image](https://user-images.githubusercontent.com/85277674/172193960-9b10b008-6bde-4dbb-b1bf-19dce5d58c62.png)

