### PR TITLE
COMCL-933: Fix Removal Of Records From Batch

### DIFF
--- a/CRM/ManualDirectDebit/Page/AJAX.php
+++ b/CRM/ManualDirectDebit/Page/AJAX.php
@@ -165,7 +165,16 @@ class CRM_ManualDirectDebit_Page_AJAX {
           $updated = CRM_Batch_BAO_EntityBatch::create($params);
         }
         else {
-          $updated = CRM_Batch_BAO_EntityBatch::del($params);
+          $record = \Civi\Api4\EntityBatch::get(FALSE)
+            ->addSelect('id')
+            ->addWhere('entity_id', '=', $value)
+            ->addWhere('entity_table', '=', $entityTable)
+            ->addWhere('batch_id', '=', $entityID)
+            ->execute()
+            ->first();
+          if ($record['id']) {
+            $updated = CRM_Batch_BAO_EntityBatch::del(['id' => $record['id']]);
+          }
         }
       }
     }


### PR DESCRIPTION
## Overview
This pr fixes the deleteion of rows from a direct debit batch.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/e97c155b-45c1-43d2-8351-a23dd19f463c)


## After
![screen_recording_after](https://github.com/user-attachments/assets/9dd2d64b-b1d2-48b6-800f-ae896027e603)


## Technical Details
In latest civicrm the id param is required to delete a record, but we were previously using different params other than id to delete records. This pr fixes this issue and uses the id param to delete rows from a batch.
