### PR TITLE
CIVIPLMMSR-487: Fix Contribution Status For Memberships

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Membership.php
@@ -37,19 +37,21 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Membership {
     $directDebitPaymentInstrumentId = DirectDebitDataProvider::getDirectDebitPaymentInstrumentId();
     $this->form->assign('directDebitPaymentInstrumentId', $directDebitPaymentInstrumentId);
 
-    $pendingPaymentStatusID = $this->getPendingPaymentStatusID();
+    $pendingPaymentStatusID = $this->getPaymentStatusID('Pending');
+    $completedPaymentStatusID = $this->getPaymentStatusID('Completed');
     $this->form->assign('pendingPaymentStatusID', $pendingPaymentStatusID);
+    $this->form->assign('completedPaymentStatusID', $completedPaymentStatusID);
 
     CRM_Core_Region::instance('page-body')->add([
       'template' => "{$this->templatesPath}/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl",
     ]);
   }
 
-  private function getPendingPaymentStatusID() {
+  private function getPaymentStatusID(string $status) {
     return civicrm_api3('OptionValue', 'getvalue', [
       'return' => 'value',
       'option_group_id' => 'contribution_status',
-      'name' => 'Pending',
+      'name' => $status,
     ]);
   }
 

--- a/templates/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl
+++ b/templates/CRM/ManualDirectDebit/Form/Membership/DDPaymentMethodWatcher.tpl
@@ -1,6 +1,7 @@
 <script type="text/javascript">
   var directDebitID = '{$directDebitPaymentInstrumentId}';
   var pendingPaymentStatusID = '{$pendingPaymentStatusID}';
+  var completedPaymentStatusID = '{$completedPaymentStatusID}';
 
   {literal}
   CRM.$('#payment_instrument_id').change(function () {
@@ -10,6 +11,8 @@
   function changePaymentStatusOptionToPendingWhenDDPaymentMethodIsSelected() {
     if (CRM.$('#payment_instrument_id option:selected').val() == directDebitID) {
       CRM.$('#contribution_status_id').val(pendingPaymentStatusID);
+    } else if (CRM.$('input[name=fe_record_payment_check]').length && CRM.$('input[name=fe_record_payment_check]').is(':checked')) {
+      CRM.$('#contribution_status_id').val(completedPaymentStatusID);
     }
   }
   {/literal}


### PR DESCRIPTION
## Overview
In [this](https://github.com/compucorp/uk.co.compucorp.manualdirectdebit/pull/67) PR we added a logic that when direct debit payment method is selected we change the contribution status to pending but this same PR introduced a bug as well that if after selecting direct debit if we change the payment method to something else the contribution status still remains pending although it should be changed back to completed if record payment is checked. This PR resolves this issue.
