### PR TITLE
COMCL-843: Resolve issue with adding a new mandate to recur contribution

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/CustomData.php
@@ -85,6 +85,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_CustomData {
     $customFieldId = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getCustomFieldIdByName('dd_ref', 'direct_debit_mandate');
     $ddRefElementNameId = $this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]['element_name'];
     unset($this->form->_groupTree[$this->directDebitMandateId]['fields'][$customFieldId]);
+    $this->form->removeElement($ddRefElementNameId);
     foreach ($this->form->_required as $requiredFieldsId => $requiredFieldsName) {
       if ($requiredFieldsName == $ddRefElementNameId) {
         unset($this->form->_required[$requiredFieldsId]);

--- a/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
+++ b/CRM/ManualDirectDebit/Hook/Links/LinkProvider.php
@@ -31,14 +31,15 @@ class CRM_ManualDirectDebit_Hook_Links_LinkProvider {
       'name' => ts('Use a new mandate'),
       'url' => 'civicrm/contact/view/cd/edit',
       'title' => 'Use a new mandate',
-      'qs' => 'reset=1&type=' . $contactType . '&groupID=%%groupID%%&entityID=%%cid%%&cgcount=%%cgcount%%&multiRecordDisplay=single&mode=add&updatedRecId=%%updatedRecId%%',
-      'class' => 'no-popup',
+      'qs' => 'reset=1&type=' . $contactType . '&groupID=%%groupID%%&entityID=%%cid%%&cgcount=%%cgcount%%&multiRecordDisplay=single&mode=add&updatedRecId=%%updatedRecId%%&tableId=%%cid%%',
+      'class' => 'popup',
     ];
 
     $values['groupID'] = CRM_ManualDirectDebit_Common_DirectDebitDataProvider::getGroupIDByName("direct_debit_mandate");
     $values['cid'] = $contactId;
     $values['cgcount'] = $this->getCgCount();
     $values['updatedRecId'] = $recurringContributionId;
+    $values['tableId'] = $contactId;
   }
 
   private function isAlreadyLinkedToMandate($recurringContributionId) {

--- a/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/InjectDirectDebitInformation.tpl
@@ -13,7 +13,7 @@
               <td class="label">{ts}Mandate ID{/ts}</td>
               <td class="html-adjust positionRelative">
                 <span id="directDebitMandate"></span>
-                <span class="newMandateButton"><a href="#" id="newDirectDebitMandate">{ts}Use a new mandate{/ts}</a></span>
+                <span class="newMandateButton"><a href="#" class="crm-popup" id="newDirectDebitMandate">{ts}Use a new mandate{/ts}</a></span>
             </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## Overview
Before this PR users couldn't add a new mandate to a recurring contribution. This issue happened because the custom data edit form requires the table ID to be passed via URL if the form is opened on a standalone page.

In this PR we now open the mandate form in a popup.

## Before
![image](https://github.com/user-attachments/assets/88a1918c-60be-4e00-abf8-4ce6c395c2df)

![image](https://github.com/user-attachments/assets/1fd8cbf8-b4f8-4065-bdc1-e1ce0ab6b7df)


## After
![111aasssssssssssaaa](https://github.com/user-attachments/assets/6fc0df03-4871-47c0-9647-deefd2965cdc)
