### PR TITLE
MAE-888: Update testing workflow to PHP 8 container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.39.1
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 -b MAE-807-PHP8 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
 
       - name: Run phpunit tests

--- a/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
+++ b/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php
@@ -59,15 +59,6 @@ class CRM_ManualDirectDebit_Hook_MandateContributionConnector {
   }
 
   /**
-   * Overrides wakeup to prevent creating instance of class,
-   * according to `Singleton` Pattern
-   *
-   * @var int
-   */
-  private function __wakeup() {
-  }
-
-  /**
    * Returns instance of current class, according to `Singleton` Pattern
    *
    * @return \CRM_ManualDirectDebit_Hook_MandateContributionConnector

--- a/CRM/ManualDirectDebit/Hook/QueryObjects/Contribution.php
+++ b/CRM/ManualDirectDebit/Hook/QueryObjects/Contribution.php
@@ -17,8 +17,8 @@ class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution extends CRM_Contact_B
   /**
    * @inheritDoc
    */
-  public function from($fieldName, $mode, $side) {
-    if (!$this->isContributionSearchForm()) {
+  public static function from($fieldName, $mode, $side) {
+    if (!self::isContributionSearchForm()) {
       return '';
     }
 
@@ -40,8 +40,8 @@ class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution extends CRM_Contact_B
   /**
    * Alters where statement.
    */
-  public function where(&$query) {
-    if (!$this->isContributionSearchForm()) {
+  public static function where(&$query) {
+    if (!self::isContributionSearchForm()) {
       return;
     }
 
@@ -72,7 +72,7 @@ class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution extends CRM_Contact_B
    *
    * @return bool
    */
-  private function isContributionSearchForm() {
+  private static function isContributionSearchForm() {
     if (CRM_Utils_System::currentPath() == 'civicrm/contribute/search') {
       return TRUE;
     }

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -94,7 +94,6 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
   }
 
   /**
-   * @depends testSaveDirectDebitMandate
    * Test assignRecurringContributionMandate function
    * @throws CiviCRM_API3_Exception
    * @throws Exception
@@ -113,7 +112,6 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
   }
 
   /**
-   * @depends testSaveDirectDebitMandate
    * Tests assignContributionMandate function
    * @return void
    * @throws CiviCRM_API3_Exception
@@ -138,7 +136,6 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
   }
 
   /**
-   * @depends testAssignContributionMandate
    * Tests ChangeMandateForContribution function
    * @return void
    * @throws CiviCRM_API3_Exception
@@ -183,7 +180,6 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
   }
 
   /**
-   * @depends testAssignContributionMandate
    * Tests DeleteMandate function
    * @return void
    * @throws CiviCRM_API3_Exception


### PR DESCRIPTION
## Overview
As part of our plan to move to PHP 8.0, we are updating the unit-tests container to use the PHP 8 version of it. With this PHP update, we are also updating Drupal to version 7.79 and CiviCRM to version 5.51.3.

Updating the container and the CiviCRM version, resulted in the following errors:

1- 
```
E..PHP Fatal error:  Cannot make static method CRM_Contact_BAO_Query_Interface::from() non static in class CRM_ManualDirectDebit_Hook_QueryObjects_Contribution in /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.manualdirectdebit/CRM/ManualDirectDebit/Hook/QueryObjects/Contribution.php on line 20
PHP Stack trace:
PHP   1. {main}() /opt/buildkit/extern/phpunit5/phpunit5.phar:0
PHP   2. PHPUnit_TextUI_Command::main($exit = *uninitialized*) /opt/buildkit/extern/phpunit5
```
Which is fixed by changing CRM_ManualDirectDebit_Hook_QueryObjects_Contribution class overridden methods to be static 
same as the CiviCRM core class they inherit. 

2- 
```
1) CRM_ManualDirectDebit_BAO_RecurrMandateRefTest::testCreate
The magic method CRM_ManualDirectDebit_Hook_MandateContributionConnector::__wakeup() must have public visibility
/var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.manualdirectdebit/CRM/ManualDirectDebit/Hook/MandateContributionConnector.php:67
```

which is fixed by removing `:__wakeup()` magic function from CRM_ManualDirectDebit_Hook_MandateContributionConnector which is not really needed for the singleton to work.

3- 

```
1) CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testAssignRecurringContributionMandate
ReflectionException: Invocation of method CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testAssignRecurringContributionMandate() failed

/opt/buildkit/extern/phpunit5/phpunit5.phar:598

Caused by
Error: Unknown named parameter $CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testSaveDirectDebitMandate


2) CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testAssignContributionMandate
ReflectionException: Invocation of method CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testAssignContributionMandate() failed

/opt/buildkit/extern/phpunit5/phpunit5.phar:598

Caused by
Error: Unknown named parameter $CRM_ManualDirectDebit_Common_MandateStorageManagerTest::testSaveDirectDebitMandate
```

These are fixed by removing the `@depends` annotation form the tests in this class, It is happening because PHPUnit5 which we are using (which is the version Civi support for now anyway so we have to stick with it) does not support PHP8, and it seems that the implementation of the `@depends` annotation in PHPUnit is a bit problematic for PHP8 (seems the way it is implemented ends up sending the dependency method as a named argument to the test method that depends on it). The reason I decided to remove them as a solution, is because the benefits of using them in these failed test are not that important, given we don't rely on them to pass data or something,  but rather as way to prevent PHPunit from running these tests if the tests they depend on failed.