### PR TITLE
COMCL-1025: Fix Ellipses Menu

### DIFF
--- a/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
+++ b/templates/CRM/ManualDirectDebit/Page/BatchList.tpl
@@ -5,7 +5,7 @@
     <form id="searchForm">
         <div class="float-left">
           <label for="type_id">{ts}Batch Type:{/ts}</label>
-          {html_options name="type_id" id="type_id" class="crm-select2 crm-form-select" options=$batchTypes selected=$type_id}
+          {html_options name="type_id" id="type_id" class="crm-form-select" options=$batchTypes selected=$type_id}
         </div>
         <div class="batch-create-date-fields float-right">
           <label for="created_date_from">{ts}From:{/ts}</label>


### PR DESCRIPTION
## Overview
This pr fixes the ellipses menu on manage direct debit batches screen.

## Before
The user was not able to open the ellipses menu as nothing happened when user clicked on the menu.

## After
The menu opens up after clicking
<img width="1792" alt="Screenshot 2025-02-13 at 1 31 04 PM" src="https://github.com/user-attachments/assets/79e61349-b245-4b0b-b61d-80e696540d2f" />


## Technical Details
This error appeared due to smarty upgrade to version 4.
