### PR TITLE
MAE-959: Fix array_merge error in PHP 8

### DIFF
--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -204,10 +204,10 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
     if (CRM_Batch_BAO_Batch::checkBatchPermission('close', $this->_values['created_id'])) {
       if (CRM_Batch_BAO_Batch::checkBatchPermission('export', $this->_values['created_id'])) {
         $this->add('submit', 'export_batch', ts('Export Batch'), ['formtarget' => '_blank']);
-        $this->add('submit', 'save_batch', ts('Save'));
+        $this->add('submit', 'save_batch', ts('Save'), []);
         $this->add('submit', 'save_and_export_batch', ts('Save and Export Batch'), ['formtarget' => '_blank']);
-        $this->add('submit', 'submitted', ts('Submit'));
-        $this->add('submit', 'discard', ts('Discard'));
+        $this->add('submit', 'submitted', ts('Submit'), []);
+        $this->add('submit', 'discard', ts('Discard'), []);
       }
     }
 


### PR DESCRIPTION
## Overview
A syntax error `Argument #2 must be of type array, null given in array_merge()` is thrown when no attribute is specified when adding a button element to the page. we resolve this issue by specifying an empty array as an attribute

## Before
An error page is displayed while trying to create a new instruction batch
![MAE-959](https://user-images.githubusercontent.com/85277674/201645002-a1b19092-98c4-49e0-b2a8-c99eb6286e2d.gif)


## After
The user is able to create new instruction batch
![asaa](https://user-images.githubusercontent.com/85277674/201644920-2fede9f9-e703-4a16-b602-278decca7ede.gif)


