### PR TITLE
COMCL-508: Fix Button Styles For "Instruction Batch" View Page

### DIFF
--- a/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchTransaction.tpl
@@ -48,7 +48,7 @@
   {/if}
 
     {if in_array($batchStatus, array('Open', 'Reopened'))  && $action eq 4}
-        <div class="float-right">
+        <div class="float-right" style="width:200px;">
             {$form.discard.html}
             {$form.submitted.html}
         </div>
@@ -157,3 +157,12 @@ function saveRecord(recordID, op, recordBAO, entityID) {
 }
 </script>
 {/literal}
+
+<style>
+  {literal}
+  .crm-button.crm-button-type-submitted.crm-buttonsubmitted.crm-form-xbutton,
+  .crm-button.crm-button-type-discard.crm-buttondiscard.crm-form-xbutton {
+    float: left !important;
+  }
+  {/literal}
+</style>


### PR DESCRIPTION
## Overview
This pr fixes the broken button styles on **instruction batch** view page

## Before
<img width="1792" alt="Screenshot 2024-04-17 at 7 48 47 PM" src="https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/147053234/bf0be7da-0485-4abd-9c6f-96a2aac9d134">


## After
<img width="1792" alt="Screenshot 2024-04-17 at 7 50 37 PM" src="https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/assets/147053234/1ef0ef43-0a36-4951-a3da-ec8d8792e6b5">
