### PR TITLE
CIVIPLMMSR-199: Allow users with 'administer ManualDirectDebit' permission to be able to delete mandates

### DIFF
--- a/manualdirectdebit.php
+++ b/manualdirectdebit.php
@@ -83,6 +83,16 @@ function manualdirectdebit_civicrm_permission(&$permissions) {
 }
 
 /**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ */
+function manualdirectdebit_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  if ($entity == 'manual_direct_debit' && $action == 'deletemandate') {
+    $permissions[$entity][$action] = ['administer ManualDirectDebit'];
+  }
+}
+
+/**
  * Implements hook_civicrm_navigationMenu().
  *
  */
@@ -392,7 +402,6 @@ function manualdirectdebit_civicrm_searchTasks($objectName, &$tasks) {
       'result' => FALSE,
     ];
   }
-
 }
 
 function manualdirectdebit_civicrm_container($container) {


### PR DESCRIPTION
## Before

Users with `administer ManualDirectDebit` are unable to delete mandates, only users with `administer CiviCRM` can do that:

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/6275540/e6757927-465b-4bcb-9b92-41bb8dc580aa


## After
Users with `administer ManualDirectDebit` are no able to delete mandates:

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/6275540/f6016b78-a9ca-4c7c-9409-388a785db0d3



## Technical Details

When the user tries to delete a mandate, an Ajax API v3 call is triggered against `ManualDirectDebit.delete` end point, which is the one responsible to delete the mandate:

https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/blob/master/js/mandateEdit.js#L36-L42


And permission check is enforced by default on all API calls that are called using Ajax, and if it happens that the API end point have no permission defined using `hook_civicrm_alterAPIPermissions` hook, then CiviCRM will by default enforce `administer CiviCRM`  permission on it, I explained in this previous PR how CiviCRM API permission checks work in general, so refer to it for more details: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/430

So the fix here was easy, which is just to implement `hook_civicrm_alterAPIPermissions` and set the permission for  `ManualDirectDebit.delete` API to be `administer ManualDirectDebit`
