### PR TITLE
COMCL-1426: Fix Batch Submission

### DIFF
--- a/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
+++ b/CRM/ManualDirectDebit/Hook/Custom/CancellationBatchChecker.php
@@ -75,6 +75,7 @@ class CRM_ManualDirectDebit_Hook_Custom_CancellationBatchChecker {
       return;
     }
 
+    \Civi::cache('metadata')->clear();
     $pendingCancellationBatches = $this->getPendingCancellationBatches();
     foreach ($pendingCancellationBatches as $batch) {
       $batchItemID = $this->getPendingCancellationBatchItemID($mandate, $batch);

--- a/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
+++ b/CRM/ManualDirectDebit/Page/BatchSubmissionQueue.php
@@ -84,6 +84,8 @@ class CRM_ManualDirectDebit_Page_BatchSubmissionQueue extends CRM_Core_Page {
    * @throws \CRM_Core_Exception
    */
   private function getNonCancelledMandates() {
+    \Civi::cache('metadata')->clear();
+
     $result = civicrm_api3('EntityBatch', 'get', [
       'sequential' => 1,
       'batch_id' => $this->batchId,

--- a/CRM/ManualDirectDebit/Queue/Build/InstructionsQueueBuilder.php
+++ b/CRM/ManualDirectDebit/Queue/Build/InstructionsQueueBuilder.php
@@ -3,6 +3,8 @@
 class CRM_ManualDirectDebit_Queue_Build_InstructionsQueueBuilder extends CRM_ManualDirectDebit_Queue_Build_BaseBuilder {
 
   public function buildQueue() {
+    \Civi::cache('metadata')->clear();
+
     $rows = civicrm_api3('EntityBatch', 'get', [
       'return' => ['entity_id'],
       'options' => ['limit' => 0],


### PR DESCRIPTION
## Overview
This PR fixes an issue which restricted the user from submitting a direct debit batch.


## Technical Details
This issue was introduced with civicrm upgrade due to [this](https://github.com/civicrm/civicrm-core/commit/65caaff14af4999428ff7dc9b37a8502dedc637c) commit which uses EntityMetadata instead of CRM_Core_Pseudoconstant for buildOptions.

And the problem was that the EntityMetadata uses cache for creating options so when user submitted the batch first time a cache of valid batch ids got build but when user was attempting to submit the batch second time the recently created batch id was not there in cache so it complaint about invalid batch id. This PR fixes the issue by clearing out the metadata cache where appropriate.
