### PR TITLE
Ensure group selectors render correctly

### DIFF
--- a/CRM/ManualDirectDebit/Form/BatchTransaction.php
+++ b/CRM/ManualDirectDebit/Form/BatchTransaction.php
@@ -211,7 +211,7 @@ class CRM_ManualDirectDebit_Form_BatchTransaction extends CRM_Contribute_Form_Se
       }
     }
 
-    $this->_group = CRM_Core_PseudoConstant::nestedGroup();
+    $this->_group = CRM_Core_PseudoConstant::nestedGroup(TRUE, NULL, TRUE, 'plain');
 
     CRM_Contribute_BAO_Query::buildSearchForm($this);
     $this->addElement('checkbox', 'toggleSelects', NULL, NULL);


### PR DESCRIPTION
In 6.13 select dropdowns always escape html which causes group selectors to look bad.
This passes the new to param to format the group hierarchy in a plain text compatible format.

This change is backward-compatible; in CiviCRM < 6.13 the new param will be ignored.