### PR TITLE
CIWEMB-254: Fetch custom fields correctly

### DIFF
--- a/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
+++ b/CRM/ManualDirectDebit/Common/CollectionReminderSendFlagManager.php
@@ -25,6 +25,7 @@ class CRM_ManualDirectDebit_Common_CollectionReminderSendFlagManager {
       return civicrm_api3('CustomField', 'getvalue', [
         'return' => 'id',
         'name' => 'is_notification_sent',
+        'custom_group_id' => 'direct_debit_collection_reminder_sendflag',
       ]);
     }
     catch (CRM_Core_Exception $e) {

--- a/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
+++ b/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php
@@ -206,14 +206,16 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProvider {
   /**
    * Gets id of custom field by name
    *
-   * @param $customFieldName
+   * @param string $customFieldName
+   * @param string $customGroupName
    *
    * @return int
    */
-  public static function getCustomFieldIdByName($customFieldName) {
+  public static function getCustomFieldIdByName($customFieldName, $customGroupName) {
     return civicrm_api3('CustomField', 'getvalue', [
       'return' => "id",
       'name' => $customFieldName,
+      'custom_group_id' => $customGroupName,
     ]);
   }
 

--- a/CRM/ManualDirectDebit/Common/MandateStorageManager.php
+++ b/CRM/ManualDirectDebit/Common/MandateStorageManager.php
@@ -24,7 +24,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManager {
    *
    */
   public function assignContributionMandate($contributionId, $mandateID) {
-    $mandateIdCustomFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+    $mandateIdCustomFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
 
     civicrm_api3('Contribution', 'create', [
       'id' => $contributionId,

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -82,7 +82,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
    *  Hides 'DD ref' custom field
    */
   private function hideDdRef() {
-    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("dd_ref");
+    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('dd_ref', 'direct_debit_mandate');
     $ddRefElementNameId = $this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]['element_name'];
     unset($this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]);
     foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName) {

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php
@@ -54,7 +54,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomDataByType {
    *  Hides Direct Debit Information if it`s empty
    */
   private function hideDirectDebitInformationIfEmpty() {
-    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+    $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
     $mandateIdValue = $this->customGroupTree[$this->directDebitInformationId]['fields'][$customFieldId]['element_value'];
 
     if (!isset($mandateIdValue) || empty($mandateIdValue)) {

--- a/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
+++ b/CRM/ManualDirectDebit/Hook/PageRun/TabPage.php
@@ -37,8 +37,9 @@ class CRM_ManualDirectDebit_Hook_PageRun_TabPage {
    */
   private function isCustomFieldNeedToHide($contributionId) {
     $customFieldId = civicrm_api3('CustomField', 'getvalue', [
-      'return' => "id",
-      'name' => "mandate_id",
+      'return' => 'id',
+      'name' => 'mandate_id',
+      'custom_group_id' => 'direct_debit_information',
     ]);
 
     $mandateId = civicrm_api3('Contribution', 'getvalue', [

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/DirectDebitDataProviderTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/DirectDebitDataProviderTest.php
@@ -15,7 +15,7 @@ class CRM_ManualDirectDebit_Common_DirectDebitDataProviderTest extends BaseHeadl
    * Tests getCustomFieldIdbyName function
    */
   public function testGetCustomFieldIdByName() {
-    $customFieldId = DirectDebitDataProvider::getCustomFieldIdByName('mandate_id');
+    $customFieldId = DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
     $this->assertNotNull($customFieldId);
   }
 

--- a/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
+++ b/tests/phpunit/CRM/ManualDirectDebit/Common/MandateStorageManagerTest.php
@@ -131,7 +131,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
     $this->assertNotEmpty($contribution['values']);
 
     $mandateIdCustomFieldId =
-      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
     $this->assertEquals($contribution['values'][0]['custom_' . $mandateIdCustomFieldId], $mandate->id);
   }
 
@@ -148,7 +148,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
     $fabricatedContribution = $fabricatedContributionWithMandate['contribution'];
 
     $mandateIdCustomFieldId =
-      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
 
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
@@ -192,7 +192,7 @@ class CRM_ManualDirectDebit_Common_MandateStorageManagerTest extends BaseHeadles
     $fabricatedContribution = $fabricatedContributionWithMandate['contribution'];
 
     $mandateIdCustomFieldId =
-      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName("mandate_id");
+      CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('mandate_id', 'direct_debit_information');
 
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
## Overview

While working on CIWEMB-254 and tried to create new custom field that is also called "mandate_id" on https://github.com/compucorp/io.compuco.automateddirectdebit/ extension,  I got the following error on the contribution view and edit pages: 


```
rough xdebug.client_host/xdebug.client_port) :-("
php_1      | Apr 05 11:59:03  [error]
php_1      | $Fatal Error Details = array:3 [
php_1      |   "message" => "Expected one CustomField but found 2"
php_1      |   "code" => null
php_1      |   "exception" => CiviCRM_API3_Exception {#1154
php_1      |     -extraParams: array:4 [
php_1      |       "count" => 2
php_1      |       "is_error" => 1
php_1      |       "error_message" => "Expected one CustomField but found 2"
php_1      |       "error_code" => "undefined"
php_1      |     ]
php_1      |     #message: "Expected one CustomField but found 2"
php_1      |     #code: 0
php_1      |     #file: "/var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/api/api.php"
php_1      |     #line: 135
php_1      |     trace: {
php_1      |       /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/api/api.php:135 {
php_1      |         › if (is_array($result) && !empty($result['is_error'])) {
php_1      |         ›   throw new CiviCRM_API3_Exception($result['error_message'], CRM_Utils_Array::value('error_code', $result, 'undefined'), $result);
php_1      |         › }
php_1      |       }
php_1      |       /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.manualdirectdebit/CRM/ManualDirectDebit/Common/DirectDebitDataProvider.php:216 { …}
php_1      |       /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.manualdirectdebit/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php:57 { …}
php_1      |       /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.manualdirectdebit/CRM/ManualDirectDebit/Hook/BuildForm/CustomDataByType.php:40 { …}
```


It seems many places in this extension tries to fetch custom fields by the their names only, without specifying which custom group they are part of, which is not correct given the custom field is not guaranteed to be unique across different custom groups. 

In this PR I've updated all the places that I found doing that, so these custom fields are not fetched by both their name and custom group name.