### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
+++ b/CRM/ManualDirectDebit/Hook/BuildForm/Payment.php
@@ -70,7 +70,7 @@ class CRM_ManualDirectDebit_Hook_BuildForm_Payment {
    */
   private function addMandateSelectionField() {
     $this->form->assign('paymentTypeLabel', ts('Direct Debit Mandate'));
-    $templateVars = $this->form->get_template_vars();
+    $templateVars = $this->form->getTemplateVars();
 
     $paymentFields = $templateVars['paymentFields'];
     $paymentFields[] = 'mandate_id';


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.