### PR TITLE
CIWEMB-257: Only show 'use new mandate' action on manual direct debit payment plans

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -20,6 +20,10 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
    * @param $recurringContributionId
    */
   public function alterRecurContributionLinks(&$values, $recurringContributionId) {
+    if (!$this->isAlreadyLinkedToMandate($recurringContributionId)) {
+      return;
+    }
+
     $contactId = CRM_Utils_Request::retrieve('cid', 'Integer');
     $contactType = $this->getContactType($contactId);
 
@@ -35,6 +39,16 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
     $values['cid'] = $contactId;
     $values['cgcount'] = $this->getCgCount();
     $values['updatedRecId'] = $recurringContributionId;
+  }
+
+  private function isAlreadyLinkedToMandate($recurringContributionId) {
+    CRM_ManualDirectDebit_Common_DirectDebitDataProvider::isPaymentMethodDirectDebit($this->contributionRecurDao->payment_instrument_id);
+    $linkedMandateId = CRM_ManualDirectDebit_BAO_RecurrMandateRef::getMandateIdForRecurringContribution($recurringContributionId);
+    if (empty($linkedMandateId)) {
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
   private function getContactType($contactId) {


### PR DESCRIPTION
## Before

"Use A New mandate" action appears for all manual direct and non manual direct debit recurring contributions (payment plans)

Here is an example of two recurring contribtions, were one is Manual direct debit and already linked to a mandate, and the other is non manual direct debit, both shows the "Use A New mandate"  option.

![111111111](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/6275540/fd79ca3c-5643-45df-9ea2-40000dbace82)


## After

"Use A New mandate" action appears only for recurring contributions that are linked to a mandate:

![2222](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/6275540/a0f2e81b-fe9f-49aa-b717-c5d5f8cf9baf)



