### PR TITLE
ESEB-148: Fix Submission Of Contribution Webforms

### DIFF
--- a/CRM/ManualDirectDebit/Common/SettingsManager.php
+++ b/CRM/ManualDirectDebit/Common/SettingsManager.php
@@ -25,10 +25,10 @@ class CRM_ManualDirectDebit_Common_SettingsManager {
     ];
 
     $settings['new_instruction_run_dates'] = $this->incrementAllArrayValues(
-      CRM_Utils_Array::value('manualdirectdebit_new_instruction_run_dates', $settingValues)
+      (array) CRM_Utils_Array::value('manualdirectdebit_new_instruction_run_dates', $settingValues)
     );
     $settings['payment_collection_run_dates'] = $this->incrementAllArrayValues(
-      CRM_Utils_Array::value('manualdirectdebit_payment_collection_run_dates', $settingValues)
+      (array) CRM_Utils_Array::value('manualdirectdebit_payment_collection_run_dates', $settingValues)
     );
 
     return $settings;


### PR DESCRIPTION
## Overview
This pr fixes a bug due to which user was unable to submit a webform for creating contributions.

## Before
when user tries to submit any webform for making a reccuring contribution the user sees the following maintenance page
![Screenshot 2024-02-15 at 5 08 08 PM](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/147053234/8d341573-1593-402d-acf5-5b66b98f2a0c)

## Technical Details
[This](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/master/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php#L41) expects the second param as array, but when it is getting called from [here](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/master/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php#L22) and [here](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/master/CRM/ManualDirectDebit/Hook/CalculateContributionReceiveDate/FirstContribution.php#L29) it sometimes receives a string the reason for this is that the default values for these settings is a single value so until user changes these settings from the direct debit setting page, these settings continue to be string and this causes an error. 