### PR TITLE
COMCL-651: Resolve issue while creating direct debit batch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,24 @@ jobs:
         run: |
           git clone --depth 1 -b 6.6.0-dev https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
+      
+      - name: Setup Test DB
+        run: echo "CREATE DATABASE civicrm_test;" | mysql -u root --password=root --host=mysql
+
+      - name: Update civicrm.settings.php
+        run: |
+          FILE_PATH="$GITHUB_WORKSPACE/site/web/sites/default/civicrm.settings.php"
+          INSERT_LINE="\$GLOBALS['_CV']['TEST_DB_DSN'] = 'mysql://root:root@mysql:3306/civicrm_test?new_link=true';"
+          TMP_FILE=$(mktemp)
+          while IFS= read -r line
+          do
+              echo "$line" >> "$TMP_FILE"
+              if [ "$line" = "<?php" ]; then
+                  echo "$INSERT_LINE" >> "$TMP_FILE"
+              fi
+          done < "$FILE_PATH"
+          mv "$TMP_FILE" "$FILE_PATH"
+          echo "File modified successfully."
 
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.75.0 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.51.3
+          version: 5.75.0
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 -b 6.6.0-dev https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
 
       - name: Run phpunit tests

--- a/CRM/ManualDirectDebit/Form/Batch.php
+++ b/CRM/ManualDirectDebit/Form/Batch.php
@@ -11,6 +11,13 @@ class CRM_ManualDirectDebit_Form_Batch extends CRM_Admin_Form {
   private $batchType;
 
   /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'Batch';
+  }
+
+  /**
    * PreProcess function.
    */
   public function preProcess() {

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -485,6 +485,7 @@
       <is_active>0</is_active>
       <group_type>Contact</group_type>
       <title>Direct Debit Information</title>
+      <frontend_title>Direct Debit Information</frontend_title>
       <add_captcha>0</add_captcha>
       <is_map>0</is_map>
       <is_edit_link>0</is_edit_link>


### PR DESCRIPTION
## Overview
Resolve issue while creating direct debit batch, this is caused by the update in the latest CiviCRM version that requires the Batch form to declare entity name https://github.com/civicrm/civicrm-core/blob/cf147b8aaba4e0b842fc798f3e603cbbbf0bb267/CRM/Batch/Form/Batch.php#L22-L26

## Before
![image](https://github.com/user-attachments/assets/4c86ac08-372b-44ac-90a0-95f989463282)


## After
Error is no longer thrown