### PR TITLE
COMCL-842: Fix issue with editing direct debit mandate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Installing Manual Direct Debit and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 -b 6.6.0-dev https://github.com/compucorp/uk.co.compucorp.membershipextras.git
+          git clone --depth 1 -b master https://github.com/compucorp/uk.co.compucorp.membershipextras.git
           cv en uk.co.compucorp.membershipextras uk.co.compucorp.manualdirectdebit
       
       - name: Setup Test DB

--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -58,7 +58,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
   private function checkIfDirectDebitMandateInGroupTree() {
     $customGroupTree = $this->form->getVar('_groupTree');
 
-    return array_key_exists($this->directDebitMandateId, $customGroupTree);
+    return !empty($customGroupTree) && array_key_exists($this->directDebitMandateId, $customGroupTree);
   }
 
   /**


### PR DESCRIPTION
## Overview
Previously users couldn't edit the direct debit mandate because the array_key_exists now throws an error if the array passed to it is null, we now check the array is empty before passing to array_key_exist

## Before
![image](https://github.com/user-attachments/assets/de5b33f2-c321-47d8-b563-6fac1a0324dc)


## After
