### PR TITLE
CIWEMB-249: Add Direct debit to Membershipextras supported payment processors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone -b CIWEMB-84-workstream --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
 
       - name: Run phpunit tests


### PR DESCRIPTION
## Overview

This is a continuation for this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/461

Where this extension  own "Direct debit" payment processor, is added to the list of Membershipextras supported Payment processors.

![2023-04-06 18_42_10-Payment Plan Settings _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/230434078-3ce1a108-90d6-48ab-b93c-8c6e708fa929.png)
